### PR TITLE
[feat] NF-16 온보딩 저장 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
 	runtimeOnly 'org.flywaydb:flyway-database-postgresql'
 	runtimeOnly 'org.postgresql:postgresql'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/sagongsa/backend/auth/CurrentUserId.java
+++ b/src/main/java/com/sagongsa/backend/auth/CurrentUserId.java
@@ -1,0 +1,11 @@
+package com.sagongsa.backend.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUserId {
+}

--- a/src/main/java/com/sagongsa/backend/auth/CurrentUserIdArgumentResolver.java
+++ b/src/main/java/com/sagongsa/backend/auth/CurrentUserIdArgumentResolver.java
@@ -1,5 +1,6 @@
 package com.sagongsa.backend.auth;
 
+import java.security.Principal;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.MethodParameter;
@@ -39,19 +40,28 @@ class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResolver {
 		NativeWebRequest webRequest,
 		WebDataBinderFactory binderFactory
 	) {
-		if (!trustedHeaderEnabled) {
-			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authenticated user is required.");
+		String rawUserId = webRequest.getHeader(trustedHeaderName);
+		if (trustedHeaderEnabled && StringUtils.hasText(rawUserId)) {
+			return parseUserId(rawUserId, trustedHeaderName + " header");
 		}
 
-		String rawUserId = webRequest.getHeader(trustedHeaderName);
-		if (!StringUtils.hasText(rawUserId)) {
+		Principal principal = webRequest.getUserPrincipal();
+		if (principal != null && StringUtils.hasText(principal.getName())) {
+			return parseUserId(principal.getName(), "authenticated principal");
+		}
+
+		if (trustedHeaderEnabled) {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, trustedHeaderName + " header is required.");
 		}
 
+		throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authenticated user is required.");
+	}
+
+	private UUID parseUserId(String rawUserId, String source) {
 		try {
 			return UUID.fromString(rawUserId.trim());
 		} catch (IllegalArgumentException exception) {
-			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, trustedHeaderName + " header must be a UUID.");
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, source + " must be a UUID.");
 		}
 	}
 }

--- a/src/main/java/com/sagongsa/backend/auth/CurrentUserIdArgumentResolver.java
+++ b/src/main/java/com/sagongsa/backend/auth/CurrentUserIdArgumentResolver.java
@@ -1,0 +1,57 @@
+package com.sagongsa.backend.auth;
+
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.server.ResponseStatusException;
+
+@Component
+class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+	private final boolean trustedHeaderEnabled;
+	private final String trustedHeaderName;
+
+	CurrentUserIdArgumentResolver(
+		@Value("${app.auth.trusted-user-id-header.enabled:false}") boolean trustedHeaderEnabled,
+		@Value("${app.auth.trusted-user-id-header.name:X-User-Id}") String trustedHeaderName
+	) {
+		this.trustedHeaderEnabled = trustedHeaderEnabled;
+		this.trustedHeaderName = trustedHeaderName;
+	}
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(CurrentUserId.class)
+			&& UUID.class.equals(parameter.getParameterType());
+	}
+
+	@Override
+	public Object resolveArgument(
+		MethodParameter parameter,
+		ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest,
+		WebDataBinderFactory binderFactory
+	) {
+		if (!trustedHeaderEnabled) {
+			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authenticated user is required.");
+		}
+
+		String rawUserId = webRequest.getHeader(trustedHeaderName);
+		if (!StringUtils.hasText(rawUserId)) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, trustedHeaderName + " header is required.");
+		}
+
+		try {
+			return UUID.fromString(rawUserId.trim());
+		} catch (IllegalArgumentException exception) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, trustedHeaderName + " header must be a UUID.");
+		}
+	}
+}

--- a/src/main/java/com/sagongsa/backend/auth/CurrentUserWebMvcConfig.java
+++ b/src/main/java/com/sagongsa/backend/auth/CurrentUserWebMvcConfig.java
@@ -1,0 +1,21 @@
+package com.sagongsa.backend.auth;
+
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+class CurrentUserWebMvcConfig implements WebMvcConfigurer {
+
+	private final CurrentUserIdArgumentResolver currentUserIdArgumentResolver;
+
+	CurrentUserWebMvcConfig(CurrentUserIdArgumentResolver currentUserIdArgumentResolver) {
+		this.currentUserIdArgumentResolver = currentUserIdArgumentResolver;
+	}
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(currentUserIdArgumentResolver);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingBadRequestException.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingBadRequestException.java
@@ -1,0 +1,8 @@
+package com.sagongsa.backend.onboarding;
+
+class OnboardingBadRequestException extends RuntimeException {
+
+	OnboardingBadRequestException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingCompleteRequest.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingCompleteRequest.java
@@ -1,0 +1,10 @@
+package com.sagongsa.backend.onboarding;
+
+public record OnboardingCompleteRequest(
+	String nickname,
+	String mascotName,
+	String timezone,
+	Integer monthlyBudgetAmount,
+	String regretFrequencyChoice
+) {
+}

--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingCompleteResponse.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingCompleteResponse.java
@@ -1,0 +1,11 @@
+package com.sagongsa.backend.onboarding;
+
+import java.util.UUID;
+
+public record OnboardingCompleteResponse(
+	UUID userId,
+	String onboardingStatus,
+	String budgetYearMonth,
+	UUID surveyResponseSetId
+) {
+}

--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingConflictException.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingConflictException.java
@@ -1,0 +1,8 @@
+package com.sagongsa.backend.onboarding;
+
+class OnboardingConflictException extends RuntimeException {
+
+	OnboardingConflictException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingController.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingController.java
@@ -1,18 +1,16 @@
 package com.sagongsa.backend.onboarding;
 
+import com.sagongsa.backend.auth.CurrentUserId;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/onboarding")
 public class OnboardingController {
-
-	private static final String USER_ID_HEADER = "X-User-Id";
 
 	private final OnboardingService onboardingService;
 
@@ -22,21 +20,9 @@ public class OnboardingController {
 
 	@PostMapping("/complete")
 	public ResponseEntity<OnboardingCompleteResponse> complete(
-		@RequestHeader(name = USER_ID_HEADER, required = false) String userIdHeader,
+		@CurrentUserId UUID userId,
 		@RequestBody(required = false) OnboardingCompleteRequest request
 	) {
-		return ResponseEntity.ok(onboardingService.complete(parseUserId(userIdHeader), request));
-	}
-
-	private UUID parseUserId(String userIdHeader) {
-		if (userIdHeader == null || userIdHeader.isBlank()) {
-			throw new OnboardingBadRequestException("X-User-Id header is required.");
-		}
-
-		try {
-			return UUID.fromString(userIdHeader.trim());
-		} catch (IllegalArgumentException exception) {
-			throw new OnboardingBadRequestException("X-User-Id header must be a UUID.");
-		}
+		return ResponseEntity.ok(onboardingService.complete(userId, request));
 	}
 }

--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingController.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingController.java
@@ -1,0 +1,42 @@
+package com.sagongsa.backend.onboarding;
+
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/onboarding")
+public class OnboardingController {
+
+	private static final String USER_ID_HEADER = "X-User-Id";
+
+	private final OnboardingService onboardingService;
+
+	public OnboardingController(OnboardingService onboardingService) {
+		this.onboardingService = onboardingService;
+	}
+
+	@PostMapping("/complete")
+	public ResponseEntity<OnboardingCompleteResponse> complete(
+		@RequestHeader(name = USER_ID_HEADER, required = false) String userIdHeader,
+		@RequestBody(required = false) OnboardingCompleteRequest request
+	) {
+		return ResponseEntity.ok(onboardingService.complete(parseUserId(userIdHeader), request));
+	}
+
+	private UUID parseUserId(String userIdHeader) {
+		if (userIdHeader == null || userIdHeader.isBlank()) {
+			throw new OnboardingBadRequestException("X-User-Id header is required.");
+		}
+
+		try {
+			return UUID.fromString(userIdHeader.trim());
+		} catch (IllegalArgumentException exception) {
+			throw new OnboardingBadRequestException("X-User-Id header must be a UUID.");
+		}
+	}
+}

--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingExceptionHandler.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingExceptionHandler.java
@@ -37,6 +37,13 @@ class OnboardingExceptionHandler {
 			.body(new OnboardingErrorResponse("ONBOARDING_CONFLICT", exception.getMessage()));
 	}
 
+	@ExceptionHandler(OnboardingForbiddenException.class)
+	ResponseEntity<OnboardingErrorResponse> handleForbidden(OnboardingForbiddenException exception) {
+		return ResponseEntity
+			.status(HttpStatus.FORBIDDEN)
+			.body(new OnboardingErrorResponse("FORBIDDEN", exception.getMessage()));
+	}
+
 	private record OnboardingErrorResponse(String code, String message) {
 	}
 }

--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingExceptionHandler.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.sagongsa.backend.onboarding;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(assignableTypes = OnboardingController.class)
+class OnboardingExceptionHandler {
+
+	@ExceptionHandler(OnboardingBadRequestException.class)
+	ResponseEntity<OnboardingErrorResponse> handleBadRequest(OnboardingBadRequestException exception) {
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(new OnboardingErrorResponse("BAD_REQUEST", exception.getMessage()));
+	}
+
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	ResponseEntity<OnboardingErrorResponse> handleUnreadableRequest() {
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(new OnboardingErrorResponse("BAD_REQUEST", "Request body is malformed."));
+	}
+
+	@ExceptionHandler(OnboardingNotFoundException.class)
+	ResponseEntity<OnboardingErrorResponse> handleNotFound(OnboardingNotFoundException exception) {
+		return ResponseEntity
+			.status(HttpStatus.NOT_FOUND)
+			.body(new OnboardingErrorResponse("USER_NOT_FOUND", exception.getMessage()));
+	}
+
+	@ExceptionHandler(OnboardingConflictException.class)
+	ResponseEntity<OnboardingErrorResponse> handleConflict(OnboardingConflictException exception) {
+		return ResponseEntity
+			.status(HttpStatus.CONFLICT)
+			.body(new OnboardingErrorResponse("ONBOARDING_CONFLICT", exception.getMessage()));
+	}
+
+	private record OnboardingErrorResponse(String code, String message) {
+	}
+}

--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingForbiddenException.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingForbiddenException.java
@@ -1,0 +1,8 @@
+package com.sagongsa.backend.onboarding;
+
+class OnboardingForbiddenException extends RuntimeException {
+
+	OnboardingForbiddenException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingNotFoundException.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingNotFoundException.java
@@ -1,0 +1,8 @@
+package com.sagongsa.backend.onboarding;
+
+class OnboardingNotFoundException extends RuntimeException {
+
+	OnboardingNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingService.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingService.java
@@ -20,6 +20,7 @@ public class OnboardingService {
 	static final String ONBOARDING_SURVEY_TYPE = "ONBOARDING";
 	static final String REGRET_FREQUENCY_QUESTION_CODE = "RECENT_MONTH_PURCHASE_REGRET_FREQUENCY";
 
+	private static final String ACTIVE_STATUS = "ACTIVE";
 	private static final String COMPLETED_STATUS = "COMPLETED";
 	private static final String DEFAULT_TIMEZONE = "Asia/Seoul";
 	private static final BigDecimal DEFAULT_WARNING_THRESHOLD_RATE = new BigDecimal("80.00");
@@ -38,9 +39,12 @@ public class OnboardingService {
 	@Transactional
 	public OnboardingCompleteResponse complete(UUID userId, OnboardingCompleteRequest request) {
 		NormalizedOnboardingRequest normalizedRequest = normalize(request);
-		String onboardingStatus = findOnboardingStatus(userId);
+		OnboardingUser onboardingUser = findOnboardingUser(userId);
 
-		if (COMPLETED_STATUS.equals(onboardingStatus)) {
+		if (!ACTIVE_STATUS.equals(onboardingUser.status())) {
+			throw new OnboardingForbiddenException("Only active users can complete onboarding.");
+		}
+		if (COMPLETED_STATUS.equals(onboardingUser.onboardingStatus())) {
 			throw new OnboardingConflictException("Onboarding has already been completed.");
 		}
 		if (hasOnboardingSurvey(userId)) {
@@ -64,10 +68,17 @@ public class OnboardingService {
 		}
 
 		int updated = jdbcTemplate.update(
-			"update users set onboarding_status = ?, updated_at = ? where id = ? and onboarding_status <> ?",
+			"""
+			update users
+			set onboarding_status = ?, updated_at = ?
+			where id = ?
+			  and status = ?
+			  and onboarding_status <> ?
+			""",
 			COMPLETED_STATUS,
 			now,
 			userId,
+			ACTIVE_STATUS,
 			COMPLETED_STATUS
 		);
 		if (updated != 1) {
@@ -77,11 +88,14 @@ public class OnboardingService {
 		return new OnboardingCompleteResponse(userId, COMPLETED_STATUS, budgetYearMonth, surveyResponseSetId);
 	}
 
-	private String findOnboardingStatus(UUID userId) {
+	private OnboardingUser findOnboardingUser(UUID userId) {
 		try {
 			return jdbcTemplate.queryForObject(
-				"select onboarding_status from users where id = ?",
-				String.class,
+				"select status, onboarding_status from users where id = ?",
+				(rs, rowNum) -> new OnboardingUser(
+					rs.getString("status"),
+					rs.getString("onboarding_status")
+				),
 				userId
 			);
 		} catch (EmptyResultDataAccessException exception) {
@@ -264,5 +278,8 @@ public class OnboardingService {
 		int monthlyBudgetAmount,
 		String regretFrequencyChoice
 	) {
+	}
+
+	private record OnboardingUser(String status, String onboardingStatus) {
 	}
 }

--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingService.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingService.java
@@ -1,0 +1,268 @@
+package com.sagongsa.backend.onboarding;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.zone.ZoneRulesException;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OnboardingService {
+
+	static final String ONBOARDING_SURVEY_TYPE = "ONBOARDING";
+	static final String REGRET_FREQUENCY_QUESTION_CODE = "RECENT_MONTH_PURCHASE_REGRET_FREQUENCY";
+
+	private static final String COMPLETED_STATUS = "COMPLETED";
+	private static final String DEFAULT_TIMEZONE = "Asia/Seoul";
+	private static final BigDecimal DEFAULT_WARNING_THRESHOLD_RATE = new BigDecimal("80.00");
+	private static final Map<String, Integer> REGRET_FREQUENCY_CHOICES = Map.of(
+		"LESS_THAN_ONCE", 1,
+		"ONE_TO_THREE", 2,
+		"FOUR_OR_MORE", 3
+	);
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public OnboardingService(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Transactional
+	public OnboardingCompleteResponse complete(UUID userId, OnboardingCompleteRequest request) {
+		NormalizedOnboardingRequest normalizedRequest = normalize(request);
+		String onboardingStatus = findOnboardingStatus(userId);
+
+		if (COMPLETED_STATUS.equals(onboardingStatus)) {
+			throw new OnboardingConflictException("Onboarding has already been completed.");
+		}
+		if (hasOnboardingSurvey(userId)) {
+			throw new OnboardingConflictException("Onboarding survey has already been submitted.");
+		}
+
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		String budgetYearMonth = YearMonth.now(normalizedRequest.zoneId()).toString();
+		UUID budgetCycleId = UUID.randomUUID();
+		UUID surveyResponseSetId = UUID.randomUUID();
+		UUID surveyAnswerId = UUID.randomUUID();
+
+		try {
+			insertUserProfile(userId, normalizedRequest, now);
+			insertBudgetCycle(userId, budgetCycleId, normalizedRequest.monthlyBudgetAmount(), budgetYearMonth, now);
+			insertSurveyResponseSet(userId, surveyResponseSetId, now);
+			insertSurveyAnswer(surveyResponseSetId, surveyAnswerId, normalizedRequest.regretFrequencyChoice(), now);
+			insertMascotProfile(userId, now);
+		} catch (DuplicateKeyException exception) {
+			throw new OnboardingConflictException("Onboarding data already exists for this user.");
+		}
+
+		int updated = jdbcTemplate.update(
+			"update users set onboarding_status = ?, updated_at = ? where id = ? and onboarding_status <> ?",
+			COMPLETED_STATUS,
+			now,
+			userId,
+			COMPLETED_STATUS
+		);
+		if (updated != 1) {
+			throw new OnboardingConflictException("Onboarding has already been completed.");
+		}
+
+		return new OnboardingCompleteResponse(userId, COMPLETED_STATUS, budgetYearMonth, surveyResponseSetId);
+	}
+
+	private String findOnboardingStatus(UUID userId) {
+		try {
+			return jdbcTemplate.queryForObject(
+				"select onboarding_status from users where id = ?",
+				String.class,
+				userId
+			);
+		} catch (EmptyResultDataAccessException exception) {
+			throw new OnboardingNotFoundException("User was not found.");
+		}
+	}
+
+	private boolean hasOnboardingSurvey(UUID userId) {
+		Boolean exists = jdbcTemplate.queryForObject(
+			"select exists (select 1 from survey_response_sets where user_id = ? and survey_type = ?)",
+			Boolean.class,
+			userId,
+			ONBOARDING_SURVEY_TYPE
+		);
+		return Boolean.TRUE.equals(exists);
+	}
+
+	private void insertUserProfile(UUID userId, NormalizedOnboardingRequest request, OffsetDateTime now) {
+		jdbcTemplate.update(
+			"""
+				insert into user_profiles (
+					user_id, nickname, mascot_name, timezone, profile_image_url, created_at, updated_at
+				)
+				values (?, ?, ?, ?, null, ?, ?)
+				""",
+			userId,
+			request.nickname(),
+			request.mascotName(),
+			request.timezone(),
+			now,
+			now
+		);
+	}
+
+	private void insertBudgetCycle(UUID userId, UUID budgetCycleId, int monthlyBudgetAmount, String budgetYearMonth, OffsetDateTime now) {
+		jdbcTemplate.update(
+			"""
+				insert into budget_cycles (
+					id, user_id, year_month, monthly_budget_amount, spent_amount, warning_threshold_rate, created_at, updated_at
+				)
+				values (?, ?, ?, ?, 0, ?, ?, ?)
+				""",
+			budgetCycleId,
+			userId,
+			budgetYearMonth,
+			monthlyBudgetAmount,
+			DEFAULT_WARNING_THRESHOLD_RATE,
+			now,
+			now
+		);
+	}
+
+	private void insertSurveyResponseSet(UUID userId, UUID surveyResponseSetId, OffsetDateTime now) {
+		jdbcTemplate.update(
+			"""
+				insert into survey_response_sets (
+					id, user_id, survey_type, submitted_at, created_at, updated_at
+				)
+				values (?, ?, ?, ?, ?, ?)
+				""",
+			surveyResponseSetId,
+			userId,
+			ONBOARDING_SURVEY_TYPE,
+			now,
+			now,
+			now
+		);
+	}
+
+	private void insertSurveyAnswer(UUID surveyResponseSetId, UUID surveyAnswerId, String regretFrequencyChoice, OffsetDateTime now) {
+		jdbcTemplate.update(
+			"""
+				insert into survey_answers (
+					id, response_set_id, question_code, answer_text, answer_number, answer_choice, created_at, updated_at
+				)
+				values (?, ?, ?, null, ?, ?, ?, ?)
+				""",
+			surveyAnswerId,
+			surveyResponseSetId,
+			REGRET_FREQUENCY_QUESTION_CODE,
+			REGRET_FREQUENCY_CHOICES.get(regretFrequencyChoice),
+			regretFrequencyChoice,
+			now,
+			now
+		);
+	}
+
+	private void insertMascotProfile(UUID userId, OffsetDateTime now) {
+		jdbcTemplate.update(
+			"""
+				insert into mascot_profiles (
+					user_id, mascot_state, last_reaction_message, last_state_changed_at, reaction_expires_at, updated_at
+				)
+				values (?, 'DEFAULT', null, ?, null, ?)
+				""",
+			userId,
+			now,
+			now
+		);
+	}
+
+	private NormalizedOnboardingRequest normalize(OnboardingCompleteRequest request) {
+		if (request == null) {
+			throw new OnboardingBadRequestException("Request body is required.");
+		}
+
+		String nickname = requireText(request.nickname(), "nickname", 40);
+		String mascotName = requireText(request.mascotName(), "mascotName", 40);
+		String timezone = normalizeTimezone(request.timezone());
+		int monthlyBudgetAmount = normalizeMonthlyBudgetAmount(request.monthlyBudgetAmount());
+		String regretFrequencyChoice = normalizeRegretFrequencyChoice(request.regretFrequencyChoice());
+
+		return new NormalizedOnboardingRequest(
+			nickname,
+			mascotName,
+			timezone,
+			ZoneId.of(timezone),
+			monthlyBudgetAmount,
+			regretFrequencyChoice
+		);
+	}
+
+	private String requireText(String value, String fieldName, int maxLength) {
+		if (value == null || value.isBlank()) {
+			throw new OnboardingBadRequestException(fieldName + " is required.");
+		}
+
+		String trimmed = value.trim();
+		if (trimmed.length() > maxLength) {
+			throw new OnboardingBadRequestException(fieldName + " must be " + maxLength + " characters or less.");
+		}
+		return trimmed;
+	}
+
+	private String normalizeTimezone(String timezone) {
+		if (timezone == null) {
+			return DEFAULT_TIMEZONE;
+		}
+		if (timezone.isBlank()) {
+			throw new OnboardingBadRequestException("timezone must not be blank.");
+		}
+
+		String trimmed = timezone.trim();
+		if (trimmed.length() > 40) {
+			throw new OnboardingBadRequestException("timezone must be 40 characters or less.");
+		}
+		try {
+			ZoneId.of(trimmed);
+		} catch (ZoneRulesException exception) {
+			throw new OnboardingBadRequestException("timezone must be a valid time zone ID.");
+		}
+		return trimmed;
+	}
+
+	private int normalizeMonthlyBudgetAmount(Integer monthlyBudgetAmount) {
+		if (monthlyBudgetAmount == null) {
+			throw new OnboardingBadRequestException("monthlyBudgetAmount is required.");
+		}
+		if (monthlyBudgetAmount < 0) {
+			throw new OnboardingBadRequestException("monthlyBudgetAmount must be zero or greater.");
+		}
+		return monthlyBudgetAmount;
+	}
+
+	private String normalizeRegretFrequencyChoice(String regretFrequencyChoice) {
+		String normalized = requireText(regretFrequencyChoice, "regretFrequencyChoice", 80);
+		if (!REGRET_FREQUENCY_CHOICES.containsKey(normalized)) {
+			throw new OnboardingBadRequestException(
+				"regretFrequencyChoice must be one of LESS_THAN_ONCE, ONE_TO_THREE, FOUR_OR_MORE."
+			);
+		}
+		return normalized;
+	}
+
+	private record NormalizedOnboardingRequest(
+		String nickname,
+		String mascotName,
+		String timezone,
+		ZoneId zoneId,
+		int monthlyBudgetAmount,
+		String regretFrequencyChoice
+	) {
+	}
+}

--- a/src/test/java/com/sagongsa/backend/onboarding/OnboardingCompleteIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/onboarding/OnboardingCompleteIntegrationTest.java
@@ -96,7 +96,27 @@ class OnboardingCompleteIntegrationTest extends PostgreSqlContainerTest {
 		assertThat(queryString("select onboarding_status from users where id = ?", userId)).isEqualTo("COMPLETED");
 	}
 
+	@Test
+	void completeBlocksSuspendedUser() throws Exception {
+		UUID userId = insertUser("ACTIVE", "NOT_STARTED");
+
+		jdbcTemplate.update("update users set status = 'SUSPENDED' where id = ?", userId);
+
+		mockMvc.perform(post("/api/v1/onboarding/complete")
+				.header("X-User-Id", userId.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(onboardingRequestBody()))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("FORBIDDEN"));
+
+		assertThat(countRows("user_profiles", userId)).isZero();
+	}
+
 	private UUID insertUser(String onboardingStatus) {
+		return insertUser("ACTIVE", onboardingStatus);
+	}
+
+	private UUID insertUser(String status, String onboardingStatus) {
 		UUID userId = UUID.randomUUID();
 		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
 		jdbcTemplate.update(
@@ -104,9 +124,10 @@ class OnboardingCompleteIntegrationTest extends PostgreSqlContainerTest {
 				insert into users (
 					id, status, onboarding_status, created_at, updated_at, withdrawn_at
 				)
-				values (?, 'ACTIVE', ?, ?, ?, null)
+				values (?, ?, ?, ?, ?, null)
 				""",
 			userId,
+			status,
 			onboardingStatus,
 			now,
 			now

--- a/src/test/java/com/sagongsa/backend/onboarding/OnboardingCompleteIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/onboarding/OnboardingCompleteIntegrationTest.java
@@ -1,0 +1,195 @@
+package com.sagongsa.backend.onboarding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class OnboardingCompleteIntegrationTest extends PostgreSqlContainerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Test
+	void completePersistsOnboardingData() throws Exception {
+		UUID userId = insertUser("NOT_STARTED");
+		String expectedYearMonth = YearMonth.now(ZoneId.of("Asia/Seoul")).toString();
+
+		mockMvc.perform(post("/api/v1/onboarding/complete")
+				.header("X-User-Id", userId.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(onboardingRequestBody()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.userId").value(userId.toString()))
+			.andExpect(jsonPath("$.onboardingStatus").value("COMPLETED"))
+			.andExpect(jsonPath("$.budgetYearMonth").value(expectedYearMonth));
+
+		assertThat(countRows("user_profiles", userId)).isEqualTo(1);
+		assertThat(countRows("budget_cycles", userId)).isEqualTo(1);
+		assertThat(countRows("survey_response_sets", userId)).isEqualTo(1);
+		assertThat(countRows("mascot_profiles", userId)).isEqualTo(1);
+
+		assertThat(queryString("select nickname from user_profiles where user_id = ?", userId)).isEqualTo("planner");
+		assertThat(queryString("select mascot_name from user_profiles where user_id = ?", userId)).isEqualTo("wigul");
+		assertThat(queryString("select timezone from user_profiles where user_id = ?", userId)).isEqualTo("Asia/Seoul");
+		assertThat(queryString("select year_month from budget_cycles where user_id = ?", userId)).isEqualTo(expectedYearMonth);
+		assertThat(queryInteger("select monthly_budget_amount from budget_cycles where user_id = ?", userId)).isEqualTo(300000);
+		assertThat(queryInteger("select spent_amount from budget_cycles where user_id = ?", userId)).isZero();
+		assertThat(queryBigDecimal("select warning_threshold_rate from budget_cycles where user_id = ?", userId))
+			.isEqualByComparingTo("80.00");
+		assertThat(queryString("select mascot_state from mascot_profiles where user_id = ?", userId)).isEqualTo("DEFAULT");
+		assertThat(queryOnboardingSurveyAnswer(userId)).isEqualTo("FOUR_OR_MORE");
+		assertThat(queryOnboardingSurveyAnswerNumber(userId)).isEqualTo(3);
+	}
+
+	@Test
+	void completeBlocksDuplicateSubmit() throws Exception {
+		UUID userId = insertUser("NOT_STARTED");
+
+		mockMvc.perform(post("/api/v1/onboarding/complete")
+				.header("X-User-Id", userId.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(onboardingRequestBody()))
+			.andExpect(status().isOk());
+
+		mockMvc.perform(post("/api/v1/onboarding/complete")
+				.header("X-User-Id", userId.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(onboardingRequestBody()))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.code").value("ONBOARDING_CONFLICT"));
+
+		assertThat(countRows("survey_response_sets", userId)).isEqualTo(1);
+		assertThat(countRows("survey_answers", userId)).isEqualTo(1);
+	}
+
+	@Test
+	void completeUpdatesUserStatus() throws Exception {
+		UUID userId = insertUser("IN_PROGRESS");
+
+		mockMvc.perform(post("/api/v1/onboarding/complete")
+				.header("X-User-Id", userId.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(onboardingRequestBody()))
+			.andExpect(status().isOk());
+
+		assertThat(queryString("select onboarding_status from users where id = ?", userId)).isEqualTo("COMPLETED");
+	}
+
+	private UUID insertUser(String onboardingStatus) {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+				insert into users (
+					id, status, onboarding_status, created_at, updated_at, withdrawn_at
+				)
+				values (?, 'ACTIVE', ?, ?, ?, null)
+				""",
+			userId,
+			onboardingStatus,
+			now,
+			now
+		);
+		return userId;
+	}
+
+	private String onboardingRequestBody() {
+		return """
+			{
+				"nickname": "planner",
+				"mascotName": "wigul",
+				"timezone": "Asia/Seoul",
+				"monthlyBudgetAmount": 300000,
+				"regretFrequencyChoice": "FOUR_OR_MORE"
+			}
+			""";
+	}
+
+	private Integer countRows(String tableName, UUID userId) {
+		String userIdColumn = "survey_answers".equals(tableName) ? "s.user_id" : "user_id";
+		if ("survey_answers".equals(tableName)) {
+			return jdbcTemplate.queryForObject(
+				"""
+					select count(*)
+					from survey_answers a
+					join survey_response_sets s on s.id = a.response_set_id
+					where s.user_id = ?
+					""",
+				Integer.class,
+				userId
+			);
+		}
+		return jdbcTemplate.queryForObject(
+			"select count(*) from " + tableName + " where " + userIdColumn + " = ?",
+			Integer.class,
+			userId
+		);
+	}
+
+	private String queryOnboardingSurveyAnswer(UUID userId) {
+		return jdbcTemplate.queryForObject(
+			"""
+				select a.answer_choice
+				from survey_answers a
+				join survey_response_sets s on s.id = a.response_set_id
+				where s.user_id = ?
+				  and s.survey_type = ?
+				  and a.question_code = ?
+				""",
+			String.class,
+			userId,
+			OnboardingService.ONBOARDING_SURVEY_TYPE,
+			OnboardingService.REGRET_FREQUENCY_QUESTION_CODE
+		);
+	}
+
+	private Integer queryOnboardingSurveyAnswerNumber(UUID userId) {
+		return jdbcTemplate.queryForObject(
+			"""
+				select a.answer_number
+				from survey_answers a
+				join survey_response_sets s on s.id = a.response_set_id
+				where s.user_id = ?
+				  and s.survey_type = ?
+				  and a.question_code = ?
+				""",
+			Integer.class,
+			userId,
+			OnboardingService.ONBOARDING_SURVEY_TYPE,
+			OnboardingService.REGRET_FREQUENCY_QUESTION_CODE
+		);
+	}
+
+	private String queryString(String sql, UUID userId) {
+		return jdbcTemplate.queryForObject(sql, String.class, userId);
+	}
+
+	private Integer queryInteger(String sql, UUID userId) {
+		return jdbcTemplate.queryForObject(sql, Integer.class, userId);
+	}
+
+	private BigDecimal queryBigDecimal(String sql, UUID userId) {
+		return jdbcTemplate.queryForObject(sql, BigDecimal.class, userId);
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,3 +5,8 @@ spring:
     hibernate:
       ddl-auto: validate
     open-in-view: false
+
+app:
+  auth:
+    trusted-user-id-header:
+      enabled: true


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-16`
- Jira: https://parkjaehong.atlassian.net/browse/NF-16
- GitHub: Related #11
- GitHub: Closes #11

> PR 제목: `[feat] NF-16 온보딩 저장 API 구현`
> 브랜치: `feat/NF-16-onboarding-backend`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #11의 1/1 단계
- 선행 PR: NF-12 도메인·스키마 베이스라인과 리뷰 보완이 `develop`에 반영됨
- 후속 PR: #14 / NF-17 위시 저장 API, #16 / NF-18 홈 요약 API

### 이 PR에서 변경한 것
- 온보딩 완료 API를 추가했습니다. (`POST /api/v1/onboarding/complete`)
- 유저 프로필, 현재 월 예산, 온보딩 설문 응답, 마스코트 기본 상태를 한 번에 저장합니다.
- 온보딩 완료 시 `users.onboarding_status`를 `COMPLETED`로 갱신합니다.
- PRD 기준 설문 선택지 3단계(`LESS_THAN_ONCE`, `ONE_TO_THREE`, `FOUR_OR_MORE`)만 허용합니다.
- 이미 완료된 온보딩/중복 설문 저장을 방지합니다.
- 활성 사용자만 온보딩 완료 처리를 할 수 있도록 사용자 상태 검증을 추가했습니다.
- NF-8 인증 머지 전까지 테스트에서만 사용할 임시 `CurrentUserId` resolver를 분리했습니다.

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
- AC1: 닉네임, 너굴 이름, 타임존, 월 예산, 후회 빈도 설문을 온보딩 완료 시 저장합니다.
- AC2: 현재 달(`YYYY-MM`) 기준 예산 사이클을 생성합니다.
- AC3: 온보딩 설문은 최초 1회만 저장되고 중복 제출을 차단합니다.
- AC4: 온보딩 완료 후 사용자 상태를 `COMPLETED`로 전환합니다.
- AC5: 활성 사용자만 온보딩을 완료할 수 있습니다.

### Not covered (후속 작업)
- AC6: 소셜 로그인 성공 직후 온보딩 진입 라우팅은 #10 / NF-8과 앱 연동에서 처리합니다.
- AC7: 온보딩 단계별 중간 저장은 MVP 범위 밖이며, 현재 PR은 최종 완료 저장 API만 제공합니다.

---

## 🧪 테스트 결과 (필수)
### 로컬
```
./gradlew.bat test
```
- ✅ 결과: 통과

### CI
- Draft PR 상태에서 자동 확인 예정

### Smoke 테스트
- 시나리오: 온보딩 완료 저장, 중복 제출 차단, `IN_PROGRESS` 사용자 완료 전환, 정지 사용자 차단
- 결과: PostgreSQL Testcontainers 통합 테스트로 통과

---

## 🧭 영향 범위 체크 (필수)
- [x] API 변경 (요약: `POST /api/v1/onboarding/complete` 추가)
- [ ] DB 변경 (마이그레이션: 없음, NF-12 baseline 스키마 사용)
- [x] 설정 변경 (항목: 테스트 환경에서만 `app.auth.trusted-user-id-header.enabled=true`)
- [ ] Breaking change (무엇: 없음)

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인: `OnboardingService`, `OnboardingController`, `OnboardingCompleteIntegrationTest`
- 트레이드오프/대안: MVP 요구사항에 맞춰 단계별 저장이 아니라 최종 제출 시 한 번에 저장하는 API로 구현했습니다.

