### PR TITLE
[feat] NF-9 쇼핑 링크 import preview 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ repositories {
 dependencies {
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.jsoup:jsoup:1.18.3'
 	runtimeOnly 'org.flywaydb:flyway-database-postgresql'
 	runtimeOnly 'org.postgresql:postgresql'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/sagongsa/backend/itemimport/ItemImportController.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/ItemImportController.java
@@ -1,0 +1,25 @@
+package com.sagongsa.backend.itemimport;
+
+import com.sagongsa.backend.itemimport.item.ShoppingLinkImportRequest;
+import com.sagongsa.backend.itemimport.item.ShoppingLinkImportResponse;
+import com.sagongsa.backend.itemimport.item.ShoppingLinkImportService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/items")
+public class ItemImportController {
+
+	private final ShoppingLinkImportService shoppingLinkImportService;
+
+	public ItemImportController(ShoppingLinkImportService shoppingLinkImportService) {
+		this.shoppingLinkImportService = shoppingLinkImportService;
+	}
+
+	@PostMapping("/import-link")
+	public ShoppingLinkImportResponse importLink(@RequestBody ShoppingLinkImportRequest request) {
+		return shoppingLinkImportService.importLink(request);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/itemimport/item/FetchedPage.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/FetchedPage.java
@@ -1,0 +1,12 @@
+package com.sagongsa.backend.itemimport.item;
+
+import java.net.URI;
+
+public record FetchedPage(
+	URI requestedUri,
+	URI finalUri,
+	int statusCode,
+	String contentType,
+	String body
+) {
+}

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ItemSourceMetadataDraft.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ItemSourceMetadataDraft.java
@@ -1,0 +1,14 @@
+package com.sagongsa.backend.itemimport.item;
+
+import java.time.Instant;
+
+public record ItemSourceMetadataDraft(
+	String sourceDomain,
+	String rawTitle,
+	String rawDescription,
+	String rawPriceText,
+	String rawPayloadJson,
+	Instant extractedAt,
+	String extractionMethod
+) {
+}

--- a/src/main/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcher.java
@@ -1,0 +1,82 @@
+package com.sagongsa.backend.itemimport.item;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+@Component
+public class JsoupPageFetcher implements PageFetcher {
+
+	private static final String ANDROID_USER_AGENT =
+		"Mozilla/5.0 (Linux; Android 14; Pixel 7) AppleWebKit/537.36 "
+			+ "(KHTML, like Gecko) Chrome/135.0.0.0 Mobile Safari/537.36";
+	private static final int MAX_REDIRECTS = 5;
+
+	@Override
+	public FetchedPage fetch(URI uri) {
+		URI currentUri = uri;
+		try {
+			for (int redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount++) {
+				validatePublicHost(currentUri);
+				Connection.Response response = Jsoup.connect(currentUri.toString())
+					.userAgent(ANDROID_USER_AGENT)
+					.header("Accept-Language", "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7")
+					.followRedirects(false)
+					.ignoreContentType(true)
+					.ignoreHttpErrors(true)
+					.timeout(10_000)
+					.execute();
+
+				if (isRedirect(response.statusCode())) {
+					String location = response.header("Location");
+					if (location != null && !location.isBlank()) {
+						currentUri = currentUri.resolve(location);
+						continue;
+					}
+				}
+
+				return new FetchedPage(
+					uri,
+					URI.create(response.url().toString()),
+					response.statusCode(),
+					response.contentType(),
+					response.body()
+				);
+			}
+			throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Shopping page redirected too many times");
+		} catch (IOException exception) {
+			throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Failed to fetch shopping page", exception);
+		}
+	}
+
+	private void validatePublicHost(URI uri) {
+		String host = uri.getHost();
+		if (host == null || host.isBlank()) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Shopping url host is required");
+		}
+
+		try {
+			for (InetAddress address : InetAddress.getAllByName(host)) {
+				if (address.isAnyLocalAddress()
+					|| address.isLoopbackAddress()
+					|| address.isLinkLocalAddress()
+					|| address.isSiteLocalAddress()
+					|| address.isMulticastAddress()) {
+					throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Private network shopping urls are not supported");
+				}
+			}
+		} catch (UnknownHostException exception) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Shopping url host could not be resolved", exception);
+		}
+	}
+
+	private boolean isRedirect(int statusCode) {
+		return statusCode >= 300 && statusCode < 400;
+	}
+}

--- a/src/main/java/com/sagongsa/backend/itemimport/item/PageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/PageFetcher.java
@@ -1,0 +1,8 @@
+package com.sagongsa.backend.itemimport.item;
+
+import java.net.URI;
+
+public interface PageFetcher {
+
+	FetchedPage fetch(URI uri);
+}

--- a/src/main/java/com/sagongsa/backend/itemimport/item/SavedItemDraft.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/SavedItemDraft.java
@@ -1,0 +1,22 @@
+package com.sagongsa.backend.itemimport.item;
+
+import com.sagongsa.backend.domain.enums.ItemCategory;
+import com.sagongsa.backend.domain.enums.ItemInputSource;
+import com.sagongsa.backend.domain.enums.ItemStatus;
+
+public record SavedItemDraft(
+	ItemInputSource inputSource,
+	String originalUrl,
+	String normalizedUrl,
+	String title,
+	String brandName,
+	String summary,
+	String imageUrl,
+	Integer listedPrice,
+	String currencyCode,
+	ItemCategory category,
+	Double categoryConfidence,
+	boolean categoryLockedByUser,
+	ItemStatus status
+) {
+}

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportRequest.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportRequest.java
@@ -1,0 +1,13 @@
+package com.sagongsa.backend.itemimport.item;
+
+import com.sagongsa.backend.domain.enums.ItemInputSource;
+
+public record ShoppingLinkImportRequest(
+	ItemInputSource inputSource,
+	String url,
+	String title,
+	String brandName,
+	Integer price,
+	String imageUrl
+) {
+}

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportResponse.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportResponse.java
@@ -1,0 +1,12 @@
+package com.sagongsa.backend.itemimport.item;
+
+import java.util.List;
+
+public record ShoppingLinkImportResponse(
+	String retrievalStatus,
+	SavedItemDraft item,
+	ItemSourceMetadataDraft sourceMetadata,
+	WishlistSaveDraft saveRequest,
+	List<String> warnings
+) {
+}

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
@@ -1,0 +1,603 @@
+package com.sagongsa.backend.itemimport.item;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sagongsa.backend.domain.enums.ItemCategory;
+import com.sagongsa.backend.domain.enums.ItemInputSource;
+import com.sagongsa.backend.domain.enums.ItemStatus;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class ShoppingLinkImportService {
+
+	private static final Pattern PRICE_WITH_CURRENCY_PATTERN = Pattern.compile("\\b([0-9]{1,3}(?:,[0-9]{3})+)\\s*원");
+	private static final Set<String> NOISE_IMAGE_KEYWORDS = Set.of("logo", "icon", "sprite", "badge", "banner");
+	private static final Set<String> TRACKING_QUERY_KEYS = Set.of(
+		"fbclid", "gclid", "igshid", "mc_cid", "mc_eid", "n_media", "n_query", "n_rank", "n_ad_group"
+	);
+	private static final double DEFAULT_CATEGORY_CONFIDENCE = 0.35d;
+
+	private final PageFetcher pageFetcher;
+	private final ObjectMapper objectMapper;
+
+	public ShoppingLinkImportService(PageFetcher pageFetcher, ObjectMapper objectMapper) {
+		this.pageFetcher = pageFetcher;
+		this.objectMapper = objectMapper;
+	}
+
+	public ShoppingLinkImportResponse importLink(ShoppingLinkImportRequest request) {
+		if (request == null) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Request body is required");
+		}
+
+		ItemInputSource inputSource = Optional.ofNullable(request.inputSource())
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "inputSource is required"));
+
+		return switch (inputSource) {
+			case SHARE -> importSharedLink(request);
+			case DIRECT_INPUT -> importManualInput(request);
+		};
+	}
+
+	private ShoppingLinkImportResponse importSharedLink(ShoppingLinkImportRequest request) {
+		URI originalUri = parseHttpUri(request.url(), "url is required for SHARE");
+		NormalizationResult normalized = normalizeShoppingUri(originalUri);
+		FetchedPage page = pageFetcher.fetch(normalized.uri());
+
+		if (page.statusCode() >= 400) {
+			throw new ResponseStatusException(
+				HttpStatus.BAD_GATEWAY,
+				"Shopping page returned " + page.statusCode()
+			);
+		}
+
+		Document document = Jsoup.parse(page.body(), page.finalUri().toString());
+		ExtractionResult extracted = extractFromPage(document, page);
+		List<String> warnings = new ArrayList<>(normalized.warnings());
+
+		if (extracted.isPartial()) {
+			warnings.add("상품 메타데이터가 일부만 추출되었습니다.");
+		}
+
+		if (isBlank(extracted.title()) && extracted.price() == null && isBlank(extracted.imageUrl())) {
+			throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Unable to extract shopping metadata");
+		}
+
+		ItemCategory category = classifyCategory(sourceDomain(page.finalUri()), extracted.title(), extracted.summary());
+		SavedItemDraft item = new SavedItemDraft(
+			ItemInputSource.SHARE,
+			originalUri.toString(),
+			page.finalUri().toString(),
+			extracted.title(),
+			firstNonBlank(request.brandName(), extracted.brandName()),
+			extracted.summary(),
+			extracted.imageUrl(),
+			extracted.price(),
+			"KRW",
+			category,
+			category == ItemCategory.ETC ? null : DEFAULT_CATEGORY_CONFIDENCE,
+			false,
+			ItemStatus.SAVED
+		);
+		ItemSourceMetadataDraft sourceMetadata = new ItemSourceMetadataDraft(
+			sourceDomain(page.finalUri()),
+			extracted.rawTitle(),
+			extracted.rawDescription(),
+			extracted.rawPriceText(),
+			toJson(extracted.rawPayloadJson()),
+			Instant.now(),
+			extracted.method()
+		);
+
+		return new ShoppingLinkImportResponse(
+			extracted.isPartial() ? "PARTIAL" : "SUCCESS",
+			item,
+			sourceMetadata,
+			toWishlistSaveDraft(item, sourceMetadata),
+			List.copyOf(warnings)
+		);
+	}
+
+	private ShoppingLinkImportResponse importManualInput(ShoppingLinkImportRequest request) {
+		if (isBlank(request.title())) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "title is required for DIRECT_INPUT");
+		}
+
+		URI normalizedUri = null;
+		List<String> warnings = new ArrayList<>();
+		if (!isBlank(request.url())) {
+			NormalizationResult normalizationResult = normalizeShoppingUri(parseHttpUri(request.url(), "Invalid url"));
+			normalizedUri = normalizationResult.uri();
+			warnings.addAll(normalizationResult.warnings());
+		}
+
+		String normalizedTitle = normalizeWhitespace(request.title());
+		String normalizedBrandName = normalizeWhitespace(request.brandName());
+		String normalizedImageUrl = normalizeImageUrl(request.imageUrl());
+		ItemCategory category = classifyCategory(
+			normalizedUri == null ? null : sourceDomain(normalizedUri),
+			normalizedTitle,
+			null
+		);
+
+		SavedItemDraft item = new SavedItemDraft(
+			ItemInputSource.DIRECT_INPUT,
+			blankToNull(request.url()),
+			normalizedUri == null ? null : normalizedUri.toString(),
+			normalizedTitle,
+			normalizedBrandName,
+			null,
+			normalizedImageUrl,
+			request.price(),
+			request.price() == null ? null : "KRW",
+			category,
+			null,
+			false,
+			ItemStatus.SAVED
+		);
+		ItemSourceMetadataDraft sourceMetadata = new ItemSourceMetadataDraft(
+			normalizedUri == null ? null : sourceDomain(normalizedUri),
+			normalizedTitle,
+			null,
+			request.price() == null ? null : String.valueOf(request.price()),
+			toJson(Map.of(
+				"inputSource", ItemInputSource.DIRECT_INPUT.name(),
+				"manualFields", List.of("title", "brandName", "price", "imageUrl")
+			)),
+			Instant.now(),
+			"MANUAL"
+		);
+
+		return new ShoppingLinkImportResponse(
+			"SUCCESS",
+			item,
+			sourceMetadata,
+			toWishlistSaveDraft(item, sourceMetadata),
+			List.copyOf(warnings)
+		);
+	}
+
+	private NormalizationResult normalizeShoppingUri(URI uri) {
+		String host = Optional.ofNullable(uri.getHost()).orElse("").toLowerCase(Locale.ROOT);
+		List<String> warnings = new ArrayList<>();
+		URI normalized = uri;
+
+		if ("www.coupang.com".equals(host) && uri.getPath() != null && uri.getPath().startsWith("/vp/products/")) {
+			String[] segments = uri.getPath().split("/");
+			if (segments.length >= 4) {
+				normalized = URI.create("https://m.coupang.com/nm/products/" + segments[3]);
+				warnings.add("쿠팡 링크를 모바일 상품 경로로 정규화했습니다.");
+			}
+		}
+
+		if (normalized.getRawQuery() != null && !normalized.getRawQuery().isBlank()) {
+			String filteredQuery = removeTrackingQueryParameters(normalized.getRawQuery());
+			if (!Objects.equals(normalized.getRawQuery(), filteredQuery)) {
+				normalized = rebuildUri(normalized, filteredQuery);
+				warnings.add("추적성 query parameter를 제거했습니다.");
+			}
+		}
+
+		return new NormalizationResult(normalized, List.copyOf(warnings));
+	}
+
+	private ExtractionResult extractFromPage(Document document, FetchedPage page) {
+		String html = page.body();
+		String summary = firstNonBlank(
+			metaContent(document, "meta[property=og:description]"),
+			metaContent(document, "meta[name=description]"),
+			metaContent(document, "meta[name=twitter:description]"),
+			jsonLdText(document, "description")
+		);
+		String title = firstNonBlank(
+			metaContent(document, "meta[property=og:title]"),
+			metaContent(document, "meta[name=twitter:title]"),
+			jsonLdText(document, "name"),
+			normalizeWhitespace(document.title()),
+			firstText(document, "h1", "[data-testid=productName]", ".prod-buy-header__title")
+		);
+
+		String brandName = firstNonBlank(
+			jsonLdText(document, "brand.name"),
+			jsonLdText(document, "brand"),
+			firstText(document, "[itemprop=brand]", ".prod-brand-name", ".brand-name")
+		);
+
+		Integer price = firstNonNull(
+			parsePrice(metaContent(document, "meta[property=product:price:amount]")),
+			parsePrice(metaContent(document, "meta[property=og:price:amount]")),
+			parsePrice(jsonLdText(document, "offers.price")),
+			parsePrice(jsonLdText(document, "price")),
+			parsePrice(findByRegex(html, PRICE_WITH_CURRENCY_PATTERN))
+		);
+		String rawPriceText = firstNonBlank(
+			metaContent(document, "meta[property=product:price:amount]"),
+			metaContent(document, "meta[property=og:price:amount]"),
+			jsonLdText(document, "offers.price"),
+			jsonLdText(document, "price"),
+			findByRegex(html, PRICE_WITH_CURRENCY_PATTERN)
+		);
+
+		String imageUrl = firstNonBlank(
+			normalizeImageUrl(metaContent(document, "meta[property=og:image]")),
+			normalizeImageUrl(metaContent(document, "meta[name=twitter:image]")),
+			normalizeImageUrl(jsonLdText(document, "image")),
+			bestImage(document)
+		);
+
+		String method = "OPEN_GRAPH";
+		if (!isBlank(jsonLdText(document, "name")) || !isBlank(jsonLdText(document, "offers.price"))) {
+			method = "JSON_LD";
+		} else if (title != null || price != null || imageUrl != null) {
+			method = "HTML_META";
+		}
+
+		Map<String, Object> rawPayloadJson = new LinkedHashMap<>();
+		rawPayloadJson.put("requestedUrl", page.requestedUri().toString());
+		rawPayloadJson.put("finalUrl", page.finalUri().toString());
+		rawPayloadJson.put("statusCode", page.statusCode());
+		rawPayloadJson.put("contentType", page.contentType());
+		rawPayloadJson.put("title", title);
+		rawPayloadJson.put("brandName", brandName);
+		rawPayloadJson.put("summary", summary);
+		rawPayloadJson.put("price", price);
+		rawPayloadJson.put("imageUrl", imageUrl);
+		rawPayloadJson.put("method", method);
+
+		return new ExtractionResult(
+			title,
+			brandName,
+			summary,
+			price,
+			rawPriceText,
+			imageUrl,
+			method,
+			rawPayloadJson
+		);
+	}
+
+	private ItemCategory classifyCategory(String sourceDomain, String title, String summary) {
+		String haystack = ((sourceDomain == null ? "" : sourceDomain) + " " + (title == null ? "" : title) + " " + (summary == null ? "" : summary))
+			.toLowerCase(Locale.ROOT);
+
+		if (containsAny(haystack, "셔츠", "니트", "팬츠", "아우터", "원피스", "스니커즈", "신발", "가방", "musinsa", "zigzag", "ably", "29cm")) {
+			return ItemCategory.FASHION;
+		}
+		if (containsAny(haystack, "립", "쿠션", "에센스", "크림", "마스크팩", "oliveyoung", "향수", "샴푸")) {
+			return ItemCategory.BEAUTY;
+		}
+		if (containsAny(haystack, "이어폰", "헤드폰", "키보드", "마우스", "노트북", "갤럭시", "아이폰", "ipad", "monitor", "ssd")) {
+			return ItemCategory.DIGITAL;
+		}
+		if (containsAny(haystack, "컵", "머그", "침구", "수납", "조명", "청소", "커피머신", "테이블")) {
+			return ItemCategory.LIVING;
+		}
+		if (containsAny(haystack, "간식", "음료", "커피", "프로틴", "식품", "라면", "과자")) {
+			return ItemCategory.FOOD;
+		}
+		if (containsAny(haystack, "레고", "피규어", "게임", "취미", "캠핑", "자전거")) {
+			return ItemCategory.HOBBY;
+		}
+		if (containsAny(haystack, "subscription", "멤버십", "정기구독", "월간", "연간 구독")) {
+			return ItemCategory.SUBSCRIPTION;
+		}
+		return ItemCategory.ETC;
+	}
+
+	private String bestImage(Document document) {
+		return document.select("img[src], img[data-src], img[srcset]").stream()
+			.map(element -> firstNonBlank(element.absUrl("src"), element.absUrl("data-src"), firstSrcSetUrl(element.attr("srcset"))))
+			.map(this::normalizeImageUrl)
+			.filter(Objects::nonNull)
+			.filter(url -> NOISE_IMAGE_KEYWORDS.stream().noneMatch(url.toLowerCase(Locale.ROOT)::contains))
+			.findFirst()
+			.orElse(null);
+	}
+
+	private String firstSrcSetUrl(String srcSet) {
+		if (isBlank(srcSet)) {
+			return null;
+		}
+		String firstCandidate = srcSet.split(",")[0].trim();
+		return firstCandidate.split("\\s+")[0];
+	}
+
+	private String jsonLdText(Document document, String path) {
+		for (Element scriptElement : document.select("script[type=application/ld+json]")) {
+			String rawJson = scriptElement.data();
+			if (isBlank(rawJson)) {
+				rawJson = scriptElement.html();
+			}
+			String value = jsonValue(rawJson, path);
+			if (!isBlank(value)) {
+				return normalizeWhitespace(value);
+			}
+		}
+		return null;
+	}
+
+	private String jsonValue(String rawJson, String path) {
+		try {
+			JsonNode root = objectMapper.readTree(rawJson);
+			return searchJson(root, path.split("\\."));
+		} catch (JsonProcessingException exception) {
+			return null;
+		}
+	}
+
+	private String searchJson(JsonNode node, String[] path) {
+		if (node == null || node.isNull()) {
+			return null;
+		}
+		if (node.isArray()) {
+			for (JsonNode child : node) {
+				String value = searchJson(child, path);
+				if (!isBlank(value)) {
+					return value;
+				}
+			}
+			return null;
+		}
+		if (path.length == 0) {
+			if (node.isValueNode()) {
+				return node.asText();
+			}
+			if (node.has("@value")) {
+				return node.get("@value").asText();
+			}
+			return null;
+		}
+		if (node.has(path[0])) {
+			return searchJson(node.get(path[0]), tail(path));
+		}
+		Iterator<JsonNode> children = node.elements();
+		while (children.hasNext()) {
+			String value = searchJson(children.next(), path);
+			if (!isBlank(value)) {
+				return value;
+			}
+		}
+		return null;
+	}
+
+	private String[] tail(String[] path) {
+		if (path.length <= 1) {
+			return new String[0];
+		}
+		String[] tail = new String[path.length - 1];
+		System.arraycopy(path, 1, tail, 0, path.length - 1);
+		return tail;
+	}
+
+	private String metaContent(Document document, String cssQuery) {
+		String content = document.selectFirst(cssQuery) == null ? null : document.selectFirst(cssQuery).attr("content");
+		return normalizeWhitespace(content);
+	}
+
+	private String firstText(Document document, String... selectors) {
+		for (String selector : selectors) {
+			if (document.selectFirst(selector) != null) {
+				String text = normalizeWhitespace(document.selectFirst(selector).text());
+				if (!isBlank(text)) {
+					return text;
+				}
+			}
+		}
+		return null;
+	}
+
+	private String findByRegex(String text, Pattern pattern) {
+		Matcher matcher = pattern.matcher(text);
+		return matcher.find() ? matcher.group(1) : null;
+	}
+
+	private Integer parsePrice(String rawPrice) {
+		if (isBlank(rawPrice)) {
+			return null;
+		}
+		String digitsOnly = rawPrice.replaceAll("[^0-9]", "");
+		if (digitsOnly.isBlank()) {
+			return null;
+		}
+		try {
+			return Integer.parseInt(digitsOnly);
+		} catch (NumberFormatException exception) {
+			return null;
+		}
+	}
+
+	private URI parseHttpUri(String rawUrl, String errorMessage) {
+		if (isBlank(rawUrl)) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, errorMessage);
+		}
+
+		try {
+			URI uri = URI.create(rawUrl.trim());
+			String scheme = Optional.ofNullable(uri.getScheme()).orElse("").toLowerCase(Locale.ROOT);
+			if (!scheme.equals("http") && !scheme.equals("https")) {
+				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Only http/https urls are supported");
+			}
+			if (isBlank(uri.getHost())) {
+				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, errorMessage);
+			}
+			return uri;
+		} catch (IllegalArgumentException exception) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, errorMessage, exception);
+		}
+	}
+
+	private String sourceDomain(URI uri) {
+		String host = Optional.ofNullable(uri.getHost()).orElse("");
+		return host.toLowerCase(Locale.ROOT).replaceFirst("^www\\.", "");
+	}
+
+	private boolean containsAny(String value, String... keywords) {
+		for (String keyword : keywords) {
+			if (value.contains(keyword.toLowerCase(Locale.ROOT))) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private String normalizeImageUrl(String imageUrl) {
+		if (isBlank(imageUrl)) {
+			return null;
+		}
+		try {
+			URI uri = URI.create(imageUrl.trim());
+			String scheme = Optional.ofNullable(uri.getScheme()).orElse("").toLowerCase(Locale.ROOT);
+			if (!scheme.equals("http") && !scheme.equals("https")) {
+				return null;
+			}
+			return uri.toString();
+		} catch (IllegalArgumentException exception) {
+			return null;
+		}
+	}
+
+	private String normalizeWhitespace(String value) {
+		if (value == null) {
+			return null;
+		}
+		String normalized = value.replaceAll("\\s+", " ").trim();
+		return normalized.isBlank() ? null : normalized;
+	}
+
+	private String blankToNull(String value) {
+		return isBlank(value) ? null : value.trim();
+	}
+
+	private boolean isBlank(String value) {
+		return value == null || value.isBlank();
+	}
+
+	private URI rebuildUri(URI uri, String rawQuery) {
+		try {
+			return new URI(uri.getScheme(), uri.getAuthority(), uri.getPath(), rawQuery, null);
+		} catch (URISyntaxException exception) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid normalized url", exception);
+		}
+	}
+
+	private String removeTrackingQueryParameters(String rawQuery) {
+		String filtered = Arrays.stream(rawQuery.split("&"))
+			.filter(parameter -> !isTrackingQueryParameter(parameter))
+			.collect(Collectors.joining("&"));
+		return filtered.isBlank() ? null : filtered;
+	}
+
+	private boolean isTrackingQueryParameter(String parameter) {
+		String key = parameter.split("=", 2)[0].toLowerCase(Locale.ROOT);
+		return key.startsWith("utm_") || TRACKING_QUERY_KEYS.contains(key);
+	}
+
+	private String toJson(Map<String, Object> rawPayloadJson) {
+		try {
+			return objectMapper.writeValueAsString(rawPayloadJson);
+		} catch (JsonProcessingException exception) {
+			throw new IllegalStateException("Failed to serialize import metadata", exception);
+		}
+	}
+
+	private WishlistSaveDraft toWishlistSaveDraft(SavedItemDraft item, ItemSourceMetadataDraft metadata) {
+		return new WishlistSaveDraft(
+			item.inputSource(),
+			item.originalUrl(),
+			item.normalizedUrl(),
+			item.title(),
+			item.imageUrl(),
+			item.listedPrice(),
+			item.currencyCode(),
+			item.category(),
+			item.categoryConfidence(),
+			item.categoryLockedByUser(),
+			metadata.sourceDomain(),
+			metadata.rawTitle(),
+			metadata.rawDescription(),
+			metadata.rawPriceText(),
+			metadata.rawPayloadJson()
+		);
+	}
+
+	@SafeVarargs
+	private <T> T firstNonNull(T... values) {
+		for (T value : values) {
+			if (value != null) {
+				return value;
+			}
+		}
+		return null;
+	}
+
+	private String firstNonBlank(String... values) {
+		for (String value : values) {
+			if (!isBlank(value)) {
+				return normalizeWhitespace(value);
+			}
+		}
+		return null;
+	}
+
+	private record NormalizationResult(URI uri, List<String> warnings) {
+	}
+
+	private record ExtractionResult(
+		String title,
+		String brandName,
+		String summary,
+		Integer price,
+		String rawPriceText,
+		String imageUrl,
+		String method,
+		Map<String, Object> rawPayloadJson
+	) {
+		private String rawTitle() {
+			return title;
+		}
+
+		private String rawDescription() {
+			return summary;
+		}
+
+		private boolean isPartial() {
+			int count = 0;
+			if (!isBlank(title)) {
+				count++;
+			}
+			if (price != null) {
+				count++;
+			}
+			if (!isBlank(imageUrl)) {
+				count++;
+			}
+			return count < 3;
+		}
+
+		private boolean isBlank(String value) {
+			return value == null || value.isBlank();
+		}
+	}
+}

--- a/src/main/java/com/sagongsa/backend/itemimport/item/WishlistSaveDraft.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/WishlistSaveDraft.java
@@ -1,0 +1,23 @@
+package com.sagongsa.backend.itemimport.item;
+
+import com.sagongsa.backend.domain.enums.ItemCategory;
+import com.sagongsa.backend.domain.enums.ItemInputSource;
+
+public record WishlistSaveDraft(
+	ItemInputSource inputSource,
+	String originalUrl,
+	String normalizedUrl,
+	String title,
+	String imageUrl,
+	Integer listedPrice,
+	String currencyCode,
+	ItemCategory category,
+	Double categoryConfidence,
+	boolean categoryLockedByUser,
+	String sourceDomain,
+	String rawTitle,
+	String rawDescription,
+	String rawPriceText,
+	String rawPayloadJson
+) {
+}

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
@@ -1,0 +1,167 @@
+package com.sagongsa.backend.itemimport.item;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sagongsa.backend.domain.enums.ItemCategory;
+import com.sagongsa.backend.domain.enums.ItemInputSource;
+import com.sagongsa.backend.domain.enums.ItemStatus;
+import java.net.URI;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+class ShoppingLinkImportServiceTest {
+
+	private FakePageFetcher pageFetcher;
+	private ShoppingLinkImportService service;
+
+	@BeforeEach
+	void setUp() {
+		pageFetcher = new FakePageFetcher();
+		service = new ShoppingLinkImportService(pageFetcher, new ObjectMapper());
+	}
+
+	@Test
+	void importsSharedLinkFromOpenGraphMetadata() {
+		pageFetcher.stub(
+			"https://shopping.example.com/products/100",
+			"""
+				<html>
+				<head>
+				  <title>Example</title>
+				  <meta property="og:title" content="Air Runner Sneakers" />
+				  <meta property="og:image" content="https://cdn.example.com/air-runner.jpg" />
+				  <meta property="product:price:amount" content="129000" />
+				</head>
+				<body></body>
+				</html>
+				"""
+		);
+
+		ShoppingLinkImportResponse response = service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.SHARE,
+				"https://shopping.example.com/products/100?utm_source=kakao",
+				null,
+				null,
+				null,
+				null
+			)
+		);
+
+		assertThat(response.item().normalizedUrl()).isEqualTo("https://shopping.example.com/products/100");
+		assertThat(response.sourceMetadata().sourceDomain()).isEqualTo("shopping.example.com");
+		assertThat(response.item().title()).isEqualTo("Air Runner Sneakers");
+		assertThat(response.item().listedPrice()).isEqualTo(129000);
+		assertThat(response.item().imageUrl()).isEqualTo("https://cdn.example.com/air-runner.jpg");
+		assertThat(response.sourceMetadata().extractionMethod()).isEqualTo("HTML_META");
+		assertThat(response.item().status()).isEqualTo(ItemStatus.SAVED);
+		assertThat(response.saveRequest().normalizedUrl()).isEqualTo("https://shopping.example.com/products/100");
+		assertThat(response.saveRequest().sourceDomain()).isEqualTo("shopping.example.com");
+		assertThat(response.warnings()).contains("추적성 query parameter를 제거했습니다.");
+	}
+
+	@Test
+	void importsSharedLinkFromJsonLdMetadata() {
+		pageFetcher.stub(
+			"https://m.coupang.com/nm/products/3013825663",
+			"""
+				<html>
+				<head>
+				  <script type="application/ld+json">
+				  {
+				    "@context": "https://schema.org",
+				    "@type": "Product",
+				    "name": "쿠팡 무선 이어폰",
+				    "image": ["https://image.coupangcdn.com/item.jpg"],
+				    "brand": {
+				      "@type": "Brand",
+				      "name": "Coupang Basics"
+				    },
+				    "offers": {
+				      "@type": "Offer",
+				      "price": "49900"
+				    }
+				  }
+				  </script>
+				</head>
+				<body></body>
+				</html>
+				"""
+		);
+
+		ShoppingLinkImportResponse response = service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.SHARE,
+				"https://www.coupang.com/vp/products/3013825663?itemId=1",
+				null,
+				null,
+				null,
+				null
+			)
+		);
+
+		assertThat(response.item().normalizedUrl()).isEqualTo("https://m.coupang.com/nm/products/3013825663");
+		assertThat(response.item().title()).isEqualTo("쿠팡 무선 이어폰");
+		assertThat(response.item().brandName()).isEqualTo("Coupang Basics");
+		assertThat(response.item().listedPrice()).isEqualTo(49900);
+		assertThat(response.sourceMetadata().extractionMethod()).isEqualTo("JSON_LD");
+		assertThat(response.item().category()).isEqualTo(ItemCategory.DIGITAL);
+		assertThat(response.warnings()).contains("쿠팡 링크를 모바일 상품 경로로 정규화했습니다.");
+	}
+
+	@Test
+	void acceptsDirectInputWithoutRemoteFetch() {
+		ShoppingLinkImportResponse response = service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.DIRECT_INPUT,
+				"https://zigzag.kr/catalog/products/110621280",
+				"여름 셔츠",
+				"Zigzag",
+				39000,
+				"https://image.example.com/shirt.jpg"
+			)
+		);
+
+		assertThat(response.item().title()).isEqualTo("여름 셔츠");
+		assertThat(response.item().brandName()).isEqualTo("Zigzag");
+		assertThat(response.item().listedPrice()).isEqualTo(39000);
+		assertThat(response.sourceMetadata().extractionMethod()).isEqualTo("MANUAL");
+		assertThat(response.sourceMetadata().sourceDomain()).isEqualTo("zigzag.kr");
+		assertThat(response.item().category()).isEqualTo(ItemCategory.FASHION);
+	}
+
+	@Test
+	void rejectsShareRequestWithoutUrl() {
+		assertThatThrownBy(() -> service.importLink(
+			new ShoppingLinkImportRequest(ItemInputSource.SHARE, null, null, null, null, null)
+		))
+			.isInstanceOf(ResponseStatusException.class)
+			.satisfies(exception -> {
+				ResponseStatusException responseStatusException = (ResponseStatusException) exception;
+				assertThat(responseStatusException.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+			});
+	}
+
+	private static final class FakePageFetcher implements PageFetcher {
+
+		private final Map<String, String> pages = new java.util.HashMap<>();
+
+		private void stub(String url, String body) {
+			pages.put(url, body);
+		}
+
+		@Override
+		public FetchedPage fetch(URI uri) {
+			String body = pages.get(uri.toString());
+			if (body == null) {
+				throw new AssertionError("No stubbed page for " + uri);
+			}
+			return new FetchedPage(uri, uri, 200, "text/html", body);
+		}
+	}
+}


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-9`
- Jira: https://parkjaehong.atlassian.net/browse/NF-9
- GitHub: Related #7
- GitHub: Closes #7

> PR 제목: `[feat] NF-9 쇼핑 링크 import preview 구현`
> 브랜치: `feat/NF-9-import-preview-develop`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #7의 1/1 단계
- 선행 PR: NF-12 도메인/스키마가 반영된 `develop`
- 후속 PR: #14 / NF-17 위시 상품 저장 및 위시리스트 조회 API

### 이 PR에서 변경한 것
- 최신 `develop` 기준으로 쇼핑 링크 import preview 기능만 이식했습니다.
- `POST /api/v1/items/import-link` API를 추가했습니다.
- `SHARE`, `DIRECT_INPUT` 입력 경로를 처리하는 import preview 로직을 구현했습니다.
- URL 정규화, HTML meta/JSON-LD 기반 메타데이터 추출, 카테고리 추정 로직을 추가했습니다.
- preview 결과가 NF-17 저장 API로 이어질 수 있도록 `WishlistSaveDraft` 응답 계약을 유지했습니다.
- 기존 NF-12 도메인 enum(`ItemInputSource`, `ItemCategory`, `ItemStatus`)을 재사용하도록 정리했습니다.

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
- AC1: 외부 공유 링크와 수동 링크 입력 경로를 모두 지원합니다.
- AC2: 쇼핑 링크의 URL 정규화와 기본 상품 메타데이터 추출을 수행합니다.
- AC3: 저장 전 미리보기 결과를 위시 저장 API 입력으로 사용할 수 있는 draft 형태로 반환합니다.

### Not covered (후속 작업)
- AC4: 실제 위시 상품 저장/조회는 #14 / NF-17에서 처리합니다.
- AC5: 로그인 사용자 연결은 #10 / NF-8 인증 흐름과 후속 통합에서 처리합니다.

---

## 🧪 테스트 결과 (필수)
### 로컬
```
./gradlew.bat test
```
- ✅ 결과: 통과

### CI
- Draft PR 상태에서 자동 확인 예정

### Smoke 테스트
- 시나리오: URL 정규화, Open Graph 추출, JSON-LD 추출, 수동 입력 경로, 저장 draft 응답 확인
- 결과: 서비스 테스트로 통과

---

## 🧭 영향 범위 체크 (필수)
- [x] API 변경 (요약: `POST /api/v1/items/import-link` 추가)
- [ ] DB 변경 (마이그레이션: 없음)
- [x] 설정 변경 (항목: `spring-boot-starter-web`, `jsoup` 의존성 추가)
- [ ] Breaking change (무엇: 없음)

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인: `ShoppingLinkImportService`, `JsoupPageFetcher`, `ShoppingLinkImportResponse`, `ShoppingLinkImportServiceTest`
- 트레이드오프/대안: 실제 저장은 NF-17로 분리하고, 이 PR은 저장 직전 preview와 저장 계약 정렬까지만 포함했습니다.
