### PR TITLE
[feat] NF-17 위시 상품 저장 및 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
 	runtimeOnly 'org.flywaydb:flyway-database-postgresql'
 	runtimeOnly 'org.postgresql:postgresql'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/sagongsa/backend/auth/CurrentUserId.java
+++ b/src/main/java/com/sagongsa/backend/auth/CurrentUserId.java
@@ -1,0 +1,11 @@
+package com.sagongsa.backend.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUserId {
+}

--- a/src/main/java/com/sagongsa/backend/auth/CurrentUserIdArgumentResolver.java
+++ b/src/main/java/com/sagongsa/backend/auth/CurrentUserIdArgumentResolver.java
@@ -1,5 +1,6 @@
 package com.sagongsa.backend.auth;
 
+import java.security.Principal;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.MethodParameter;
@@ -39,19 +40,28 @@ class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResolver {
 		NativeWebRequest webRequest,
 		WebDataBinderFactory binderFactory
 	) {
-		if (!trustedHeaderEnabled) {
-			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authenticated user is required.");
+		String rawUserId = webRequest.getHeader(trustedHeaderName);
+		if (trustedHeaderEnabled && StringUtils.hasText(rawUserId)) {
+			return parseUserId(rawUserId, trustedHeaderName + " header");
 		}
 
-		String rawUserId = webRequest.getHeader(trustedHeaderName);
-		if (!StringUtils.hasText(rawUserId)) {
+		Principal principal = webRequest.getUserPrincipal();
+		if (principal != null && StringUtils.hasText(principal.getName())) {
+			return parseUserId(principal.getName(), "authenticated principal");
+		}
+
+		if (trustedHeaderEnabled) {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, trustedHeaderName + " header is required.");
 		}
 
+		throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authenticated user is required.");
+	}
+
+	private UUID parseUserId(String rawUserId, String source) {
 		try {
 			return UUID.fromString(rawUserId.trim());
 		} catch (IllegalArgumentException exception) {
-			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, trustedHeaderName + " header must be a UUID.");
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, source + " must be a UUID.");
 		}
 	}
 }

--- a/src/main/java/com/sagongsa/backend/auth/CurrentUserIdArgumentResolver.java
+++ b/src/main/java/com/sagongsa/backend/auth/CurrentUserIdArgumentResolver.java
@@ -1,0 +1,57 @@
+package com.sagongsa.backend.auth;
+
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.server.ResponseStatusException;
+
+@Component
+class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+	private final boolean trustedHeaderEnabled;
+	private final String trustedHeaderName;
+
+	CurrentUserIdArgumentResolver(
+		@Value("${app.auth.trusted-user-id-header.enabled:false}") boolean trustedHeaderEnabled,
+		@Value("${app.auth.trusted-user-id-header.name:X-User-Id}") String trustedHeaderName
+	) {
+		this.trustedHeaderEnabled = trustedHeaderEnabled;
+		this.trustedHeaderName = trustedHeaderName;
+	}
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(CurrentUserId.class)
+			&& UUID.class.equals(parameter.getParameterType());
+	}
+
+	@Override
+	public Object resolveArgument(
+		MethodParameter parameter,
+		ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest,
+		WebDataBinderFactory binderFactory
+	) {
+		if (!trustedHeaderEnabled) {
+			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authenticated user is required.");
+		}
+
+		String rawUserId = webRequest.getHeader(trustedHeaderName);
+		if (!StringUtils.hasText(rawUserId)) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, trustedHeaderName + " header is required.");
+		}
+
+		try {
+			return UUID.fromString(rawUserId.trim());
+		} catch (IllegalArgumentException exception) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, trustedHeaderName + " header must be a UUID.");
+		}
+	}
+}

--- a/src/main/java/com/sagongsa/backend/auth/CurrentUserWebMvcConfig.java
+++ b/src/main/java/com/sagongsa/backend/auth/CurrentUserWebMvcConfig.java
@@ -1,0 +1,21 @@
+package com.sagongsa.backend.auth;
+
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+class CurrentUserWebMvcConfig implements WebMvcConfigurer {
+
+	private final CurrentUserIdArgumentResolver currentUserIdArgumentResolver;
+
+	CurrentUserWebMvcConfig(CurrentUserIdArgumentResolver currentUserIdArgumentResolver) {
+		this.currentUserIdArgumentResolver = currentUserIdArgumentResolver;
+	}
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(currentUserIdArgumentResolver);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/wishlist/ApiErrorResponse.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/ApiErrorResponse.java
@@ -1,0 +1,4 @@
+package com.sagongsa.backend.wishlist;
+
+public record ApiErrorResponse(String code, String message) {
+}

--- a/src/main/java/com/sagongsa/backend/wishlist/BadRequestException.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/BadRequestException.java
@@ -1,0 +1,8 @@
+package com.sagongsa.backend.wishlist;
+
+public class BadRequestException extends RuntimeException {
+
+	public BadRequestException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/wishlist/DuplicateSavedItemException.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/DuplicateSavedItemException.java
@@ -1,0 +1,8 @@
+package com.sagongsa.backend.wishlist;
+
+public class DuplicateSavedItemException extends RuntimeException {
+
+	public DuplicateSavedItemException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/wishlist/DuplicateSavedItemException.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/DuplicateSavedItemException.java
@@ -2,7 +2,14 @@ package com.sagongsa.backend.wishlist;
 
 public class DuplicateSavedItemException extends RuntimeException {
 
-	public DuplicateSavedItemException(String message) {
+	private final WishlistItemResponse existingItem;
+
+	public DuplicateSavedItemException(String message, WishlistItemResponse existingItem) {
 		super(message);
+		this.existingItem = existingItem;
+	}
+
+	public WishlistItemResponse existingItem() {
+		return existingItem;
 	}
 }

--- a/src/main/java/com/sagongsa/backend/wishlist/DuplicateSavedItemResponse.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/DuplicateSavedItemResponse.java
@@ -1,0 +1,8 @@
+package com.sagongsa.backend.wishlist;
+
+public record DuplicateSavedItemResponse(
+	String code,
+	String message,
+	WishlistItemResponse existingItem
+) {
+}

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistCategoryUpdateRequest.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistCategoryUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.sagongsa.backend.wishlist;
+
+public record WishlistCategoryUpdateRequest(String category) {
+}

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistController.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistController.java
@@ -1,17 +1,16 @@
 package com.sagongsa.backend.wishlist;
 
+import com.sagongsa.backend.auth.CurrentUserId;
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,8 +18,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/wishlist/items")
 public class WishlistController {
-
-	private static final String USER_ID_HEADER = "X-User-Id";
 
 	private final WishlistService wishlistService;
 
@@ -30,50 +27,36 @@ public class WishlistController {
 
 	@PostMapping
 	public ResponseEntity<WishlistItemResponse> create(
-		@RequestHeader(value = USER_ID_HEADER, required = false) String rawUserId,
+		@CurrentUserId UUID userId,
 		@RequestBody WishlistItemCreateRequest request
 	) {
-		UUID userId = parseUserId(rawUserId);
 		WishlistItemResponse response = wishlistService.create(userId, request);
 		return ResponseEntity.created(URI.create("/api/v1/wishlist/items/" + response.id())).body(response);
 	}
 
 	@GetMapping
 	public List<WishlistItemResponse> list(
-		@RequestHeader(value = USER_ID_HEADER, required = false) String rawUserId,
+		@CurrentUserId UUID userId,
 		@RequestParam(required = false) String category
 	) {
-		return wishlistService.list(parseUserId(rawUserId), category);
+		return wishlistService.list(userId, category);
 	}
 
 	@PatchMapping("/{itemId}/category")
 	public WishlistItemResponse updateCategory(
-		@RequestHeader(value = USER_ID_HEADER, required = false) String rawUserId,
+		@CurrentUserId UUID userId,
 		@PathVariable UUID itemId,
 		@RequestBody WishlistCategoryUpdateRequest request
 	) {
-		return wishlistService.updateCategory(parseUserId(rawUserId), itemId, request);
+		return wishlistService.updateCategory(userId, itemId, request);
 	}
 
 	@DeleteMapping("/{itemId}")
 	public ResponseEntity<Void> delete(
-		@RequestHeader(value = USER_ID_HEADER, required = false) String rawUserId,
+		@CurrentUserId UUID userId,
 		@PathVariable UUID itemId
 	) {
-		wishlistService.drop(parseUserId(rawUserId), itemId);
+		wishlistService.drop(userId, itemId);
 		return ResponseEntity.noContent().build();
-	}
-
-	private UUID parseUserId(String rawUserId) {
-		if (!StringUtils.hasText(rawUserId)) {
-			throw new BadRequestException(USER_ID_HEADER + " header is required.");
-		}
-
-		try {
-			return UUID.fromString(rawUserId.trim());
-		}
-		catch (IllegalArgumentException exception) {
-			throw new BadRequestException(USER_ID_HEADER + " header must be a UUID.");
-		}
 	}
 }

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistController.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistController.java
@@ -1,0 +1,79 @@
+package com.sagongsa.backend.wishlist;
+
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/wishlist/items")
+public class WishlistController {
+
+	private static final String USER_ID_HEADER = "X-User-Id";
+
+	private final WishlistService wishlistService;
+
+	public WishlistController(WishlistService wishlistService) {
+		this.wishlistService = wishlistService;
+	}
+
+	@PostMapping
+	public ResponseEntity<WishlistItemResponse> create(
+		@RequestHeader(value = USER_ID_HEADER, required = false) String rawUserId,
+		@RequestBody WishlistItemCreateRequest request
+	) {
+		UUID userId = parseUserId(rawUserId);
+		WishlistItemResponse response = wishlistService.create(userId, request);
+		return ResponseEntity.created(URI.create("/api/v1/wishlist/items/" + response.id())).body(response);
+	}
+
+	@GetMapping
+	public List<WishlistItemResponse> list(
+		@RequestHeader(value = USER_ID_HEADER, required = false) String rawUserId,
+		@RequestParam(required = false) String category
+	) {
+		return wishlistService.list(parseUserId(rawUserId), category);
+	}
+
+	@PatchMapping("/{itemId}/category")
+	public WishlistItemResponse updateCategory(
+		@RequestHeader(value = USER_ID_HEADER, required = false) String rawUserId,
+		@PathVariable UUID itemId,
+		@RequestBody WishlistCategoryUpdateRequest request
+	) {
+		return wishlistService.updateCategory(parseUserId(rawUserId), itemId, request);
+	}
+
+	@DeleteMapping("/{itemId}")
+	public ResponseEntity<Void> delete(
+		@RequestHeader(value = USER_ID_HEADER, required = false) String rawUserId,
+		@PathVariable UUID itemId
+	) {
+		wishlistService.drop(parseUserId(rawUserId), itemId);
+		return ResponseEntity.noContent().build();
+	}
+
+	private UUID parseUserId(String rawUserId) {
+		if (!StringUtils.hasText(rawUserId)) {
+			throw new BadRequestException(USER_ID_HEADER + " header is required.");
+		}
+
+		try {
+			return UUID.fromString(rawUserId.trim());
+		}
+		catch (IllegalArgumentException exception) {
+			throw new BadRequestException(USER_ID_HEADER + " header must be a UUID.");
+		}
+	}
+}

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistController.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistController.java
@@ -42,6 +42,14 @@ public class WishlistController {
 		return wishlistService.list(userId, category);
 	}
 
+	@GetMapping("/{itemId}")
+	public WishlistItemResponse get(
+		@CurrentUserId UUID userId,
+		@PathVariable UUID itemId
+	) {
+		return wishlistService.get(userId, itemId);
+	}
+
 	@PatchMapping("/{itemId}/category")
 	public WishlistItemResponse updateCategory(
 		@CurrentUserId UUID userId,

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistExceptionHandler.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistExceptionHandler.java
@@ -1,0 +1,41 @@
+package com.sagongsa.backend.wishlist;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class WishlistExceptionHandler {
+
+	@ExceptionHandler(BadRequestException.class)
+	public ResponseEntity<ApiErrorResponse> handleBadRequest(BadRequestException exception) {
+		return error(HttpStatus.BAD_REQUEST, "BAD_REQUEST", exception.getMessage());
+	}
+
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ResponseEntity<ApiErrorResponse> handleUnreadableJson() {
+		return error(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "Request body is not readable JSON.");
+	}
+
+	@ExceptionHandler(DuplicateSavedItemException.class)
+	public ResponseEntity<ApiErrorResponse> handleDuplicate(DuplicateSavedItemException exception) {
+		return error(HttpStatus.CONFLICT, "DUPLICATE_SAVED_ITEM", exception.getMessage());
+	}
+
+	@ExceptionHandler(WishlistItemNotFoundException.class)
+	public ResponseEntity<ApiErrorResponse> handleNotFound(WishlistItemNotFoundException exception) {
+		return error(HttpStatus.NOT_FOUND, "NOT_FOUND", exception.getMessage());
+	}
+
+	@ExceptionHandler(DataIntegrityViolationException.class)
+	public ResponseEntity<ApiErrorResponse> handleDataIntegrityViolation() {
+		return error(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "Request violates wishlist data constraints.");
+	}
+
+	private ResponseEntity<ApiErrorResponse> error(HttpStatus status, String code, String message) {
+		return ResponseEntity.status(status).body(new ApiErrorResponse(code, message));
+	}
+}

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistExceptionHandler.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistExceptionHandler.java
@@ -21,13 +21,20 @@ public class WishlistExceptionHandler {
 	}
 
 	@ExceptionHandler(DuplicateSavedItemException.class)
-	public ResponseEntity<ApiErrorResponse> handleDuplicate(DuplicateSavedItemException exception) {
-		return error(HttpStatus.CONFLICT, "DUPLICATE_SAVED_ITEM", exception.getMessage());
+	public ResponseEntity<DuplicateSavedItemResponse> handleDuplicate(DuplicateSavedItemException exception) {
+		return ResponseEntity
+			.status(HttpStatus.CONFLICT)
+			.body(new DuplicateSavedItemResponse("DUPLICATE_SAVED_ITEM", exception.getMessage(), exception.existingItem()));
 	}
 
 	@ExceptionHandler(WishlistItemNotFoundException.class)
 	public ResponseEntity<ApiErrorResponse> handleNotFound(WishlistItemNotFoundException exception) {
 		return error(HttpStatus.NOT_FOUND, "NOT_FOUND", exception.getMessage());
+	}
+
+	@ExceptionHandler(WishlistForbiddenException.class)
+	public ResponseEntity<ApiErrorResponse> handleForbidden(WishlistForbiddenException exception) {
+		return error(HttpStatus.FORBIDDEN, "FORBIDDEN", exception.getMessage());
 	}
 
 	@ExceptionHandler(DataIntegrityViolationException.class)

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistForbiddenException.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistForbiddenException.java
@@ -1,0 +1,8 @@
+package com.sagongsa.backend.wishlist;
+
+public class WishlistForbiddenException extends RuntimeException {
+
+	public WishlistForbiddenException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistItemCreateRequest.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistItemCreateRequest.java
@@ -1,0 +1,22 @@
+package com.sagongsa.backend.wishlist;
+
+import java.math.BigDecimal;
+
+public record WishlistItemCreateRequest(
+	String inputSource,
+	String originalUrl,
+	String normalizedUrl,
+	String title,
+	String imageUrl,
+	Integer listedPrice,
+	String currencyCode,
+	String category,
+	BigDecimal categoryConfidence,
+	Boolean categoryLockedByUser,
+	String sourceDomain,
+	String rawTitle,
+	String rawDescription,
+	String rawPriceText,
+	String rawPayloadJson
+) {
+}

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistItemNotFoundException.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistItemNotFoundException.java
@@ -1,0 +1,8 @@
+package com.sagongsa.backend.wishlist;
+
+public class WishlistItemNotFoundException extends RuntimeException {
+
+	public WishlistItemNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistItemResponse.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistItemResponse.java
@@ -1,0 +1,30 @@
+package com.sagongsa.backend.wishlist;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public record WishlistItemResponse(
+	UUID id,
+	UUID userId,
+	String inputSource,
+	String originalUrl,
+	String normalizedUrl,
+	String title,
+	String imageUrl,
+	Integer listedPrice,
+	String currencyCode,
+	String category,
+	BigDecimal categoryConfidence,
+	boolean categoryLockedByUser,
+	String status,
+	Instant createdAt,
+	Instant updatedAt,
+	String sourceDomain,
+	String rawTitle,
+	String rawDescription,
+	String rawPriceText,
+	String rawPayloadJson,
+	Instant extractedAt
+) {
+}

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
@@ -5,14 +5,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sagongsa.backend.domain.enums.ItemCategory;
 import com.sagongsa.backend.domain.enums.ItemInputSource;
 import java.math.BigDecimal;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
@@ -24,6 +31,9 @@ public class WishlistService {
 
 	private static final BigDecimal MIN_CONFIDENCE = BigDecimal.ZERO;
 	private static final BigDecimal MAX_CONFIDENCE = BigDecimal.valueOf(100);
+	private static final Set<String> TRACKING_QUERY_KEYS = Set.of(
+		"fbclid", "gclid", "igshid", "mc_cid", "mc_eid", "n_media", "n_query", "n_rank", "n_ad_group"
+	);
 
 	private final JdbcTemplate jdbcTemplate;
 	private final ObjectMapper objectMapper;
@@ -35,13 +45,13 @@ public class WishlistService {
 
 	@Transactional
 	public WishlistItemResponse create(UUID userId, WishlistItemCreateRequest request) {
-		ensureUserExists(userId);
+		ensureWishlistUserAllowed(userId);
 
 		ItemInputSource inputSource = parseRequiredEnum(request.inputSource(), ItemInputSource.class, "inputSource");
 		ItemCategory category = parseRequiredEnum(request.category(), ItemCategory.class, "category");
 		String title = cleanRequired(request.title(), "title", 255);
 		String originalUrl = cleanOptional(request.originalUrl(), "originalUrl");
-		String normalizedUrl = cleanOptional(request.normalizedUrl(), "normalizedUrl");
+		String normalizedUrl = normalizeSavedUrl(originalUrl, cleanOptional(request.normalizedUrl(), "normalizedUrl"));
 		String imageUrl = cleanOptional(request.imageUrl(), "imageUrl");
 		Integer listedPrice = validateListedPrice(request.listedPrice());
 		String currencyCode = cleanCurrencyCode(request.currencyCode());
@@ -49,8 +59,12 @@ public class WishlistService {
 		boolean categoryLockedByUser = Boolean.TRUE.equals(request.categoryLockedByUser());
 		MetadataFields metadata = metadataFields(request);
 
-		if (normalizedUrl != null && existsSavedNormalizedUrl(userId, normalizedUrl)) {
-			throw new DuplicateSavedItemException("Saved wishlist item already exists for the normalized URL.");
+		Optional<WishlistItemResponse> existingItem = findExistingSavedNormalizedUrl(userId, normalizedUrl);
+		if (existingItem.isPresent()) {
+			throw new DuplicateSavedItemException(
+				"Saved wishlist item already exists for the normalized URL.",
+				existingItem.get()
+			);
 		}
 
 		UUID itemId = UUID.randomUUID();
@@ -82,7 +96,10 @@ public class WishlistService {
 			);
 		}
 		catch (DuplicateKeyException exception) {
-			throw new DuplicateSavedItemException("Saved wishlist item already exists for the normalized URL.");
+			throw new DuplicateSavedItemException(
+				"Saved wishlist item already exists for the normalized URL.",
+				findExistingSavedNormalizedUrl(userId, normalizedUrl).orElse(null)
+			);
 		}
 
 		if (metadata.hasAnyValue()) {
@@ -109,7 +126,7 @@ public class WishlistService {
 
 	@Transactional(readOnly = true)
 	public List<WishlistItemResponse> list(UUID userId, String rawCategory) {
-		ensureUserExists(userId);
+		ensureWishlistUserAllowed(userId);
 
 		String category = null;
 		if (StringUtils.hasText(rawCategory)) {
@@ -143,7 +160,7 @@ public class WishlistService {
 
 	@Transactional
 	public WishlistItemResponse updateCategory(UUID userId, UUID itemId, WishlistCategoryUpdateRequest request) {
-		ensureUserExists(userId);
+		ensureWishlistUserAllowed(userId);
 		ItemCategory category = parseRequiredEnum(request.category(), ItemCategory.class, "category");
 		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
 
@@ -172,7 +189,7 @@ public class WishlistService {
 
 	@Transactional
 	public void drop(UUID userId, UUID itemId) {
-		ensureUserExists(userId);
+		ensureWishlistUserAllowed(userId);
 		int updated = jdbcTemplate.update(
 			"""
 			update saved_items
@@ -210,7 +227,7 @@ public class WishlistService {
 		return items.getFirst();
 	}
 
-	private void ensureUserExists(UUID userId) {
+	private void ensureWishlistUserAllowed(UUID userId) {
 		Boolean exists = jdbcTemplate.queryForObject(
 			"select exists(select 1 from users where id = ?)",
 			Boolean.class,
@@ -219,24 +236,38 @@ public class WishlistService {
 		if (!Boolean.TRUE.equals(exists)) {
 			throw new WishlistItemNotFoundException("User was not found.");
 		}
-	}
 
-	private boolean existsSavedNormalizedUrl(UUID userId, String normalizedUrl) {
-		Boolean exists = jdbcTemplate.queryForObject(
+		Boolean allowed = jdbcTemplate.queryForObject(
 			"""
 			select exists(
 				select 1
-				from saved_items
-				where user_id = ?
-				  and normalized_url = ?
-				  and status = 'SAVED'
+				from users
+				where id = ?
+				  and status = 'ACTIVE'
+				  and onboarding_status = 'COMPLETED'
 			)
 			""",
 			Boolean.class,
+			userId
+		);
+		if (!Boolean.TRUE.equals(allowed)) {
+			throw new WishlistForbiddenException("Wishlist can be used only by active users who completed onboarding.");
+		}
+	}
+
+	private Optional<WishlistItemResponse> findExistingSavedNormalizedUrl(UUID userId, String normalizedUrl) {
+		List<WishlistItemResponse> items = jdbcTemplate.query(
+			baseSelect() + """
+			where si.user_id = ?
+			  and si.normalized_url = ?
+			  and si.status = 'SAVED'
+			limit 1
+			""",
+			this::mapRow,
 			userId,
 			normalizedUrl
 		);
-		return Boolean.TRUE.equals(exists);
+		return items.stream().findFirst();
 	}
 
 	private String baseSelect() {
@@ -358,6 +389,60 @@ public class WishlistService {
 			throw new BadRequestException("currencyCode must be 3 characters.");
 		}
 		return cleaned;
+	}
+
+	private String normalizeSavedUrl(String originalUrl, String normalizedUrl) {
+		if (!StringUtils.hasText(originalUrl) && !StringUtils.hasText(normalizedUrl)) {
+			throw new BadRequestException("originalUrl or normalizedUrl is required.");
+		}
+		if (StringUtils.hasText(originalUrl)) {
+			parseHttpUrl(originalUrl, "originalUrl");
+		}
+		return canonicalizeHttpUrl(StringUtils.hasText(normalizedUrl) ? normalizedUrl : originalUrl, "normalizedUrl");
+	}
+
+	private URI parseHttpUrl(String rawUrl, String fieldName) {
+		try {
+			URI uri = URI.create(rawUrl.trim());
+			String scheme = Optional.ofNullable(uri.getScheme()).orElse("").toLowerCase(Locale.ROOT);
+			if (!Objects.equals(scheme, "http") && !Objects.equals(scheme, "https")) {
+				throw new BadRequestException(fieldName + " must use http or https.");
+			}
+			if (!StringUtils.hasText(uri.getHost())) {
+				throw new BadRequestException(fieldName + " host is required.");
+			}
+			return uri;
+		} catch (IllegalArgumentException exception) {
+			throw new BadRequestException(fieldName + " must be a valid URL.");
+		}
+	}
+
+	private String canonicalizeHttpUrl(String rawUrl, String fieldName) {
+		URI uri = parseHttpUrl(rawUrl, fieldName);
+		String filteredQuery = uri.getRawQuery() == null ? null : removeTrackingQueryParameters(uri.getRawQuery());
+		try {
+			return new URI(
+				uri.getScheme().toLowerCase(Locale.ROOT),
+				uri.getAuthority().toLowerCase(Locale.ROOT),
+				uri.getPath(),
+				filteredQuery,
+				null
+			).toString();
+		} catch (URISyntaxException exception) {
+			throw new BadRequestException(fieldName + " must be a valid URL.");
+		}
+	}
+
+	private String removeTrackingQueryParameters(String rawQuery) {
+		String filtered = Arrays.stream(rawQuery.split("&"))
+			.filter(parameter -> !isTrackingQueryParameter(parameter))
+			.collect(Collectors.joining("&"));
+		return filtered.isBlank() ? null : filtered;
+	}
+
+	private boolean isTrackingQueryParameter(String parameter) {
+		String key = parameter.split("=", 2)[0].toLowerCase(Locale.ROOT);
+		return key.startsWith("utm_") || TRACKING_QUERY_KEYS.contains(key);
 	}
 
 	private BigDecimal validateCategoryConfidence(BigDecimal categoryConfidence) {

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
@@ -1,0 +1,410 @@
+package com.sagongsa.backend.wishlist;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sagongsa.backend.domain.enums.ItemCategory;
+import com.sagongsa.backend.domain.enums.ItemInputSource;
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+public class WishlistService {
+
+	private static final BigDecimal MIN_CONFIDENCE = BigDecimal.ZERO;
+	private static final BigDecimal MAX_CONFIDENCE = BigDecimal.valueOf(100);
+
+	private final JdbcTemplate jdbcTemplate;
+	private final ObjectMapper objectMapper;
+
+	public WishlistService(JdbcTemplate jdbcTemplate, ObjectMapper objectMapper) {
+		this.jdbcTemplate = jdbcTemplate;
+		this.objectMapper = objectMapper;
+	}
+
+	@Transactional
+	public WishlistItemResponse create(UUID userId, WishlistItemCreateRequest request) {
+		ensureUserExists(userId);
+
+		ItemInputSource inputSource = parseRequiredEnum(request.inputSource(), ItemInputSource.class, "inputSource");
+		ItemCategory category = parseRequiredEnum(request.category(), ItemCategory.class, "category");
+		String title = cleanRequired(request.title(), "title", 255);
+		String originalUrl = cleanOptional(request.originalUrl(), "originalUrl");
+		String normalizedUrl = cleanOptional(request.normalizedUrl(), "normalizedUrl");
+		String imageUrl = cleanOptional(request.imageUrl(), "imageUrl");
+		Integer listedPrice = validateListedPrice(request.listedPrice());
+		String currencyCode = cleanCurrencyCode(request.currencyCode());
+		BigDecimal categoryConfidence = validateCategoryConfidence(request.categoryConfidence());
+		boolean categoryLockedByUser = Boolean.TRUE.equals(request.categoryLockedByUser());
+		MetadataFields metadata = metadataFields(request);
+
+		if (normalizedUrl != null && existsSavedNormalizedUrl(userId, normalizedUrl)) {
+			throw new DuplicateSavedItemException("Saved wishlist item already exists for the normalized URL.");
+		}
+
+		UUID itemId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		try {
+			jdbcTemplate.update(
+				"""
+				insert into saved_items (
+					id, user_id, input_source, original_url, normalized_url, title, image_url,
+					listed_price, currency_code, category, category_confidence, category_locked_by_user,
+					status, created_at, updated_at
+				)
+				values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'SAVED', ?, ?)
+				""",
+				itemId,
+				userId,
+				inputSource.name(),
+				originalUrl,
+				normalizedUrl,
+				title,
+				imageUrl,
+				listedPrice,
+				currencyCode,
+				category.name(),
+				categoryConfidence,
+				categoryLockedByUser,
+				now,
+				now
+			);
+		}
+		catch (DuplicateKeyException exception) {
+			throw new DuplicateSavedItemException("Saved wishlist item already exists for the normalized URL.");
+		}
+
+		if (metadata.hasAnyValue()) {
+			jdbcTemplate.update(
+				"""
+				insert into item_source_metadata (
+					item_id, source_domain, raw_title, raw_description, raw_price_text,
+					raw_payload_json, extracted_at
+				)
+				values (?, ?, ?, ?, ?, cast(? as jsonb), ?)
+				""",
+				itemId,
+				metadata.sourceDomain(),
+				metadata.rawTitle(),
+				metadata.rawDescription(),
+				metadata.rawPriceText(),
+				metadata.rawPayloadJson(),
+				now
+			);
+		}
+
+		return findByUserAndId(userId, itemId);
+	}
+
+	@Transactional(readOnly = true)
+	public List<WishlistItemResponse> list(UUID userId, String rawCategory) {
+		ensureUserExists(userId);
+
+		String category = null;
+		if (StringUtils.hasText(rawCategory)) {
+			category = parseRequiredEnum(rawCategory, ItemCategory.class, "category").name();
+		}
+
+		if (category == null) {
+			return jdbcTemplate.query(
+				baseSelect() + """
+				where si.user_id = ?
+				  and si.status = 'SAVED'
+				order by si.created_at desc
+				""",
+				this::mapRow,
+				userId
+			);
+		}
+
+		return jdbcTemplate.query(
+			baseSelect() + """
+			where si.user_id = ?
+			  and si.status = 'SAVED'
+			  and si.category = ?
+			order by si.created_at desc
+			""",
+			this::mapRow,
+			userId,
+			category
+		);
+	}
+
+	@Transactional
+	public WishlistItemResponse updateCategory(UUID userId, UUID itemId, WishlistCategoryUpdateRequest request) {
+		ensureUserExists(userId);
+		ItemCategory category = parseRequiredEnum(request.category(), ItemCategory.class, "category");
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+
+		int updated = jdbcTemplate.update(
+			"""
+			update saved_items
+			set category = ?,
+				category_locked_by_user = true,
+				updated_at = ?
+			where user_id = ?
+			  and id = ?
+			  and status = 'SAVED'
+			""",
+			category.name(),
+			now,
+			userId,
+			itemId
+		);
+
+		if (updated == 0) {
+			throw new WishlistItemNotFoundException("Saved wishlist item was not found.");
+		}
+
+		return findByUserAndId(userId, itemId);
+	}
+
+	@Transactional
+	public void drop(UUID userId, UUID itemId) {
+		ensureUserExists(userId);
+		int updated = jdbcTemplate.update(
+			"""
+			update saved_items
+			set status = 'DROPPED',
+				updated_at = ?
+			where user_id = ?
+			  and id = ?
+			  and status = 'SAVED'
+			""",
+			OffsetDateTime.now(ZoneOffset.UTC),
+			userId,
+			itemId
+		);
+
+		if (updated == 0) {
+			throw new WishlistItemNotFoundException("Saved wishlist item was not found.");
+		}
+	}
+
+	private WishlistItemResponse findByUserAndId(UUID userId, UUID itemId) {
+		List<WishlistItemResponse> items = jdbcTemplate.query(
+			baseSelect() + """
+			where si.user_id = ?
+			  and si.id = ?
+			""",
+			this::mapRow,
+			userId,
+			itemId
+		);
+
+		if (items.isEmpty()) {
+			throw new WishlistItemNotFoundException("Saved wishlist item was not found.");
+		}
+
+		return items.getFirst();
+	}
+
+	private void ensureUserExists(UUID userId) {
+		Boolean exists = jdbcTemplate.queryForObject(
+			"select exists(select 1 from users where id = ?)",
+			Boolean.class,
+			userId
+		);
+		if (!Boolean.TRUE.equals(exists)) {
+			throw new WishlistItemNotFoundException("User was not found.");
+		}
+	}
+
+	private boolean existsSavedNormalizedUrl(UUID userId, String normalizedUrl) {
+		Boolean exists = jdbcTemplate.queryForObject(
+			"""
+			select exists(
+				select 1
+				from saved_items
+				where user_id = ?
+				  and normalized_url = ?
+				  and status = 'SAVED'
+			)
+			""",
+			Boolean.class,
+			userId,
+			normalizedUrl
+		);
+		return Boolean.TRUE.equals(exists);
+	}
+
+	private String baseSelect() {
+		return """
+			select
+				si.id,
+				si.user_id,
+				si.input_source,
+				si.original_url,
+				si.normalized_url,
+				si.title,
+				si.image_url,
+				si.listed_price,
+				trim(si.currency_code) as currency_code,
+				si.category,
+				si.category_confidence,
+				si.category_locked_by_user,
+				si.status,
+				si.created_at,
+				si.updated_at,
+				ism.source_domain,
+				ism.raw_title,
+				ism.raw_description,
+				ism.raw_price_text,
+				ism.raw_payload_json::text as raw_payload_json,
+				ism.extracted_at
+			from saved_items si
+			left join item_source_metadata ism on ism.item_id = si.id
+			""";
+	}
+
+	private WishlistItemResponse mapRow(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new WishlistItemResponse(
+			resultSet.getObject("id", UUID.class),
+			resultSet.getObject("user_id", UUID.class),
+			resultSet.getString("input_source"),
+			resultSet.getString("original_url"),
+			resultSet.getString("normalized_url"),
+			resultSet.getString("title"),
+			resultSet.getString("image_url"),
+			getInteger(resultSet, "listed_price"),
+			resultSet.getString("currency_code"),
+			resultSet.getString("category"),
+			resultSet.getBigDecimal("category_confidence"),
+			resultSet.getBoolean("category_locked_by_user"),
+			resultSet.getString("status"),
+			getInstant(resultSet, "created_at"),
+			getInstant(resultSet, "updated_at"),
+			resultSet.getString("source_domain"),
+			resultSet.getString("raw_title"),
+			resultSet.getString("raw_description"),
+			resultSet.getString("raw_price_text"),
+			resultSet.getString("raw_payload_json"),
+			getInstant(resultSet, "extracted_at")
+		);
+	}
+
+	private Integer getInteger(ResultSet resultSet, String columnName) throws SQLException {
+		int value = resultSet.getInt(columnName);
+		return resultSet.wasNull() ? null : value;
+	}
+
+	private Instant getInstant(ResultSet resultSet, String columnName) throws SQLException {
+		OffsetDateTime value = resultSet.getObject(columnName, OffsetDateTime.class);
+		return value == null ? null : value.toInstant();
+	}
+
+	private <T extends Enum<T>> T parseRequiredEnum(String value, Class<T> enumType, String fieldName) {
+		String cleaned = cleanRequired(value, fieldName, 80).toUpperCase(Locale.ROOT);
+		try {
+			return Enum.valueOf(enumType, cleaned);
+		}
+		catch (IllegalArgumentException exception) {
+			throw new BadRequestException(fieldName + " has an unsupported value.");
+		}
+	}
+
+	private String cleanRequired(String value, String fieldName, int maxLength) {
+		String cleaned = cleanOptional(value, fieldName);
+		if (cleaned == null) {
+			throw new BadRequestException(fieldName + " is required.");
+		}
+		if (cleaned.length() > maxLength) {
+			throw new BadRequestException(fieldName + " must be " + maxLength + " characters or fewer.");
+		}
+		return cleaned;
+	}
+
+	private String cleanOptional(String value, String fieldName) {
+		if (!StringUtils.hasText(value)) {
+			return null;
+		}
+		return value.trim();
+	}
+
+	private String cleanOptional(String value, String fieldName, int maxLength) {
+		String cleaned = cleanOptional(value, fieldName);
+		if (cleaned != null && cleaned.length() > maxLength) {
+			throw new BadRequestException(fieldName + " must be " + maxLength + " characters or fewer.");
+		}
+		return cleaned;
+	}
+
+	private Integer validateListedPrice(Integer listedPrice) {
+		if (listedPrice != null && listedPrice < 0) {
+			throw new BadRequestException("listedPrice must be zero or greater.");
+		}
+		return listedPrice;
+	}
+
+	private String cleanCurrencyCode(String currencyCode) {
+		String cleaned = cleanOptional(currencyCode, "currencyCode");
+		if (cleaned == null) {
+			return null;
+		}
+
+		cleaned = cleaned.toUpperCase(Locale.ROOT);
+		if (cleaned.length() != 3) {
+			throw new BadRequestException("currencyCode must be 3 characters.");
+		}
+		return cleaned;
+	}
+
+	private BigDecimal validateCategoryConfidence(BigDecimal categoryConfidence) {
+		if (categoryConfidence == null) {
+			return null;
+		}
+
+		if (categoryConfidence.compareTo(MIN_CONFIDENCE) < 0 || categoryConfidence.compareTo(MAX_CONFIDENCE) > 0) {
+			throw new BadRequestException("categoryConfidence must be between 0 and 100.");
+		}
+		return categoryConfidence;
+	}
+
+	private MetadataFields metadataFields(WishlistItemCreateRequest request) {
+		String rawPayloadJson = cleanOptional(request.rawPayloadJson(), "rawPayloadJson");
+		if (rawPayloadJson != null) {
+			try {
+				objectMapper.readTree(rawPayloadJson);
+			}
+			catch (JsonProcessingException exception) {
+				throw new BadRequestException("rawPayloadJson must be valid JSON.");
+			}
+		}
+
+		return new MetadataFields(
+			cleanOptional(request.sourceDomain(), "sourceDomain", 120),
+			cleanOptional(request.rawTitle(), "rawTitle"),
+			cleanOptional(request.rawDescription(), "rawDescription"),
+			cleanOptional(request.rawPriceText(), "rawPriceText", 120),
+			rawPayloadJson
+		);
+	}
+
+	private record MetadataFields(
+		String sourceDomain,
+		String rawTitle,
+		String rawDescription,
+		String rawPriceText,
+		String rawPayloadJson
+	) {
+
+		boolean hasAnyValue() {
+			return sourceDomain != null
+				|| rawTitle != null
+				|| rawDescription != null
+				|| rawPriceText != null
+				|| rawPayloadJson != null;
+		}
+	}
+}

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
@@ -158,6 +158,12 @@ public class WishlistService {
 		);
 	}
 
+	@Transactional(readOnly = true)
+	public WishlistItemResponse get(UUID userId, UUID itemId) {
+		ensureWishlistUserAllowed(userId);
+		return findSavedByUserAndId(userId, itemId);
+	}
+
 	@Transactional
 	public WishlistItemResponse updateCategory(UUID userId, UUID itemId, WishlistCategoryUpdateRequest request) {
 		ensureWishlistUserAllowed(userId);
@@ -214,6 +220,25 @@ public class WishlistService {
 			baseSelect() + """
 			where si.user_id = ?
 			  and si.id = ?
+			""",
+			this::mapRow,
+			userId,
+			itemId
+		);
+
+		if (items.isEmpty()) {
+			throw new WishlistItemNotFoundException("Saved wishlist item was not found.");
+		}
+
+		return items.getFirst();
+	}
+
+	private WishlistItemResponse findSavedByUserAndId(UUID userId, UUID itemId) {
+		List<WishlistItemResponse> items = jdbcTemplate.query(
+			baseSelect() + """
+			where si.user_id = ?
+			  and si.id = ?
+			  and si.status = 'SAVED'
 			""",
 			this::mapRow,
 			userId,

--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistApiIntegrationTest.java
@@ -39,6 +39,13 @@ class WishlistApiIntegrationTest extends PostgreSqlContainerTest {
 
 	@BeforeEach
 	void setUp() {
+		jdbcTemplate.update("delete from self_check_answers");
+		jdbcTemplate.update("delete from self_check_response_sets");
+		jdbcTemplate.update("delete from purchase_reflections");
+		jdbcTemplate.update("delete from notifications");
+		jdbcTemplate.update("delete from reminder_schedules");
+		jdbcTemplate.update("delete from purchase_decision_change_logs");
+		jdbcTemplate.update("delete from purchase_decisions");
 		jdbcTemplate.update("delete from item_source_metadata");
 		jdbcTemplate.update("delete from saved_items");
 		jdbcTemplate.update("delete from users");

--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistApiIntegrationTest.java
@@ -120,7 +120,27 @@ class WishlistApiIntegrationTest extends PostgreSqlContainerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(request))
 			.andExpect(status().isConflict())
-			.andExpect(jsonPath("$.code").value("DUPLICATE_SAVED_ITEM"));
+			.andExpect(jsonPath("$.code").value("DUPLICATE_SAVED_ITEM"))
+			.andExpect(jsonPath("$.existingItem.title").value("Duplicated item"));
+	}
+
+	@Test
+	void createsItemByNormalizingOriginalUrlWhenNormalizedUrlIsMissing() throws Exception {
+		UUID userId = createUser();
+
+		mockMvc.perform(post(WISHLIST_ITEMS_PATH)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"inputSource": "SHARE",
+					"originalUrl": "https://shop.example.com/product?id=100&utm_source=social",
+					"title": "Original only item",
+					"category": "ETC"
+				}
+				"""))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.normalizedUrl").value("https://shop.example.com/product?id=100"));
 	}
 
 	@Test
@@ -193,15 +213,31 @@ class WishlistApiIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(jsonPath("$", hasSize(0)));
 	}
 
+	@Test
+	void blocksWishlistBeforeOnboardingCompletion() throws Exception {
+		UUID userId = createUser("ACTIVE", "NOT_STARTED");
+
+		mockMvc.perform(get(WISHLIST_ITEMS_PATH)
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("FORBIDDEN"));
+	}
+
 	private UUID createUser() {
+		return createUser("ACTIVE", "COMPLETED");
+	}
+
+	private UUID createUser(String status, String onboardingStatus) {
 		UUID userId = UUID.randomUUID();
 		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
 		jdbcTemplate.update(
 			"""
 			insert into users (id, status, onboarding_status, created_at, updated_at)
-			values (?, 'ACTIVE', 'NOT_STARTED', ?, ?)
+			values (?, ?, ?, ?, ?)
 			""",
 			userId,
+			status,
+			onboardingStatus,
 			now,
 			now
 		);

--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistApiIntegrationTest.java
@@ -39,16 +39,7 @@ class WishlistApiIntegrationTest extends PostgreSqlContainerTest {
 
 	@BeforeEach
 	void setUp() {
-		jdbcTemplate.update("delete from self_check_answers");
-		jdbcTemplate.update("delete from self_check_response_sets");
-		jdbcTemplate.update("delete from purchase_reflections");
-		jdbcTemplate.update("delete from notifications");
-		jdbcTemplate.update("delete from reminder_schedules");
-		jdbcTemplate.update("delete from purchase_decision_change_logs");
-		jdbcTemplate.update("delete from purchase_decisions");
-		jdbcTemplate.update("delete from item_source_metadata");
-		jdbcTemplate.update("delete from saved_items");
-		jdbcTemplate.update("delete from users");
+		jdbcTemplate.execute("truncate table users cascade");
 	}
 
 	@Test
@@ -172,6 +163,31 @@ class WishlistApiIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(jsonPath("$[0].id").value(olderSavedId.toString()));
 
 		assertThat(droppedId).isNotNull();
+	}
+
+	@Test
+	void getsSavedItemDetail() throws Exception {
+		UUID userId = createUser();
+		UUID itemId = insertItem(userId, "Detail target", "BEAUTY", "SAVED", OffsetDateTime.now(ZoneOffset.UTC));
+
+		mockMvc.perform(get(WISHLIST_ITEMS_PATH + "/{itemId}", itemId)
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id").value(itemId.toString()))
+			.andExpect(jsonPath("$.title").value("Detail target"))
+			.andExpect(jsonPath("$.category").value("BEAUTY"))
+			.andExpect(jsonPath("$.status").value("SAVED"));
+	}
+
+	@Test
+	void hidesDroppedItemDetail() throws Exception {
+		UUID userId = createUser();
+		UUID itemId = insertItem(userId, "Dropped detail", "BEAUTY", "DROPPED", OffsetDateTime.now(ZoneOffset.UTC));
+
+		mockMvc.perform(get(WISHLIST_ITEMS_PATH + "/{itemId}", itemId)
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("NOT_FOUND"));
 	}
 
 	@Test

--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistApiIntegrationTest.java
@@ -1,0 +1,231 @@
+package com.sagongsa.backend.wishlist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class WishlistApiIntegrationTest extends PostgreSqlContainerTest {
+
+	private static final String USER_ID_HEADER = "X-User-Id";
+	private static final String WISHLIST_ITEMS_PATH = "/api/v1/wishlist/items";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.update("delete from item_source_metadata");
+		jdbcTemplate.update("delete from saved_items");
+		jdbcTemplate.update("delete from users");
+	}
+
+	@Test
+	void createsSavedItemWithSourceMetadata() throws Exception {
+		UUID userId = createUser();
+
+		String response = mockMvc.perform(post(WISHLIST_ITEMS_PATH)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"inputSource": "SHARE",
+					"originalUrl": "https://shop.example.com/product?id=100&utm_source=social",
+					"normalizedUrl": "https://shop.example.com/product?id=100",
+					"title": "Noise Canceling Headphones",
+					"imageUrl": "https://cdn.example.com/item.png",
+					"listedPrice": 129000,
+					"currencyCode": "krw",
+					"category": "DIGITAL",
+					"categoryConfidence": 92.50,
+					"categoryLockedByUser": false,
+					"sourceDomain": "shop.example.com",
+					"rawTitle": "Headphones / Sale",
+					"rawDescription": "Preview description",
+					"rawPriceText": "129,000원",
+					"rawPayloadJson": "{\\"source\\":\\"preview\\",\\"rank\\":1}"
+				}
+				"""))
+			.andExpect(status().isCreated())
+			.andExpect(header().exists(HttpHeaders.LOCATION))
+			.andExpect(jsonPath("$.status").value("SAVED"))
+			.andExpect(jsonPath("$.inputSource").value("SHARE"))
+			.andExpect(jsonPath("$.currencyCode").value("KRW"))
+			.andExpect(jsonPath("$.sourceDomain").value("shop.example.com"))
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(response).contains("\"id\"");
+		Integer savedCount = jdbcTemplate.queryForObject(
+			"select count(*) from saved_items where user_id = ? and status = 'SAVED'",
+			Integer.class,
+			userId
+		);
+		Integer metadataCount = jdbcTemplate.queryForObject(
+			"select count(*) from item_source_metadata where source_domain = ? and raw_payload_json ->> 'source' = ?",
+			Integer.class,
+			"shop.example.com",
+			"preview"
+		);
+
+		assertThat(savedCount).isEqualTo(1);
+		assertThat(metadataCount).isEqualTo(1);
+	}
+
+	@Test
+	void blocksDuplicateSavedNormalizedUrlForSameUser() throws Exception {
+		UUID userId = createUser();
+		String request = """
+			{
+				"inputSource": "DIRECT_INPUT",
+				"normalizedUrl": "https://shop.example.com/products/duplicated",
+				"title": "Duplicated item",
+				"category": "ETC"
+			}
+			""";
+
+		mockMvc.perform(post(WISHLIST_ITEMS_PATH)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(request))
+			.andExpect(status().isCreated());
+
+		mockMvc.perform(post(WISHLIST_ITEMS_PATH)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(request))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.code").value("DUPLICATE_SAVED_ITEM"));
+	}
+
+	@Test
+	void listsOnlySavedItemsNewestFirst() throws Exception {
+		UUID userId = createUser();
+		UUID olderSavedId = insertItem(userId, "Older saved", "FASHION", "SAVED", OffsetDateTime.now(ZoneOffset.UTC).minusDays(2));
+		UUID droppedId = insertItem(userId, "Dropped", "FASHION", "DROPPED", OffsetDateTime.now(ZoneOffset.UTC).minusDays(1));
+		UUID newerSavedId = insertItem(userId, "Newer saved", "DIGITAL", "SAVED", OffsetDateTime.now(ZoneOffset.UTC));
+
+		mockMvc.perform(get(WISHLIST_ITEMS_PATH)
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$", hasSize(2)))
+			.andExpect(jsonPath("$[0].id").value(newerSavedId.toString()))
+			.andExpect(jsonPath("$[1].id").value(olderSavedId.toString()));
+
+		mockMvc.perform(get(WISHLIST_ITEMS_PATH)
+				.header(USER_ID_HEADER, userId)
+				.queryParam("category", "FASHION"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$", hasSize(1)))
+			.andExpect(jsonPath("$[0].id").value(olderSavedId.toString()));
+
+		assertThat(droppedId).isNotNull();
+	}
+
+	@Test
+	void updatesCategoryAndLocksItByUser() throws Exception {
+		UUID userId = createUser();
+		UUID itemId = insertItem(userId, "Category update target", "ETC", "SAVED", OffsetDateTime.now(ZoneOffset.UTC));
+
+		mockMvc.perform(patch(WISHLIST_ITEMS_PATH + "/{itemId}/category", itemId)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"category": "LIVING"
+				}
+				"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.category").value("LIVING"))
+			.andExpect(jsonPath("$.categoryLockedByUser").value(true));
+
+		Boolean locked = jdbcTemplate.queryForObject(
+			"select category_locked_by_user from saved_items where id = ?",
+			Boolean.class,
+			itemId
+		);
+		String category = jdbcTemplate.queryForObject("select category from saved_items where id = ?", String.class, itemId);
+
+		assertThat(locked).isTrue();
+		assertThat(category).isEqualTo("LIVING");
+	}
+
+	@Test
+	void deletesByMarkingItemDropped() throws Exception {
+		UUID userId = createUser();
+		UUID itemId = insertItem(userId, "Delete target", "FOOD", "SAVED", OffsetDateTime.now(ZoneOffset.UTC));
+
+		mockMvc.perform(delete(WISHLIST_ITEMS_PATH + "/{itemId}", itemId)
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isNoContent());
+
+		String status = jdbcTemplate.queryForObject("select status from saved_items where id = ?", String.class, itemId);
+		assertThat(status).isEqualTo("DROPPED");
+
+		mockMvc.perform(get(WISHLIST_ITEMS_PATH)
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$", hasSize(0)));
+	}
+
+	private UUID createUser() {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into users (id, status, onboarding_status, created_at, updated_at)
+			values (?, 'ACTIVE', 'NOT_STARTED', ?, ?)
+			""",
+			userId,
+			now,
+			now
+		);
+		return userId;
+	}
+
+	private UUID insertItem(UUID userId, String title, String category, String status, OffsetDateTime createdAt) {
+		UUID itemId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into saved_items (
+				id, user_id, input_source, title, category, category_locked_by_user,
+				status, created_at, updated_at
+			)
+			values (?, ?, 'DIRECT_INPUT', ?, ?, false, ?, ?, ?)
+			""",
+			itemId,
+			userId,
+			title,
+			category,
+			status,
+			createdAt,
+			createdAt
+		);
+		return itemId;
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,3 +5,8 @@ spring:
     hibernate:
       ddl-auto: validate
     open-in-view: false
+
+app:
+  auth:
+    trusted-user-id-header:
+      enabled: true


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-17`
- Jira: https://parkjaehong.atlassian.net/browse/NF-17
- GitHub: Related #12
- GitHub: Closes #12

> PR 제목: `[feat] NF-17 위시 상품 저장 및 조회 API 구현`
> 브랜치: `feat/NF-17-wishlist-save`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #12의 1/1 단계
- 선행 PR: NF-12 도메인·스키마 베이스라인과 리뷰 보완이 `develop`에 반영됨
- 후속 PR: 구매 숙려 화면/결정 API에서 저장된 위시 상품을 사용

### 이 PR에서 변경한 것
- 위시 상품 저장 API를 추가했습니다. (`POST /api/v1/wishlist/items`)
- 위시리스트 목록 조회 API를 추가했습니다. (`GET /api/v1/wishlist/items`)
- 위시 상품 상세 조회 API를 추가했습니다. (`GET /api/v1/wishlist/items/{itemId}`)
- 카테고리 수정 API와 위시 삭제 API를 추가했습니다.
- 위시 삭제는 hard delete가 아니라 `DROPPED` 상태 전환으로 처리했습니다.
- 동일 사용자의 동일 `normalizedUrl` + `SAVED` 상태 중복 저장을 막았습니다.
- `normalizedUrl`이 없는 요청도 `originalUrl`을 서버에서 정규화해 중복 방지 기준으로 사용하도록 보강했습니다.
- 중복 저장 응답에 기존 아이템 정보를 포함해 앱에서 기존 아이템으로 안내할 수 있게 했습니다.
- 활성 사용자이면서 온보딩 완료 상태인 사용자만 위시 기능을 사용할 수 있도록 검증했습니다.

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
- AC1: 위시 상품 저장 시 NF-12 `saved_items`, `item_source_metadata` 스키마에 맞게 데이터를 저장합니다.
- AC2: 위시리스트 목록 조회 시 `SAVED` 상태 상품만 최신순으로 반환하고 카테고리 필터를 지원합니다.
- AC3: 위시 상품 상세 조회 시 구매숙려 화면 진입에 필요한 단일 상품 정보를 반환합니다.
- AC4: 동일 URL 중복 저장을 차단하고 기존 아이템 정보를 반환합니다.
- AC5: 카테고리 수정 시 `category_locked_by_user`를 `true`로 변경합니다.
- AC6: 위시 삭제는 `DROPPED` 상태 전환으로 처리합니다.

### Not covered (후속 작업)
- AC7: 구매 숙려 화면 진입 이후 GO/STOP 결정 처리는 NF-23 Decision API PR에서 처리합니다.
- AC8: NF-8 JWT 인증과의 최종 결합은 인증 PR 머지 후 공통 인증 모듈로 정리합니다.

---

## 🧪 테스트 결과 (필수)
### 로컬
```
./gradlew.bat test
```
- ✅ 결과: 통과

### CI
- Draft PR 상태에서 자동 확인 예정

### Smoke 테스트
- 시나리오: 위시 저장, 중복 저장 차단, 원본 URL 정규화, 목록 조회, 상세 조회, 카테고리 수정, DROPPED 삭제 전환
- 결과: PostgreSQL Testcontainers 통합 테스트로 통과

---

## 🧭 영향 범위 체크 (필수)
- [x] API 변경 (요약: `POST/GET /api/v1/wishlist/items`, `GET /api/v1/wishlist/items/{itemId}`, `PATCH /api/v1/wishlist/items/{itemId}/category`, `DELETE /api/v1/wishlist/items/{itemId}` 추가)
- [ ] DB 변경 (마이그레이션: 없음, NF-12 baseline 스키마 사용)
- [x] 설정 변경 (항목: 테스트 환경에서만 `app.auth.trusted-user-id-header.enabled=true`)
- [ ] Breaking change (무엇: 없음)

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인: `WishlistService`, `WishlistController`, `WishlistExceptionHandler`, `WishlistApiIntegrationTest`
- 트레이드오프/대안: 구매숙려 화면에서 단일 위시 상품을 안정적으로 조회할 수 있도록 상세 조회 API를 추가했습니다. 결정 처리 자체는 NF-23에서 분리해 PR 범위를 유지했습니다.