### PR TITLE
[fix] NF-12 스키마 리뷰 보완

### DIFF
--- a/docs/DOMAIN_SCHEMA_REVISED_FROM_PLANNING_2026_04_16.md
+++ b/docs/DOMAIN_SCHEMA_REVISED_FROM_PLANNING_2026_04_16.md
@@ -288,6 +288,8 @@
 - 소비기록의 `"변경됨"` 배지를 위해 `is_changed`, `change_count`, `changed_at`을 추가합니다.
 - 기획에서 "합리성 점수"보다 "합리성 판별 결과"가 적절하다고 정리했으므로 `rationality_result`, `self_check_yes_count`를 추가합니다.
 - 예산현황, 지난 카테고리 이력, 기회비용은 합리성 판별에 영향을 주지 않습니다. 따라서 합리성 관련 값은 셀프체크 Yes 개수 기준으로만 저장합니다.
+- `rationality_result`, `self_check_yes_count`는 `self_check_response_sets`에도 있으므로 중복처럼 보일 수 있습니다. 다만 `purchase_decisions`는 마이페이지 소비기록, 홈 요약, NSM 집계에서 최종 결정 기준으로 바로 조회되는 테이블이므로 최종 판별값을 함께 보관합니다.
+- 두 테이블 간 값이 어긋나지 않도록 PostgreSQL 검증 트리거로 `purchase_decisions`와 `self_check_response_sets`의 Yes 개수/판별 결과 정합성을 DB 레벨에서 방어합니다.
 - 금액 스냅샷과 변경 횟수는 음수가 될 수 없으므로 DB 제약으로 방어합니다.
 
 ### purchase_decision_change_logs
@@ -341,6 +343,7 @@
 - 기획상 최종 결정 직전 마지막 셀프체크 결과만 대표값으로 사용합니다.
 - 내부 이력까지 남기는 경우에는 위 `purchase_decision_change_logs`에 변경 전후 판별 결과를 스냅샷으로 저장합니다.
 - Yes 0~1개는 `RATIONAL`, Yes 2개 이상은 `IRRATIONAL`로 계산합니다.
+- `purchase_decisions`에 저장된 최종 판별값과 이 테이블의 제출 결과가 다르면 DB 검증 트리거가 INSERT/UPDATE를 차단합니다.
 
 ### self_check_answers
 
@@ -588,6 +591,7 @@
 - 기획에서 게시글 삭제는 가능하지만 soft delete 적용을 요청했습니다.
 - 운영/신고 기능이 MVP 밖이어도 추후 검토와 복구 가능성을 위해 `deleted_at`만 기록합니다.
 - 투표 수는 음수가 될 수 없으므로 DB 제약으로 방어합니다.
+- `go_count`, `stop_count`는 피드 목록 조회를 빠르게 하기 위해 `feed_posts`에 함께 둡니다. 값이 `post_votes`와 어긋나지 않도록 PostgreSQL trigger가 활성 투표 기준으로 INSERT/UPDATE/DELETE 시 자동 동기화합니다.
 
 ### post_votes
 
@@ -603,14 +607,16 @@
 
 인덱스:
 
-- unique (`post_id`, `user_id`)
+- unique index (`post_id`, `user_id`) where `canceled_at is null`
 - index (`post_id`, `vote_type`) where `canceled_at is null`
 
 변경 이유:
 
 - 로그인 사용자만 투표 가능하므로 `user_id`가 필수입니다.
-- `unique(post_id, user_id)`는 중복 투표 방지와 투표 변경을 모두 지원합니다.
-- 투표 취소를 지원하려면 row를 삭제하지 않고 `canceled_at`을 채우면 됩니다.
+- 활성 투표는 한 게시글당 유저 1개만 허용합니다.
+- 투표 취소를 지원하려면 row를 삭제하지 않고 `canceled_at`을 채웁니다.
+- 일반 `unique(post_id, user_id)`를 쓰면 취소된 row 때문에 재투표가 막히므로, 활성 투표에만 적용되는 partial unique index를 사용합니다.
+- 투표 변경은 기존 활성 row의 `vote_type`을 업데이트하는 방식으로 처리합니다.
 - 만약 투표 취소를 MVP에서 제외한다면 `canceled_at`은 제거해도 됩니다.
 
 ### post_comments

--- a/src/main/java/com/sagongsa/backend/domain/decision/PurchaseDecision.java
+++ b/src/main/java/com/sagongsa/backend/domain/decision/PurchaseDecision.java
@@ -1,8 +1,7 @@
 package com.sagongsa.backend.domain.decision;
 
-import com.sagongsa.backend.domain.auth.UserAccount;
 import com.sagongsa.backend.domain.budget.BudgetCycle;
-import com.sagongsa.backend.domain.common.BaseEntity;
+import com.sagongsa.backend.domain.common.UserScopedEntity;
 import com.sagongsa.backend.domain.enums.PurchaseDecisionResult;
 import com.sagongsa.backend.domain.enums.RationalityResult;
 import com.sagongsa.backend.domain.item.SavedItem;
@@ -29,11 +28,7 @@ import java.time.Instant;
 		@UniqueConstraint(name = "uk_purchase_decisions_item_id", columnNames = "item_id")
 	}
 )
-public class PurchaseDecision extends BaseEntity {
-
-	@ManyToOne(fetch = FetchType.LAZY, optional = false)
-	@JoinColumn(name = "user_id", nullable = false)
-	private UserAccount user;
+public class PurchaseDecision extends UserScopedEntity {
 
 	@OneToOne(fetch = FetchType.LAZY, optional = false)
 	@JoinColumn(name = "item_id", nullable = false)

--- a/src/main/java/com/sagongsa/backend/domain/social/PostVote.java
+++ b/src/main/java/com/sagongsa/backend/domain/social/PostVote.java
@@ -12,7 +12,6 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 
 @Entity
@@ -20,9 +19,6 @@ import java.time.Instant;
 	name = "post_votes",
 	indexes = {
 		@Index(name = "idx_post_votes_post_type_active", columnList = "post_id,vote_type")
-	},
-	uniqueConstraints = {
-		@UniqueConstraint(name = "uk_post_votes_post_user", columnNames = {"post_id", "user_id"})
 	}
 )
 public class PostVote extends BaseEntity {

--- a/src/main/resources/db/migration/V2__domain_schema_review_hardening.sql
+++ b/src/main/resources/db/migration/V2__domain_schema_review_hardening.sql
@@ -1,0 +1,146 @@
+comment on constraint uk_social_accounts_user_id on social_accounts is
+    'MVP policy: a user can link exactly one social login provider. Relax this constraint when multi-provider linking is introduced.';
+
+create or replace function assert_self_check_matches_decision()
+returns trigger
+language plpgsql
+as $$
+declare
+    decision_self_check_yes_count smallint;
+    decision_rationality_result varchar(20);
+begin
+    select self_check_yes_count, rationality_result
+      into decision_self_check_yes_count, decision_rationality_result
+      from purchase_decisions
+     where id = new.decision_id;
+
+    if decision_self_check_yes_count is distinct from new.yes_count
+        or decision_rationality_result is distinct from new.rationality_result then
+        raise exception 'self_check_response_sets must match purchase_decisions rationality fields'
+            using errcode = '23514';
+    end if;
+
+    return new;
+end;
+$$;
+
+create or replace function assert_decision_matches_self_check()
+returns trigger
+language plpgsql
+as $$
+declare
+    self_check_yes_count smallint;
+    self_check_rationality_result varchar(20);
+begin
+    select yes_count, rationality_result
+      into self_check_yes_count, self_check_rationality_result
+      from self_check_response_sets
+     where decision_id = new.id;
+
+    if found and (
+        self_check_yes_count is distinct from new.self_check_yes_count
+        or self_check_rationality_result is distinct from new.rationality_result
+    ) then
+        raise exception 'purchase_decisions rationality fields must match self_check_response_sets'
+            using errcode = '23514';
+    end if;
+
+    return new;
+end;
+$$;
+
+do $$
+begin
+    if exists (
+        select 1
+          from self_check_response_sets sc
+          join purchase_decisions pd on pd.id = sc.decision_id
+         where sc.yes_count is distinct from pd.self_check_yes_count
+            or sc.rationality_result is distinct from pd.rationality_result
+    ) then
+        raise exception 'existing self_check_response_sets and purchase_decisions rationality fields do not match'
+            using errcode = '23514';
+    end if;
+end;
+$$;
+
+create constraint trigger trg_self_check_matches_decision
+after insert or update on self_check_response_sets
+deferrable initially deferred
+for each row execute function assert_self_check_matches_decision();
+
+create constraint trigger trg_decision_matches_self_check
+after update on purchase_decisions
+deferrable initially deferred
+for each row execute function assert_decision_matches_self_check();
+
+alter table post_votes drop constraint if exists uk_post_votes_post_user;
+
+create unique index uk_post_votes_post_user_active on post_votes(post_id, user_id) where canceled_at is null;
+
+update feed_posts fp
+   set go_count = vote_counts.go_count,
+       stop_count = vote_counts.stop_count,
+       updated_at = now()
+  from (
+        select fp_inner.id as post_id,
+               count(pv.id) filter (where pv.vote_type = 'GO' and pv.canceled_at is null)::integer as go_count,
+               count(pv.id) filter (where pv.vote_type = 'STOP' and pv.canceled_at is null)::integer as stop_count
+          from feed_posts fp_inner
+          left join post_votes pv on pv.post_id = fp_inner.id
+         group by fp_inner.id
+       ) vote_counts
+ where fp.id = vote_counts.post_id;
+
+create or replace function sync_feed_post_vote_counts()
+returns trigger
+language plpgsql
+as $$
+begin
+    if tg_op = 'INSERT' then
+        if new.canceled_at is null then
+            update feed_posts
+               set go_count = go_count + case when new.vote_type = 'GO' then 1 else 0 end,
+                   stop_count = stop_count + case when new.vote_type = 'STOP' then 1 else 0 end,
+                   updated_at = now()
+             where id = new.post_id;
+        end if;
+        return new;
+    elsif tg_op = 'UPDATE' then
+        if old.canceled_at is null then
+            update feed_posts
+               set go_count = go_count - case when old.vote_type = 'GO' then 1 else 0 end,
+                   stop_count = stop_count - case when old.vote_type = 'STOP' then 1 else 0 end,
+                   updated_at = now()
+             where id = old.post_id;
+        end if;
+
+        if new.canceled_at is null then
+            update feed_posts
+               set go_count = go_count + case when new.vote_type = 'GO' then 1 else 0 end,
+                   stop_count = stop_count + case when new.vote_type = 'STOP' then 1 else 0 end,
+                   updated_at = now()
+             where id = new.post_id;
+        end if;
+        return new;
+    elsif tg_op = 'DELETE' then
+        if old.canceled_at is null then
+            update feed_posts
+               set go_count = go_count - case when old.vote_type = 'GO' then 1 else 0 end,
+                   stop_count = stop_count - case when old.vote_type = 'STOP' then 1 else 0 end,
+                   updated_at = now()
+             where id = old.post_id;
+        end if;
+        return old;
+    end if;
+
+    return null;
+end;
+$$;
+
+create trigger trg_post_votes_sync_feed_counts
+after insert or update or delete on post_votes
+for each row execute function sync_feed_post_vote_counts();
+
+comment on table share_tokens is
+    'MVP policy: one non-expiring share token is issued per feed post. Add expires_at/revoked_at when abuse handling requires it.';

--- a/src/test/java/com/sagongsa/backend/domain/DomainSchemaSmokeTest.java
+++ b/src/test/java/com/sagongsa/backend/domain/DomainSchemaSmokeTest.java
@@ -1,14 +1,17 @@
 package com.sagongsa.backend.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.sagongsa.backend.support.PostgreSqlContainerTest;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 @SpringBootTest
@@ -118,8 +121,15 @@ class DomainSchemaSmokeTest extends PostgreSqlContainerTest {
 
 		assertPartialIndex("uk_saved_items_user_saved_url", "normalized_url is not null", "'saved'");
 		assertPartialIndex("idx_feed_posts_visible_created", "deleted_at is null");
+		assertNoConstraint("post_votes", "uk_post_votes_post_user");
+		assertPartialIndex("uk_post_votes_post_user_active", "canceled_at is null");
 		assertPartialIndex("idx_post_votes_post_type_active", "canceled_at is null");
 		assertPartialIndex("idx_post_comments_post_created_visible", "deleted_at is null");
+		assertTrigger("trg_post_votes_sync_feed_counts", "post_votes");
+		assertTrigger("trg_self_check_matches_decision", "self_check_response_sets");
+		assertTrigger("trg_decision_matches_self_check", "purchase_decisions");
+		assertConstraintComment("social_accounts", "uk_social_accounts_user_id", "MVP policy");
+		assertTableComment("share_tokens", "MVP policy");
 	}
 
 	@Test
@@ -267,6 +277,71 @@ class DomainSchemaSmokeTest extends PostgreSqlContainerTest {
 		assertConstraint("feed_posts", "chk_feed_posts_vote_counts", "go_count", "stop_count", ">= 0");
 	}
 
+	@Test
+	void rejectsInvalidCheckConstraintValues() {
+		UUID userId = insertUser();
+		UUID itemId = insertSavedItem(userId, "https://shop.example/check-violation");
+
+		assertThatThrownBy(() -> insertPurchaseDecision(userId, itemId, (short) 5, "IRRATIONAL"))
+			.isInstanceOf(DataIntegrityViolationException.class);
+		assertThatThrownBy(() -> insertPurchaseDecision(userId, itemId, (short) 1, "IRRATIONAL"))
+			.isInstanceOf(DataIntegrityViolationException.class);
+	}
+
+	@Test
+	void rejectsRationalityMismatchBetweenDecisionAndSelfCheckSet() {
+		UUID userId = insertUser();
+		UUID itemId = insertSavedItem(userId, "https://shop.example/rationality-mismatch");
+		UUID decisionId = insertPurchaseDecision(userId, itemId, (short) 1, "RATIONAL");
+
+		assertThatThrownBy(
+			() -> insertSelfCheckResponseSet(decisionId, (short) 2, "IRRATIONAL")
+		).isInstanceOf(DataIntegrityViolationException.class);
+
+		insertSelfCheckResponseSet(decisionId, (short) 1, "RATIONAL");
+
+		assertThatThrownBy(() ->
+			jdbcTemplate.update(
+				"""
+				update purchase_decisions
+				set self_check_yes_count = 2,
+				    rationality_result = 'IRRATIONAL',
+				    updated_at = now()
+				where id = ?
+				""",
+				decisionId
+			)
+		).isInstanceOf(DataIntegrityViolationException.class);
+	}
+
+	@Test
+	void allowsRevoteAfterCancelAndKeepsVoteCountsInSync() {
+		UUID postOwnerId = insertUser();
+		UUID voterId = insertUser();
+		UUID postId = insertFeedPost(postOwnerId);
+
+		UUID firstVoteId = insertPostVote(postId, voterId, "GO");
+		assertVoteCounts(postId, 1, 0);
+
+		assertThatThrownBy(() -> insertPostVote(postId, voterId, "STOP"))
+			.isInstanceOf(DataIntegrityViolationException.class);
+
+		jdbcTemplate.update(
+			"update post_votes set canceled_at = now(), updated_at = now() where id = ?",
+			firstVoteId
+		);
+		assertVoteCounts(postId, 0, 0);
+
+		UUID secondVoteId = insertPostVote(postId, voterId, "STOP");
+		assertVoteCounts(postId, 0, 1);
+
+		jdbcTemplate.update(
+			"update post_votes set vote_type = 'GO', updated_at = now() where id = ?",
+			secondVoteId
+		);
+		assertVoteCounts(postId, 1, 0);
+	}
+
 	private void assertColumns(String table, String... expectedColumns) {
 		Set<String> actualColumns = jdbcTemplate.queryForList(
 				"select lower(column_name) from information_schema.columns where lower(table_name) = ?",
@@ -290,6 +365,61 @@ class DomainSchemaSmokeTest extends PostgreSqlContainerTest {
 		assertThat(indexDefinition).contains(expectedPredicates);
 	}
 
+	private void assertTrigger(String triggerName, String tableName) {
+		Integer count = jdbcTemplate.queryForObject(
+			"""
+			select count(*)
+			from pg_trigger trg
+			join pg_class tbl on tbl.oid = trg.tgrelid
+			join pg_namespace n on n.oid = tbl.relnamespace
+			where n.nspname = current_schema()
+			  and lower(trg.tgname) = ?
+			  and lower(tbl.relname) = ?
+			  and not trg.tgisinternal
+			""",
+			Integer.class,
+			triggerName,
+			tableName
+		);
+
+		assertThat(count).isNotNull().isGreaterThan(0);
+	}
+
+	private void assertConstraintComment(String tableName, String constraintName, String expectedFragment) {
+		String comment = jdbcTemplate.queryForObject(
+			"""
+			select obj_description(c.oid, 'pg_constraint')
+			from pg_constraint c
+			join pg_class t on t.oid = c.conrelid
+			join pg_namespace n on n.oid = c.connamespace
+			where n.nspname = current_schema()
+			  and t.relname = ?
+			  and c.conname = ?
+			""",
+			String.class,
+			tableName,
+			constraintName
+		);
+
+		assertThat(comment).contains(expectedFragment);
+	}
+
+	private void assertTableComment(String tableName, String expectedFragment) {
+		String comment = jdbcTemplate.queryForObject(
+			"""
+			select obj_description(c.oid, 'pg_class')
+			from pg_class c
+			join pg_namespace n on n.oid = c.relnamespace
+			where n.nspname = current_schema()
+			  and c.relname = ?
+			""",
+			String.class,
+			tableName
+		);
+
+		assertThat(comment).contains(expectedFragment);
+	}
+
 	private void assertConstraint(String tableName, String constraintName, String... expectedFragments) {
 		String constraintDefinition = jdbcTemplate.queryForObject(
 			"""
@@ -307,5 +437,135 @@ class DomainSchemaSmokeTest extends PostgreSqlContainerTest {
 		);
 
 		assertThat(constraintDefinition).contains(expectedFragments);
+	}
+
+	private void assertNoConstraint(String tableName, String constraintName) {
+		Integer count = jdbcTemplate.queryForObject(
+			"""
+			select count(*)
+			from pg_constraint c
+			join pg_class t on t.oid = c.conrelid
+			join pg_namespace n on n.oid = c.connamespace
+			where n.nspname = current_schema()
+			  and t.relname = ?
+			  and c.conname = ?
+			""",
+			Integer.class,
+			tableName,
+			constraintName
+		);
+
+		assertThat(count).isZero();
+	}
+
+	private UUID insertUser() {
+		UUID userId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into users (id, status, onboarding_status, created_at, updated_at)
+			values (?, 'ACTIVE', 'COMPLETED', now(), now())
+			""",
+			userId
+		);
+		return userId;
+	}
+
+	private UUID insertSavedItem(UUID userId, String normalizedUrl) {
+		UUID itemId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into saved_items (
+			    id, user_id, input_source, original_url, normalized_url, title,
+			    listed_price, currency_code, category, category_locked_by_user,
+			    status, created_at, updated_at
+			)
+			values (?, ?, 'DIRECT_INPUT', ?, ?, '테스트 상품', 10000, 'KRW', 'FASHION', false, 'SAVED', now(), now())
+			""",
+			itemId,
+			userId,
+			normalizedUrl,
+			normalizedUrl
+		);
+		return itemId;
+	}
+
+	private UUID insertPurchaseDecision(UUID userId, UUID itemId, short yesCount, String rationalityResult) {
+		UUID decisionId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into purchase_decisions (
+			    id, user_id, item_id, result, final_price, rationality_result,
+			    self_check_yes_count, decided_at, created_at, updated_at
+			)
+			values (?, ?, ?, 'GO', 10000, ?, ?, now(), now(), now())
+			""",
+			decisionId,
+			userId,
+			itemId,
+			rationalityResult,
+			yesCount
+		);
+		return decisionId;
+	}
+
+	private UUID insertSelfCheckResponseSet(UUID decisionId, short yesCount, String rationalityResult) {
+		UUID responseSetId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into self_check_response_sets (
+			    id, decision_id, yes_count, rationality_result, submitted_at, created_at, updated_at
+			)
+			values (?, ?, ?, ?, now(), now(), now())
+			""",
+			responseSetId,
+			decisionId,
+			yesCount,
+			rationalityResult
+		);
+		return responseSetId;
+	}
+
+	private UUID insertFeedPost(UUID userId) {
+		UUID postId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into feed_posts (id, user_id, title, created_at, updated_at)
+			values (?, ?, '살까요 말까요', now(), now())
+			""",
+			postId,
+			userId
+		);
+		return postId;
+	}
+
+	private UUID insertPostVote(UUID postId, UUID userId, String voteType) {
+		UUID voteId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into post_votes (id, post_id, user_id, vote_type, created_at, updated_at)
+			values (?, ?, ?, ?, now(), now())
+			""",
+			voteId,
+			postId,
+			userId,
+			voteType
+		);
+		return voteId;
+	}
+
+	private void assertVoteCounts(UUID postId, int expectedGoCount, int expectedStopCount) {
+		Integer goCount = jdbcTemplate.queryForObject(
+			"select go_count from feed_posts where id = ?",
+			Integer.class,
+			postId
+		);
+		Integer stopCount = jdbcTemplate.queryForObject(
+			"select stop_count from feed_posts where id = ?",
+			Integer.class,
+			postId
+		);
+
+		assertThat(goCount).isEqualTo(expectedGoCount);
+		assertThat(stopCount).isEqualTo(expectedStopCount);
 	}
 }


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-12`
- Jira: https://parkjaehong.atlassian.net/browse/NF-12
- GitHub: Related #5
- GitHub: Follow-up #6

> PR 제목: `[fix] NF-12 스키마 리뷰 보완`
> 브랜치: `fix/NF-12-schema-review-hardening`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #5의 후속 보완 PR
- 선행 PR: #6
- 후속 PR: NF-16/NF-17/NF-18 등 기능 구현 PR에서 이 스키마 기준 사용

### 이 PR에서 변경한 것
- 이미 머지된 `V1__domain_schema_baseline.sql`은 수정하지 않고, 리뷰 보완 내용은 `V2__domain_schema_review_hardening.sql`로 분리했습니다.
- `post_votes`의 일반 `unique(post_id, user_id)` 제약을 제거하고, 활성 투표에만 적용되는 조건부 unique index로 교체했습니다.
- 취소된 투표 기록이 남아 있어도 같은 유저가 같은 게시글에 다시 투표할 수 있게 했습니다.
- `post_votes`가 생성, 취소, 변경될 때 `feed_posts.go_count/stop_count`가 DB에서 자동으로 맞춰지도록 PostgreSQL 트리거를 추가했습니다.
- `purchase_decisions`도 `UserScopedEntity`를 상속하도록 맞춰 유저 소유 엔티티 구조를 통일했습니다.
- `purchase_decisions`와 `self_check_response_sets`의 최종 합리성 판별값이 서로 어긋나면 DB에서 저장을 막도록 검증 트리거를 추가했습니다.
- 소셜 계정 1유저-1계정 정책과 share token 무만료 정책은 MVP 의도임을 DB 주석과 문서에 명시했습니다.
- 실제 PostgreSQL 테스트에 CHECK 제약 위반, 합리성 값 불일치, 투표 취소 후 재투표, 투표 수 자동 반영 검증을 추가했습니다.

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
- AC1: 투표 취소 후 재투표 시 중복 제약 오류가 발생하지 않는다.
- AC2: 합리성 Yes 개수와 판별 결과의 DB CHECK 제약이 실제 INSERT/UPDATE에서 검증된다.
- AC3: `purchase_decisions`와 `self_check_response_sets`의 최종 합리성 판별값 불일치를 DB 레벨에서 차단한다.
- AC4: `feed_posts.go_count/stop_count`가 투표 기록과 어긋나지 않도록 DB 트리거로 관리된다.
- AC5: 이미 머지된 V1 마이그레이션을 수정하지 않아 Flyway checksum 문제가 생기지 않는다.

### Not covered (후속 작업)
- 실제 소셜 피드 투표 API 구현과 카운트 반환 로직
- 구매 결정/셀프체크 API에서 하나의 트랜잭션으로 최종 판별값을 저장하는 서비스 로직

---

## 🧪 테스트 결과 (필수)
### 로컬
```
./gradlew test --rerun-tasks
```
- ✅ 결과: 통과

### CI
- 자동 첨부

### Smoke 테스트
- 시나리오: Flyway V1+V2 마이그레이션 후 JPA 스키마 검증, PostgreSQL 조건부 인덱스, DB 검증 트리거, DB 주석 확인
- 실패 케이스 테스트: 잘못된 합리성 Yes 개수/판별 결과 INSERT 차단, `purchase_decisions`와 `self_check_response_sets` 불일치 차단, 활성 투표 중복 차단 및 취소 후 재투표 허용
- 트리거 테스트: `post_votes` 생성/취소/변경 시 `feed_posts.go_count/stop_count` 자동 반영 확인
- 결과: 통과

---

## 🧭 영향 범위 체크 (필수)
- [ ] API 변경 (요약: 없음)
- [x] DB 변경 (마이그레이션: `V2__domain_schema_review_hardening.sql` 추가)
- [ ] 설정 변경 (항목: 없음)
- [ ] Breaking change (무엇: )

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인:
  - `src/main/resources/db/migration/V2__domain_schema_review_hardening.sql`
  - `src/test/java/com/sagongsa/backend/domain/DomainSchemaSmokeTest.java`
  - `src/main/java/com/sagongsa/backend/domain/decision/PurchaseDecision.java`
  - `docs/DOMAIN_SCHEMA_REVISED_FROM_PLANNING_2026_04_16.md`
- 트레이드오프/대안:
  - `purchase_decisions`의 최종 합리성 판별값은 홈/마이페이지/NSM 조회에서 최종 결정 기준으로 바로 필요하므로 제거하지 않고 유지했습니다. 대신 `self_check_response_sets`와 값이 달라지면 DB 검증 트리거가 저장을 막습니다.
  - `feed_posts.go_count/stop_count`는 피드 목록 조회를 빠르게 하기 위해 유지했습니다. 투표 수가 어긋날 위험은 애플리케이션 로직에만 맡기지 않고 PostgreSQL 트리거로 방어합니다.
