### PR TITLE
NF-24 MVP 담당 범위 백엔드 보완 API 구현

### DIFF
--- a/src/main/java/com/sagongsa/backend/decision/DecisionController.java
+++ b/src/main/java/com/sagongsa/backend/decision/DecisionController.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,5 +39,14 @@ public class DecisionController {
 		@PathVariable UUID decisionId
 	) {
 		return decisionService.getResult(userId, decisionId);
+	}
+
+	@PatchMapping("/{decisionId}/result")
+	public DecisionResultResponse updateResult(
+		@CurrentUserId UUID userId,
+		@PathVariable UUID decisionId,
+		@RequestBody(required = false) DecisionResultUpdateRequest request
+	) {
+		return decisionService.updateResult(userId, decisionId, request);
 	}
 }

--- a/src/main/java/com/sagongsa/backend/decision/DecisionResultUpdateRequest.java
+++ b/src/main/java/com/sagongsa/backend/decision/DecisionResultUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.sagongsa.backend.decision;
+
+import java.util.List;
+
+public record DecisionResultUpdateRequest(
+	String result,
+	Integer finalPrice,
+	String changeReason,
+	List<SelfCheckAnswerUpdateRequest> selfCheckAnswers
+) {
+
+	public record SelfCheckAnswerUpdateRequest(
+		String questionCode,
+		Boolean answerBoolean
+	) {
+	}
+}

--- a/src/main/java/com/sagongsa/backend/decision/DecisionService.java
+++ b/src/main/java/com/sagongsa/backend/decision/DecisionService.java
@@ -132,6 +132,44 @@ public class DecisionService {
 		);
 	}
 
+	@Transactional
+	public DecisionResultResponse updateResult(UUID userId, UUID decisionId, DecisionResultUpdateRequest request) {
+		NormalizedDecisionUpdateRequest normalized = normalizeUpdate(request);
+		UserContext user = requireDecisionUser(userId);
+		DecisionForUpdate decision = lockDecision(userId, decisionId);
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		PurchaseDecisionResult previousResult = PurchaseDecisionResult.valueOf(decision.result());
+		Integer newFinalPrice = resolveUpdatedFinalPrice(
+			normalized.result(),
+			normalized.finalPrice(),
+			decision.finalPrice(),
+			decision.itemListedPrice()
+		);
+		Rationality newRationality = normalized.selfCheckAnswers() == null
+			? new Rationality(decision.selfCheckYesCount(), RationalityResult.valueOf(decision.rationalityResult()))
+			: rationality(normalized.selfCheckAnswers());
+		Integer previousGoAmount = previousResult == PurchaseDecisionResult.GO ? Objects.requireNonNullElse(decision.finalPrice(), 0) : 0;
+		Integer newGoAmount = normalized.result() == PurchaseDecisionResult.GO ? Objects.requireNonNullElse(newFinalPrice, 0) : 0;
+		int budgetDelta = newGoAmount - previousGoAmount;
+		int budgetAfterAmount = updateBudgetForDecisionChange(decision.budgetCycleId(), budgetDelta, now);
+
+		updateDecisionResult(decision, normalized.result(), newFinalPrice, newRationality, budgetAfterAmount, now);
+		updateItemStatus(decision.itemId(), normalized.result(), now);
+		updateSelfCheckIfNeeded(decision.id(), normalized.selfCheckAnswers(), newRationality, now);
+		insertDecisionChangeLog(decision, normalized, newFinalPrice, newRationality, now);
+		updateReminderForResultChange(
+			userId,
+			decision.itemId(),
+			decision.id(),
+			previousResult,
+			normalized.result(),
+			zoneId(user.timezone()),
+			now
+		);
+
+		return getResult(userId, decisionId);
+	}
+
 	private NormalizedDecisionRequest normalize(DecisionCompleteRequest request) {
 		if (request == null) {
 			throw new DecisionBadRequestException("Request body is required.");
@@ -145,6 +183,19 @@ public class DecisionService {
 		String rationaleText = cleanOptional(request.rationaleText(), "rationaleText");
 		List<NormalizedSelfCheckAnswer> answers = normalizeSelfCheckAnswers(request.selfCheckAnswers());
 		return new NormalizedDecisionRequest(request.itemId(), result, finalPrice, rationaleText, answers);
+	}
+
+	private NormalizedDecisionUpdateRequest normalizeUpdate(DecisionResultUpdateRequest request) {
+		if (request == null) {
+			throw new DecisionBadRequestException("Request body is required.");
+		}
+		PurchaseDecisionResult result = parseResult(request.result());
+		Integer finalPrice = validateFinalPrice(request.finalPrice());
+		String changeReason = cleanOptional(request.changeReason(), "changeReason");
+		List<NormalizedSelfCheckAnswer> answers = request.selfCheckAnswers() == null
+			? null
+			: normalizeSelfCheckAnswerUpdates(request.selfCheckAnswers());
+		return new NormalizedDecisionUpdateRequest(result, finalPrice, changeReason, answers);
 	}
 
 	private PurchaseDecisionResult parseResult(String rawResult) {
@@ -173,6 +224,29 @@ public class DecisionService {
 
 		Map<String, NormalizedSelfCheckAnswer> normalized = new LinkedHashMap<>();
 		for (SelfCheckAnswerRequest answer : answers) {
+			if (answer == null) {
+				throw new DecisionBadRequestException("selfCheckAnswers must not contain null.");
+			}
+			String questionCode = cleanRequired(answer.questionCode(), "questionCode", 80);
+			if (answer.answerBoolean() == null) {
+				throw new DecisionBadRequestException("answerBoolean is required.");
+			}
+			if (normalized.putIfAbsent(questionCode, new NormalizedSelfCheckAnswer(questionCode, answer.answerBoolean())) != null) {
+				throw new DecisionBadRequestException("selfCheckAnswers must not contain duplicated questionCode.");
+			}
+		}
+		return List.copyOf(normalized.values());
+	}
+
+	private List<NormalizedSelfCheckAnswer> normalizeSelfCheckAnswerUpdates(
+		List<DecisionResultUpdateRequest.SelfCheckAnswerUpdateRequest> answers
+	) {
+		if (answers.size() != 4) {
+			throw new DecisionBadRequestException("selfCheckAnswers must contain exactly 4 answers.");
+		}
+
+		Map<String, NormalizedSelfCheckAnswer> normalized = new LinkedHashMap<>();
+		for (DecisionResultUpdateRequest.SelfCheckAnswerUpdateRequest answer : answers) {
 			if (answer == null) {
 				throw new DecisionBadRequestException("selfCheckAnswers must not contain null.");
 			}
@@ -261,8 +335,54 @@ public class DecisionService {
 		}
 	}
 
+	private DecisionForUpdate lockDecision(UUID userId, UUID decisionId) {
+		try {
+			return jdbcTemplate.queryForObject(
+				"""
+				select
+					pd.id,
+					pd.user_id,
+					pd.item_id,
+					pd.budget_cycle_id,
+					pd.result,
+					pd.final_price,
+					pd.rationality_result,
+					pd.self_check_yes_count,
+					si.listed_price as item_listed_price
+				from purchase_decisions pd
+				join saved_items si on si.id = pd.item_id
+				where pd.user_id = ?
+				  and pd.id = ?
+				for update of pd, si
+				""",
+				this::mapDecisionForUpdate,
+				userId,
+				decisionId
+			);
+		}
+		catch (EmptyResultDataAccessException exception) {
+			throw new DecisionNotFoundException("Purchase decision result was not found.");
+		}
+	}
+
 	private Integer resolveFinalPrice(PurchaseDecisionResult result, Integer requestedFinalPrice, Integer listedPrice) {
 		Integer finalPrice = requestedFinalPrice == null ? listedPrice : requestedFinalPrice;
+		if (result == PurchaseDecisionResult.GO && finalPrice == null) {
+			throw new DecisionBadRequestException("finalPrice is required for GO when item price is missing.");
+		}
+		return finalPrice;
+	}
+
+	private Integer resolveUpdatedFinalPrice(
+		PurchaseDecisionResult result,
+		Integer requestedFinalPrice,
+		Integer previousFinalPrice,
+		Integer listedPrice
+	) {
+		Integer finalPrice = requestedFinalPrice;
+		if (finalPrice == null) {
+			finalPrice = previousFinalPrice == null ? listedPrice : previousFinalPrice;
+		}
 		if (result == PurchaseDecisionResult.GO && finalPrice == null) {
 			throw new DecisionBadRequestException("finalPrice is required for GO when item price is missing.");
 		}
@@ -409,6 +529,143 @@ public class DecisionService {
 		);
 	}
 
+	private int updateBudgetForDecisionChange(UUID budgetCycleId, int delta, OffsetDateTime now) {
+		if (budgetCycleId == null) {
+			return 0;
+		}
+		BudgetSpent budget = jdbcTemplate.queryForObject(
+			"""
+			update budget_cycles
+			set spent_amount = greatest(spent_amount + ?, 0),
+				updated_at = ?
+			where id = ?
+			returning spent_amount
+			""",
+			(rs, rowNumber) -> new BudgetSpent(rs.getInt("spent_amount")),
+			delta,
+			now,
+			budgetCycleId
+		);
+		return budget == null ? 0 : budget.spentAmount();
+	}
+
+	private void updateDecisionResult(
+		DecisionForUpdate decision,
+		PurchaseDecisionResult result,
+		Integer finalPrice,
+		Rationality rationality,
+		int budgetAfterAmount,
+		OffsetDateTime now
+	) {
+		jdbcTemplate.update(
+			"""
+			update purchase_decisions
+			set result = ?,
+				final_price = ?,
+				budget_after_amount = ?,
+				rationality_result = ?,
+				self_check_yes_count = ?,
+				is_changed = true,
+				change_count = change_count + 1,
+				changed_at = ?,
+				updated_at = ?
+			where id = ?
+			""",
+			result.name(),
+			finalPrice,
+			budgetAfterAmount,
+			rationality.result().name(),
+			rationality.yesCount(),
+			now,
+			now,
+			decision.id()
+		);
+	}
+
+	private void updateSelfCheckIfNeeded(
+		UUID decisionId,
+		List<NormalizedSelfCheckAnswer> answers,
+		Rationality rationality,
+		OffsetDateTime now
+	) {
+		if (answers == null) {
+			return;
+		}
+
+		UUID responseSetId = jdbcTemplate.queryForObject(
+			"select id from self_check_response_sets where decision_id = ?",
+			UUID.class,
+			decisionId
+		);
+		jdbcTemplate.update(
+			"""
+			update self_check_response_sets
+			set yes_count = ?,
+				rationality_result = ?,
+				submitted_at = ?,
+				updated_at = ?
+			where id = ?
+			""",
+			rationality.yesCount(),
+			rationality.result().name(),
+			now,
+			now,
+			responseSetId
+		);
+		jdbcTemplate.update("delete from self_check_answers where response_set_id = ?", responseSetId);
+		for (NormalizedSelfCheckAnswer answer : answers) {
+			jdbcTemplate.update(
+				"""
+				insert into self_check_answers (
+					id, response_set_id, question_code, answer_boolean, created_at, updated_at
+				)
+				values (?, ?, ?, ?, ?, ?)
+				""",
+				UUID.randomUUID(),
+				responseSetId,
+				answer.questionCode(),
+				answer.answerBoolean(),
+				now,
+				now
+			);
+		}
+	}
+
+	private void insertDecisionChangeLog(
+		DecisionForUpdate decision,
+		NormalizedDecisionUpdateRequest normalized,
+		Integer newFinalPrice,
+		Rationality newRationality,
+		OffsetDateTime now
+	) {
+		jdbcTemplate.update(
+			"""
+			insert into purchase_decision_change_logs (
+				id, decision_id, user_id, item_id, previous_result, new_result,
+				previous_final_price, new_final_price,
+				previous_rationality_result, new_rationality_result,
+				previous_self_check_yes_count, new_self_check_yes_count,
+				reason_text, changed_at
+			)
+			values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			""",
+			UUID.randomUUID(),
+			decision.id(),
+			decision.userId(),
+			decision.itemId(),
+			decision.result(),
+			normalized.result().name(),
+			decision.finalPrice(),
+			newFinalPrice,
+			decision.rationalityResult(),
+			newRationality.result().name(),
+			decision.selfCheckYesCount(),
+			newRationality.yesCount(),
+			normalized.changeReason(),
+			now
+		);
+	}
+
 	private MascotReaction updateMascotReaction(
 		UUID userId,
 		UUID itemId,
@@ -516,6 +773,75 @@ public class DecisionService {
 			now
 		);
 		return new ReminderResponse(reminderId, "REGRET_CHECK_7_DAYS", "SCHEDULED", scheduledFor.toInstant());
+	}
+
+	private void updateReminderForResultChange(
+		UUID userId,
+		UUID itemId,
+		UUID decisionId,
+		PurchaseDecisionResult previousResult,
+		PurchaseDecisionResult newResult,
+		ZoneId zoneId,
+		OffsetDateTime now
+	) {
+		if (previousResult == PurchaseDecisionResult.GO && newResult == PurchaseDecisionResult.STOP) {
+			cancelScheduledRegretReminder(decisionId, now);
+			return;
+		}
+		if (previousResult == PurchaseDecisionResult.STOP && newResult == PurchaseDecisionResult.GO && regretReminderEnabled(userId)) {
+			upsertScheduledRegretReminder(userId, itemId, decisionId, zoneId, now);
+		}
+	}
+
+	private void cancelScheduledRegretReminder(UUID decisionId, OffsetDateTime now) {
+		jdbcTemplate.update(
+			"""
+			update reminder_schedules
+			set status = 'CANCELED',
+				canceled_at = ?,
+				cancel_reason = 'DECISION_CHANGED_TO_STOP',
+				updated_at = ?
+			where decision_id = ?
+			  and reminder_type = 'REGRET_CHECK_7_DAYS'
+			  and status = 'SCHEDULED'
+			""",
+			now,
+			now,
+			decisionId
+		);
+	}
+
+	private void upsertScheduledRegretReminder(
+		UUID userId,
+		UUID itemId,
+		UUID decisionId,
+		ZoneId zoneId,
+		OffsetDateTime now
+	) {
+		OffsetDateTime scheduledFor = scheduledRegretReminderAt(now.toInstant(), zoneId);
+		jdbcTemplate.update(
+			"""
+			insert into reminder_schedules (
+				id, user_id, item_id, decision_id, reminder_type, scheduled_for,
+				status, sent_at, canceled_at, cancel_reason, created_at, updated_at
+			)
+			values (?, ?, ?, ?, 'REGRET_CHECK_7_DAYS', ?, 'SCHEDULED', null, null, null, ?, ?)
+			on conflict (decision_id, reminder_type) do update
+			   set scheduled_for = excluded.scheduled_for,
+			       status = 'SCHEDULED',
+			       sent_at = null,
+			       canceled_at = null,
+			       cancel_reason = null,
+			       updated_at = excluded.updated_at
+			""",
+			UUID.randomUUID(),
+			userId,
+			itemId,
+			decisionId,
+			scheduledFor,
+			now,
+			now
+		);
 	}
 
 	private boolean regretReminderEnabled(UUID userId) {
@@ -659,6 +985,20 @@ public class DecisionService {
 		);
 	}
 
+	private DecisionForUpdate mapDecisionForUpdate(ResultSet rs, int rowNumber) throws SQLException {
+		return new DecisionForUpdate(
+			rs.getObject("id", UUID.class),
+			rs.getObject("user_id", UUID.class),
+			rs.getObject("item_id", UUID.class),
+			rs.getObject("budget_cycle_id", UUID.class),
+			rs.getString("result"),
+			getInteger(rs, "final_price"),
+			rs.getString("rationality_result"),
+			rs.getInt("self_check_yes_count"),
+			getInteger(rs, "item_listed_price")
+		);
+	}
+
 	private DecisionResult mapDecisionResult(ResultSet rs, int rowNumber) throws SQLException {
 		return new DecisionResult(
 			rs.getObject("id", UUID.class),
@@ -697,6 +1037,14 @@ public class DecisionService {
 	) {
 	}
 
+	private record NormalizedDecisionUpdateRequest(
+		PurchaseDecisionResult result,
+		Integer finalPrice,
+		String changeReason,
+		List<NormalizedSelfCheckAnswer> selfCheckAnswers
+	) {
+	}
+
 	private record NormalizedSelfCheckAnswer(String questionCode, boolean answerBoolean) {
 	}
 
@@ -707,6 +1055,9 @@ public class DecisionService {
 	}
 
 	private record BudgetCycle(UUID id, String yearMonth, int spentAmount) {
+	}
+
+	private record BudgetSpent(int spentAmount) {
 	}
 
 	private record Rationality(int yesCount, RationalityResult result) {
@@ -730,6 +1081,19 @@ public class DecisionService {
 		String mascotState,
 		String mascotMessage,
 		Instant decidedAt
+	) {
+	}
+
+	private record DecisionForUpdate(
+		UUID id,
+		UUID userId,
+		UUID itemId,
+		UUID budgetCycleId,
+		String result,
+		Integer finalPrice,
+		String rationalityResult,
+		int selfCheckYesCount,
+		Integer itemListedPrice
 	) {
 	}
 }

--- a/src/main/java/com/sagongsa/backend/deliberation/DeliberationController.java
+++ b/src/main/java/com/sagongsa/backend/deliberation/DeliberationController.java
@@ -1,0 +1,27 @@
+package com.sagongsa.backend.deliberation;
+
+import com.sagongsa.backend.auth.CurrentUserId;
+import java.util.UUID;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/deliberations")
+public class DeliberationController {
+
+	private final DeliberationService deliberationService;
+
+	public DeliberationController(DeliberationService deliberationService) {
+		this.deliberationService = deliberationService;
+	}
+
+	@GetMapping("/items/{itemId}")
+	public DeliberationSummaryResponse getSummary(
+		@CurrentUserId UUID userId,
+		@PathVariable UUID itemId
+	) {
+		return deliberationService.getSummary(userId, itemId);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/deliberation/DeliberationService.java
+++ b/src/main/java/com/sagongsa/backend/deliberation/DeliberationService.java
@@ -1,0 +1,185 @@
+package com.sagongsa.backend.deliberation;
+
+import com.sagongsa.backend.deliberation.DeliberationSummaryResponse.BudgetProjection;
+import com.sagongsa.backend.deliberation.DeliberationSummaryResponse.ItemSummary;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.DateTimeException;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.util.Objects;
+import java.util.UUID;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class DeliberationService {
+
+	private static final ZoneId DEFAULT_ZONE_ID = ZoneId.of("Asia/Seoul");
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public DeliberationService(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	public DeliberationSummaryResponse getSummary(UUID userId, UUID itemId) {
+		UserContext user = requireUsableUser(userId);
+		ZoneId zoneId = resolveZoneId(user.timezone());
+		String yearMonth = YearMonth.now(zoneId).toString();
+		ItemSummary item = findSavedItem(userId, itemId);
+		BudgetSnapshot budget = findBudget(userId, yearMonth);
+		int itemPrice = item.listedPrice() == null ? 0 : item.listedPrice();
+		int projectedSpentAmount = budget.spentAmount() + itemPrice;
+		BigDecimal projectedUsageRate = usageRate(projectedSpentAmount, budget.monthlyBudgetAmount());
+
+		return new DeliberationSummaryResponse(
+			item,
+			new BudgetProjection(
+				yearMonth,
+				budget.monthlyBudgetAmount(),
+				budget.spentAmount(),
+				projectedSpentAmount,
+				projectedUsageRate
+			),
+			similarCategorySpendAmount(userId, item.category(), yearMonth, zoneId),
+			opportunityCostMessage(item)
+		);
+	}
+
+	private UserContext requireUsableUser(UUID userId) {
+		try {
+			UserContext user = jdbcTemplate.queryForObject(
+				"""
+				select u.status, u.onboarding_status, coalesce(up.timezone, 'Asia/Seoul') as timezone
+				from users u
+				left join user_profiles up on up.user_id = u.id
+				where u.id = ?
+				""",
+				(rs, rowNumber) -> new UserContext(
+					rs.getString("status"),
+					rs.getString("onboarding_status"),
+					rs.getString("timezone")
+				),
+				userId
+			);
+			if (!Objects.equals(user.status(), "ACTIVE") || !Objects.equals(user.onboardingStatus(), "COMPLETED")) {
+				throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Deliberation can be used only after onboarding.");
+			}
+			return user;
+		}
+		catch (EmptyResultDataAccessException exception) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User was not found.");
+		}
+	}
+
+	private ItemSummary findSavedItem(UUID userId, UUID itemId) {
+		try {
+			ItemSummary item = jdbcTemplate.queryForObject(
+				"""
+				select id, title, image_url, listed_price, currency_code, category, status
+				from saved_items
+				where user_id = ?
+				  and id = ?
+				""",
+				this::mapItem,
+				userId,
+				itemId
+			);
+			if (!Objects.equals(item.status(), "SAVED")) {
+				throw new ResponseStatusException(HttpStatus.CONFLICT, "Only saved wishlist items can enter deliberation.");
+			}
+			return item;
+		}
+		catch (EmptyResultDataAccessException exception) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Saved wishlist item was not found.");
+		}
+	}
+
+	private BudgetSnapshot findBudget(UUID userId, String yearMonth) {
+		return jdbcTemplate.query(
+				"""
+				select monthly_budget_amount, spent_amount
+				from budget_cycles
+				where user_id = ?
+				  and year_month = ?
+				""",
+				(rs, rowNumber) -> new BudgetSnapshot(rs.getInt("monthly_budget_amount"), rs.getInt("spent_amount")),
+				userId,
+				yearMonth
+			)
+			.stream()
+			.findFirst()
+			.orElse(new BudgetSnapshot(0, 0));
+	}
+
+	private int similarCategorySpendAmount(UUID userId, String category, String yearMonth, ZoneId zoneId) {
+		Integer amount = jdbcTemplate.queryForObject(
+			"""
+			select coalesce(sum(coalesce(pd.final_price, 0)), 0)::integer
+			from purchase_decisions pd
+			join saved_items si on si.id = pd.item_id
+			where pd.user_id = ?
+			  and pd.result = 'GO'
+			  and si.category = ?
+			  and to_char(pd.decided_at at time zone ?, 'YYYY-MM') = ?
+			""",
+			Integer.class,
+			userId,
+			category,
+			zoneId.getId(),
+			yearMonth
+		);
+		return amount == null ? 0 : amount;
+	}
+
+	private String opportunityCostMessage(ItemSummary item) {
+		if (item.listedPrice() == null || item.listedPrice() == 0) {
+			return "가격을 입력하면 다른 선택지와 비교하기 쉬워요.";
+		}
+		return "%,d원을 다른 곳에 쓸 수도 있어요.".formatted(item.listedPrice());
+	}
+
+	private BigDecimal usageRate(int spentAmount, int monthlyBudgetAmount) {
+		if (monthlyBudgetAmount <= 0) {
+			return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+		}
+		return BigDecimal.valueOf(spentAmount)
+			.multiply(BigDecimal.valueOf(100))
+			.divide(BigDecimal.valueOf(monthlyBudgetAmount), 2, RoundingMode.HALF_UP);
+	}
+
+	private ItemSummary mapItem(ResultSet rs, int rowNumber) throws SQLException {
+		int listedPrice = rs.getInt("listed_price");
+		Integer nullableListedPrice = rs.wasNull() ? null : listedPrice;
+		return new ItemSummary(
+			rs.getObject("id", UUID.class),
+			rs.getString("title"),
+			rs.getString("image_url"),
+			nullableListedPrice,
+			rs.getString("currency_code"),
+			rs.getString("category"),
+			rs.getString("status")
+		);
+	}
+
+	private ZoneId resolveZoneId(String timezone) {
+		try {
+			return ZoneId.of(timezone);
+		}
+		catch (DateTimeException exception) {
+			return DEFAULT_ZONE_ID;
+		}
+	}
+
+	private record UserContext(String status, String onboardingStatus, String timezone) {
+	}
+
+	private record BudgetSnapshot(int monthlyBudgetAmount, int spentAmount) {
+	}
+}

--- a/src/main/java/com/sagongsa/backend/deliberation/DeliberationSummaryResponse.java
+++ b/src/main/java/com/sagongsa/backend/deliberation/DeliberationSummaryResponse.java
@@ -1,0 +1,32 @@
+package com.sagongsa.backend.deliberation;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record DeliberationSummaryResponse(
+	ItemSummary item,
+	BudgetProjection budget,
+	int similarCategorySpendAmount,
+	String opportunityCostMessage
+) {
+
+	public record ItemSummary(
+		UUID id,
+		String title,
+		String imageUrl,
+		Integer listedPrice,
+		String currencyCode,
+		String category,
+		String status
+	) {
+	}
+
+	public record BudgetProjection(
+		String yearMonth,
+		int monthlyBudgetAmount,
+		int spentAmount,
+		int projectedSpentAmount,
+		BigDecimal projectedUsageRate
+	) {
+	}
+}

--- a/src/main/java/com/sagongsa/backend/notification/NotificationController.java
+++ b/src/main/java/com/sagongsa/backend/notification/NotificationController.java
@@ -1,0 +1,38 @@
+package com.sagongsa.backend.notification;
+
+import com.sagongsa.backend.auth.CurrentUserId;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+public class NotificationController {
+
+	private final NotificationService notificationService;
+
+	public NotificationController(NotificationService notificationService) {
+		this.notificationService = notificationService;
+	}
+
+	@GetMapping
+	public List<NotificationResponse> list(
+		@CurrentUserId UUID userId,
+		@RequestParam(defaultValue = "false") boolean unreadOnly
+	) {
+		return notificationService.list(userId, unreadOnly);
+	}
+
+	@PatchMapping("/{notificationId}/read")
+	public NotificationResponse markAsRead(
+		@CurrentUserId UUID userId,
+		@PathVariable UUID notificationId
+	) {
+		return notificationService.markAsRead(userId, notificationId);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/notification/NotificationResponse.java
+++ b/src/main/java/com/sagongsa/backend/notification/NotificationResponse.java
@@ -1,0 +1,19 @@
+package com.sagongsa.backend.notification;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record NotificationResponse(
+	UUID id,
+	String type,
+	String title,
+	String body,
+	UUID itemId,
+	UUID decisionId,
+	UUID reminderId,
+	String targetPath,
+	boolean read,
+	Instant readAt,
+	Instant createdAt
+) {
+}

--- a/src/main/java/com/sagongsa/backend/notification/NotificationService.java
+++ b/src/main/java/com/sagongsa/backend/notification/NotificationService.java
@@ -1,0 +1,129 @@
+package com.sagongsa.backend.notification;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class NotificationService {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public NotificationService(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Transactional(readOnly = true)
+	public List<NotificationResponse> list(UUID userId, boolean unreadOnly) {
+		requireUsableUser(userId);
+		String unreadFilter = unreadOnly ? "and is_read = false" : "";
+		return jdbcTemplate.query(
+			"""
+			select id, notification_type, title, body, item_id, decision_id, reminder_id,
+			       target_path, is_read, read_at, created_at
+			from notifications
+			where user_id = ?
+			%s
+			order by created_at desc, id desc
+			""".formatted(unreadFilter),
+			this::mapNotification,
+			userId
+		);
+	}
+
+	@Transactional
+	public NotificationResponse markAsRead(UUID userId, UUID notificationId) {
+		requireUsableUser(userId);
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		int updated = jdbcTemplate.update(
+			"""
+			update notifications
+			set is_read = true,
+				read_at = coalesce(read_at, ?),
+				updated_at = ?
+			where user_id = ?
+			  and id = ?
+			""",
+			now,
+			now,
+			userId,
+			notificationId
+		);
+		if (updated == 0) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Notification was not found.");
+		}
+		return findById(userId, notificationId);
+	}
+
+	private NotificationResponse findById(UUID userId, UUID notificationId) {
+		try {
+			return jdbcTemplate.queryForObject(
+				"""
+				select id, notification_type, title, body, item_id, decision_id, reminder_id,
+				       target_path, is_read, read_at, created_at
+				from notifications
+				where user_id = ?
+				  and id = ?
+				""",
+				this::mapNotification,
+				userId,
+				notificationId
+			);
+		}
+		catch (EmptyResultDataAccessException exception) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Notification was not found.");
+		}
+	}
+
+	private void requireUsableUser(UUID userId) {
+		try {
+			UserState user = jdbcTemplate.queryForObject(
+				"select status, onboarding_status from users where id = ?",
+				(rs, rowNumber) -> new UserState(rs.getString("status"), rs.getString("onboarding_status")),
+				userId
+			);
+			if (!Objects.equals(user.status(), "ACTIVE") || !Objects.equals(user.onboardingStatus(), "COMPLETED")) {
+				throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Notifications can be used only after onboarding.");
+			}
+		}
+		catch (EmptyResultDataAccessException exception) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User was not found.");
+		}
+	}
+
+	private NotificationResponse mapNotification(ResultSet rs, int rowNumber) throws SQLException {
+		return new NotificationResponse(
+			rs.getObject("id", UUID.class),
+			rs.getString("notification_type"),
+			rs.getString("title"),
+			rs.getString("body"),
+			rs.getObject("item_id", UUID.class),
+			rs.getObject("decision_id", UUID.class),
+			rs.getObject("reminder_id", UUID.class),
+			rs.getString("target_path"),
+			rs.getBoolean("is_read"),
+			readInstant(rs, "read_at"),
+			readInstant(rs, "created_at")
+		);
+	}
+
+	private Instant readInstant(ResultSet rs, String columnName) throws SQLException {
+		Timestamp timestamp = rs.getTimestamp(columnName);
+		return timestamp == null ? null : timestamp.toInstant();
+	}
+
+	private record UserState(String status, String onboardingStatus) {
+	}
+}

--- a/src/main/java/com/sagongsa/backend/reflection/PurchaseReflectionController.java
+++ b/src/main/java/com/sagongsa/backend/reflection/PurchaseReflectionController.java
@@ -1,0 +1,32 @@
+package com.sagongsa.backend.reflection;
+
+import com.sagongsa.backend.auth.CurrentUserId;
+import java.net.URI;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/reflections")
+public class PurchaseReflectionController {
+
+	private final PurchaseReflectionService purchaseReflectionService;
+
+	public PurchaseReflectionController(PurchaseReflectionService purchaseReflectionService) {
+		this.purchaseReflectionService = purchaseReflectionService;
+	}
+
+	@PostMapping
+	public ResponseEntity<PurchaseReflectionResponse> create(
+		@CurrentUserId UUID userId,
+		@RequestBody(required = false) PurchaseReflectionRequest request
+	) {
+		PurchaseReflectionResponse response = purchaseReflectionService.create(userId, request);
+		return ResponseEntity
+			.created(URI.create("/api/v1/reflections/" + response.id()))
+			.body(response);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/reflection/PurchaseReflectionRequest.java
+++ b/src/main/java/com/sagongsa/backend/reflection/PurchaseReflectionRequest.java
@@ -1,0 +1,12 @@
+package com.sagongsa.backend.reflection;
+
+import java.util.UUID;
+
+public record PurchaseReflectionRequest(
+	UUID decisionId,
+	Integer satisfactionScore,
+	String regretLevel,
+	Boolean stillUsing,
+	String reflectionNote
+) {
+}

--- a/src/main/java/com/sagongsa/backend/reflection/PurchaseReflectionResponse.java
+++ b/src/main/java/com/sagongsa/backend/reflection/PurchaseReflectionResponse.java
@@ -1,0 +1,17 @@
+package com.sagongsa.backend.reflection;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record PurchaseReflectionResponse(
+	UUID id,
+	UUID decisionId,
+	UUID itemId,
+	UUID reminderId,
+	Integer satisfactionScore,
+	String regretLevel,
+	Boolean stillUsing,
+	String reflectionNote,
+	Instant reflectedAt
+) {
+}

--- a/src/main/java/com/sagongsa/backend/reflection/PurchaseReflectionService.java
+++ b/src/main/java/com/sagongsa/backend/reflection/PurchaseReflectionService.java
@@ -1,0 +1,233 @@
+package com.sagongsa.backend.reflection;
+
+import com.sagongsa.backend.domain.enums.ReflectionRegretLevel;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class PurchaseReflectionService {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public PurchaseReflectionService(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Transactional
+	public PurchaseReflectionResponse create(UUID userId, PurchaseReflectionRequest request) {
+		NormalizedRequest normalized = normalize(request);
+		requireUsableUser(userId);
+		DecisionSnapshot decision = findGoDecision(userId, normalized.decisionId());
+		if (reflectionExists(normalized.decisionId())) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT, "Reflection already exists for this decision.");
+		}
+		UUID reminderId = findReminderId(normalized.decisionId());
+		UUID reflectionId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		try {
+			jdbcTemplate.update(
+				"""
+				insert into purchase_reflections (
+					id, user_id, item_id, decision_id, reminder_id, satisfaction_score,
+					regret_level, still_using, reflection_note, reflected_at, created_at, updated_at
+				)
+				values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				""",
+				reflectionId,
+				userId,
+				decision.itemId(),
+				decision.decisionId(),
+				reminderId,
+				normalized.satisfactionScore(),
+				normalized.regretLevel().name(),
+				normalized.stillUsing(),
+				normalized.reflectionNote(),
+				now,
+				now,
+				now
+			);
+		}
+		catch (DataIntegrityViolationException exception) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT, "Reflection already exists for this decision.");
+		}
+		return findById(userId, reflectionId);
+	}
+
+	private NormalizedRequest normalize(PurchaseReflectionRequest request) {
+		if (request == null) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Request body is required.");
+		}
+		if (request.decisionId() == null) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "decisionId is required.");
+		}
+		Integer satisfactionScore = request.satisfactionScore();
+		if (satisfactionScore != null && (satisfactionScore < 1 || satisfactionScore > 5)) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "satisfactionScore must be between 1 and 5.");
+		}
+		ReflectionRegretLevel regretLevel = parseRegretLevel(request.regretLevel());
+		String note = cleanOptional(request.reflectionNote(), 500);
+		return new NormalizedRequest(request.decisionId(), satisfactionScore, regretLevel, request.stillUsing(), note);
+	}
+
+	private ReflectionRegretLevel parseRegretLevel(String rawRegretLevel) {
+		if (!StringUtils.hasText(rawRegretLevel)) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "regretLevel is required.");
+		}
+		try {
+			return ReflectionRegretLevel.valueOf(rawRegretLevel.trim().toUpperCase(Locale.ROOT));
+		}
+		catch (IllegalArgumentException exception) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "regretLevel must be NONE, LOW, MEDIUM, or HIGH.");
+		}
+	}
+
+	private String cleanOptional(String value, int maxLength) {
+		if (!StringUtils.hasText(value)) {
+			return null;
+		}
+		String cleaned = value.trim();
+		if (cleaned.length() > maxLength) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "reflectionNote must be 500 characters or fewer.");
+		}
+		return cleaned;
+	}
+
+	private void requireUsableUser(UUID userId) {
+		try {
+			UserState user = jdbcTemplate.queryForObject(
+				"select status, onboarding_status from users where id = ?",
+				(rs, rowNumber) -> new UserState(rs.getString("status"), rs.getString("onboarding_status")),
+				userId
+			);
+			if (!Objects.equals(user.status(), "ACTIVE") || !Objects.equals(user.onboardingStatus(), "COMPLETED")) {
+				throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Reflection can be used only after onboarding.");
+			}
+		}
+		catch (EmptyResultDataAccessException exception) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User was not found.");
+		}
+	}
+
+	private DecisionSnapshot findGoDecision(UUID userId, UUID decisionId) {
+		try {
+			DecisionSnapshot decision = jdbcTemplate.queryForObject(
+				"""
+				select id, item_id, result
+				from purchase_decisions
+				where user_id = ?
+				  and id = ?
+				""",
+				(rs, rowNumber) -> new DecisionSnapshot(
+					rs.getObject("id", UUID.class),
+					rs.getObject("item_id", UUID.class),
+					rs.getString("result")
+				),
+				userId,
+				decisionId
+			);
+			if (!Objects.equals(decision.result(), "GO")) {
+				throw new ResponseStatusException(HttpStatus.CONFLICT, "Reflection can be created only for GO decisions.");
+			}
+			return decision;
+		}
+		catch (EmptyResultDataAccessException exception) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Purchase decision was not found.");
+		}
+	}
+
+	private boolean reflectionExists(UUID decisionId) {
+		Boolean exists = jdbcTemplate.queryForObject(
+			"select exists(select 1 from purchase_reflections where decision_id = ?)",
+			Boolean.class,
+			decisionId
+		);
+		return Boolean.TRUE.equals(exists);
+	}
+
+	private UUID findReminderId(UUID decisionId) {
+		return jdbcTemplate.query(
+				"""
+				select id
+				from reminder_schedules
+				where decision_id = ?
+				  and reminder_type = 'REGRET_CHECK_7_DAYS'
+				limit 1
+				""",
+				(rs, rowNumber) -> rs.getObject("id", UUID.class),
+				decisionId
+			)
+			.stream()
+			.findFirst()
+			.orElse(null);
+	}
+
+	private PurchaseReflectionResponse findById(UUID userId, UUID reflectionId) {
+		try {
+			return jdbcTemplate.queryForObject(
+				"""
+				select id, decision_id, item_id, reminder_id, satisfaction_score,
+				       regret_level, still_using, reflection_note, reflected_at
+				from purchase_reflections
+				where user_id = ?
+				  and id = ?
+				""",
+				this::mapReflection,
+				userId,
+				reflectionId
+			);
+		}
+		catch (EmptyResultDataAccessException exception) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Reflection was not found.");
+		}
+	}
+
+	private PurchaseReflectionResponse mapReflection(ResultSet rs, int rowNumber) throws SQLException {
+		int score = rs.getInt("satisfaction_score");
+		return new PurchaseReflectionResponse(
+			rs.getObject("id", UUID.class),
+			rs.getObject("decision_id", UUID.class),
+			rs.getObject("item_id", UUID.class),
+			rs.getObject("reminder_id", UUID.class),
+			rs.wasNull() ? null : score,
+			rs.getString("regret_level"),
+			rs.getObject("still_using", Boolean.class),
+			rs.getString("reflection_note"),
+			readInstant(rs, "reflected_at")
+		);
+	}
+
+	private Instant readInstant(ResultSet rs, String columnName) throws SQLException {
+		Timestamp timestamp = rs.getTimestamp(columnName);
+		return timestamp == null ? null : timestamp.toInstant();
+	}
+
+	private record NormalizedRequest(
+		UUID decisionId,
+		Integer satisfactionScore,
+		ReflectionRegretLevel regretLevel,
+		Boolean stillUsing,
+		String reflectionNote
+	) {
+	}
+
+	private record UserState(String status, String onboardingStatus) {
+	}
+
+	private record DecisionSnapshot(UUID decisionId, UUID itemId, String result) {
+	}
+}

--- a/src/test/java/com/sagongsa/backend/mvp/MvpBackendGapIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/mvp/MvpBackendGapIntegrationTest.java
@@ -1,0 +1,408 @@
+package com.sagongsa.backend.mvp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class MvpBackendGapIntegrationTest extends PostgreSqlContainerTest {
+
+	private static final String USER_ID_HEADER = "X-User-Id";
+	private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.execute("truncate table users cascade");
+	}
+
+	@Test
+	void returnsDeliberationSummaryForSavedItem() throws Exception {
+		UUID userId = createReadyUser();
+		String yearMonth = YearMonth.now(SEOUL_ZONE).toString();
+		insertBudgetCycle(userId, yearMonth, 500_000, 90_000);
+		insertHistoricalGoDecision(userId, "이전 패션", "FASHION", 20_000);
+		UUID itemId = insertSavedItem(userId, "새 패션", "FASHION", "SAVED", 15_000);
+
+		mockMvc.perform(get("/api/v1/deliberations/items/{itemId}", itemId)
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.item.id").value(itemId.toString()))
+			.andExpect(jsonPath("$.item.status").value("SAVED"))
+			.andExpect(jsonPath("$.budget.spentAmount").value(90_000))
+			.andExpect(jsonPath("$.budget.projectedSpentAmount").value(105_000))
+			.andExpect(jsonPath("$.budget.projectedUsageRate").value(21.00))
+			.andExpect(jsonPath("$.similarCategorySpendAmount").value(20_000))
+			.andExpect(jsonPath("$.opportunityCostMessage").value("15,000원을 다른 곳에 쓸 수도 있어요."));
+	}
+
+	@Test
+	void listsAndReadsNotifications() throws Exception {
+		UUID userId = createReadyUser();
+		UUID oldNotificationId = insertNotification(userId, "WISHLIST_REMINDER", "오래 고민 중", "아직 고민 중인 상품이 있어요.", false, 10);
+		UUID latestNotificationId = insertNotification(userId, "REGRET_CHECK_READY", "7일 후 확인", "지금도 잘 샀다고 생각하나요?", false, 20);
+		insertNotification(userId, "SOCIAL_VOTE", "투표", "투표가 달렸어요.", true, 30);
+
+		mockMvc.perform(get("/api/v1/notifications")
+				.header(USER_ID_HEADER, userId)
+				.param("unreadOnly", "true"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$[0].id").value(latestNotificationId.toString()))
+			.andExpect(jsonPath("$[1].id").value(oldNotificationId.toString()));
+
+		mockMvc.perform(patch("/api/v1/notifications/{notificationId}/read", latestNotificationId)
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id").value(latestNotificationId.toString()))
+			.andExpect(jsonPath("$.read").value(true));
+
+		assertThat(queryInteger("select count(*) from notifications where user_id = ? and is_read = false", userId))
+			.isEqualTo(1);
+	}
+
+	@Test
+	void createsReflectionOnlyForGoDecision() throws Exception {
+		UUID userId = createReadyUser();
+		UUID goItemId = insertSavedItem(userId, "산 상품", "BEAUTY", "GO", 30_000);
+		UUID goDecisionId = insertDecision(userId, goItemId, "GO", 30_000, "RATIONAL", 1, null);
+		UUID reminderId = insertReminder(userId, goItemId, goDecisionId, "SENT");
+		UUID stopItemId = insertSavedItem(userId, "참은 상품", "FOOD", "STOP", 12_000);
+		UUID stopDecisionId = insertDecision(userId, stopItemId, "STOP", 12_000, "IRRATIONAL", 3, null);
+
+		mockMvc.perform(post("/api/v1/reflections")
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"decisionId": "%s",
+					"satisfactionScore": 5,
+					"regretLevel": "NONE",
+					"stillUsing": true,
+					"reflectionNote": "잘 쓰고 있어요"
+				}
+				""".formatted(goDecisionId)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.decisionId").value(goDecisionId.toString()))
+			.andExpect(jsonPath("$.itemId").value(goItemId.toString()))
+			.andExpect(jsonPath("$.reminderId").value(reminderId.toString()))
+			.andExpect(jsonPath("$.regretLevel").value("NONE"));
+
+		mockMvc.perform(post("/api/v1/reflections")
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"decisionId": "%s",
+					"regretLevel": "LOW"
+				}
+				""".formatted(stopDecisionId)))
+			.andExpect(status().isConflict());
+	}
+
+	@Test
+	void updatesConsumptionRecordWithoutChangingMascotReaction() throws Exception {
+		UUID userId = createReadyUser();
+		String yearMonth = YearMonth.now(SEOUL_ZONE).toString();
+		UUID budgetCycleId = insertBudgetCycle(userId, yearMonth, 500_000, 100_000);
+		UUID itemId = insertSavedItem(userId, "수정할 상품", "FASHION", "GO", 40_000);
+		UUID decisionId = insertDecision(userId, itemId, "GO", 40_000, "RATIONAL", 1, budgetCycleId);
+		insertSelfCheck(decisionId, 1, "RATIONAL", true, false, false, false);
+		insertMascotEvent(userId, itemId, decisionId);
+		insertReminder(userId, itemId, decisionId, "SCHEDULED");
+
+		mockMvc.perform(patch("/api/v1/decisions/{decisionId}/result", decisionId)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"result": "STOP",
+					"changeReason": "환불했어요",
+					"selfCheckAnswers": [
+						{"questionCode": "NEED", "answerBoolean": true},
+						{"questionCode": "BUDGET", "answerBoolean": true},
+						{"questionCode": "ALTERNATIVE", "answerBoolean": true},
+						{"questionCode": "DELAY", "answerBoolean": false}
+					]
+				}
+				"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.itemStatus").value("STOP"))
+			.andExpect(jsonPath("$.result").value("STOP"))
+			.andExpect(jsonPath("$.budgetAfterAmount").value(60_000))
+			.andExpect(jsonPath("$.selfCheckYesCount").value(3))
+			.andExpect(jsonPath("$.rationalityResult").value("IRRATIONAL"))
+			.andExpect(jsonPath("$.reminder.status").value("CANCELED"))
+			.andExpect(jsonPath("$.mascot.state").value("SMILE"));
+
+		assertThat(queryString("select status from saved_items where id = ?", itemId)).isEqualTo("STOP");
+		assertThat(queryInteger("select spent_amount from budget_cycles where id = ?", budgetCycleId)).isEqualTo(60_000);
+		assertThat(queryInteger("select change_count from purchase_decisions where id = ?", decisionId)).isEqualTo(1);
+		assertThat(queryInteger("select count(*) from purchase_decision_change_logs where decision_id = ?", decisionId)).isEqualTo(1);
+		assertThat(queryString("select status from reminder_schedules where decision_id = ?", decisionId)).isEqualTo("CANCELED");
+		assertThat(queryInteger("select count(*) from mascot_state_events where decision_id = ?", decisionId)).isEqualTo(1);
+	}
+
+	private UUID createReadyUser() {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into users (id, status, onboarding_status, created_at, updated_at)
+			values (?, 'ACTIVE', 'COMPLETED', ?, ?)
+			""",
+			userId,
+			now,
+			now
+		);
+		jdbcTemplate.update(
+			"""
+			insert into user_profiles (user_id, nickname, mascot_name, timezone, created_at, updated_at)
+			values (?, 'tester', '너굴', 'Asia/Seoul', ?, ?)
+			""",
+			userId,
+			now,
+			now
+		);
+		jdbcTemplate.update(
+			"""
+			insert into mascot_profiles (user_id, mascot_state, last_state_changed_at, updated_at)
+			values (?, 'DEFAULT', ?, ?)
+			""",
+			userId,
+			now,
+			now
+		);
+		return userId;
+	}
+
+	private UUID insertBudgetCycle(UUID userId, String yearMonth, int monthlyBudgetAmount, int spentAmount) {
+		UUID budgetCycleId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into budget_cycles (
+				id, user_id, year_month, monthly_budget_amount, spent_amount,
+				warning_threshold_rate, created_at, updated_at
+			)
+			values (?, ?, ?, ?, ?, 80.00, ?, ?)
+			""",
+			budgetCycleId,
+			userId,
+			yearMonth,
+			monthlyBudgetAmount,
+			spentAmount,
+			now,
+			now
+		);
+		return budgetCycleId;
+	}
+
+	private UUID insertSavedItem(UUID userId, String title, String category, String status, int listedPrice) {
+		UUID itemId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into saved_items (
+				id, user_id, input_source, title, listed_price, currency_code,
+				category, category_locked_by_user, status, created_at, updated_at
+			)
+			values (?, ?, 'DIRECT_INPUT', ?, ?, 'KRW', ?, false, ?, ?, ?)
+			""",
+			itemId,
+			userId,
+			title,
+			listedPrice,
+			category,
+			status,
+			now,
+			now
+		);
+		return itemId;
+	}
+
+	private void insertHistoricalGoDecision(UUID userId, String title, String category, int finalPrice) {
+		UUID itemId = insertSavedItem(userId, title, category, "GO", finalPrice);
+		insertDecision(userId, itemId, "GO", finalPrice, "RATIONAL", 0, null);
+	}
+
+	private UUID insertDecision(
+		UUID userId,
+		UUID itemId,
+		String result,
+		int finalPrice,
+		String rationalityResult,
+		int yesCount,
+		UUID budgetCycleId
+	) {
+		UUID decisionId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);
+		jdbcTemplate.update(
+			"""
+			insert into purchase_decisions (
+				id, user_id, item_id, budget_cycle_id, result, final_price,
+				budget_after_amount, similar_category_spend_amount, rationality_result,
+				self_check_yes_count, decided_at, created_at, updated_at
+			)
+			values (?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?)
+			""",
+			decisionId,
+			userId,
+			itemId,
+			budgetCycleId,
+			result,
+			finalPrice,
+			result.equals("GO") ? finalPrice : 0,
+			rationalityResult,
+			yesCount,
+			now,
+			now,
+			now
+		);
+		return decisionId;
+	}
+
+	private void insertSelfCheck(UUID decisionId, int yesCount, String rationalityResult, boolean first, boolean second, boolean third, boolean fourth) {
+		UUID responseSetId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);
+		jdbcTemplate.update(
+			"""
+			insert into self_check_response_sets (
+				id, decision_id, yes_count, rationality_result, submitted_at, created_at, updated_at
+			)
+			values (?, ?, ?, ?, ?, ?, ?)
+			""",
+			responseSetId,
+			decisionId,
+			yesCount,
+			rationalityResult,
+			now,
+			now,
+			now
+		);
+		insertSelfCheckAnswer(responseSetId, "NEED", first);
+		insertSelfCheckAnswer(responseSetId, "BUDGET", second);
+		insertSelfCheckAnswer(responseSetId, "ALTERNATIVE", third);
+		insertSelfCheckAnswer(responseSetId, "DELAY", fourth);
+	}
+
+	private void insertSelfCheckAnswer(UUID responseSetId, String questionCode, boolean answerBoolean) {
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);
+		jdbcTemplate.update(
+			"""
+			insert into self_check_answers (
+				id, response_set_id, question_code, answer_boolean, created_at, updated_at
+			)
+			values (?, ?, ?, ?, ?, ?)
+			""",
+			UUID.randomUUID(),
+			responseSetId,
+			questionCode,
+			answerBoolean,
+			now,
+			now
+		);
+	}
+
+	private UUID insertReminder(UUID userId, UUID itemId, UUID decisionId, String status) {
+		UUID reminderId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);
+		OffsetDateTime scheduledFor = now.plusDays(7);
+		OffsetDateTime sentAt = status.equals("SENT") ? now : null;
+		OffsetDateTime canceledAt = status.equals("CANCELED") ? now : null;
+		jdbcTemplate.update(
+			"""
+			insert into reminder_schedules (
+				id, user_id, item_id, decision_id, reminder_type, scheduled_for,
+				status, sent_at, canceled_at, created_at, updated_at
+			)
+			values (?, ?, ?, ?, 'REGRET_CHECK_7_DAYS', ?, ?, ?, ?, ?, ?)
+			""",
+			reminderId,
+			userId,
+			itemId,
+			decisionId,
+			scheduledFor,
+			status,
+			sentAt,
+			canceledAt,
+			now,
+			now
+		);
+		return reminderId;
+	}
+
+	private void insertMascotEvent(UUID userId, UUID itemId, UUID decisionId) {
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);
+		jdbcTemplate.update(
+			"""
+			insert into mascot_state_events (
+				id, user_id, item_id, decision_id, event_type, previous_state,
+				new_state, reaction_message, created_at, updated_at
+			)
+			values (?, ?, ?, ?, 'DECISION_REACTION', 'DEFAULT', 'SMILE', '합리적으로 잘 결정했어요', ?, ?)
+			""",
+			UUID.randomUUID(),
+			userId,
+			itemId,
+			decisionId,
+			now,
+			now
+		);
+	}
+
+	private UUID insertNotification(UUID userId, String type, String title, String body, boolean read, int secondsOffset) {
+		UUID notificationId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).plusSeconds(secondsOffset);
+		jdbcTemplate.update(
+			"""
+			insert into notifications (
+				id, user_id, notification_type, title, body, target_path,
+				is_read, read_at, created_at, updated_at
+			)
+			values (?, ?, ?, ?, ?, '/target', ?, ?, ?, ?)
+			""",
+			notificationId,
+			userId,
+			type,
+			title,
+			body,
+			read,
+			read ? now : null,
+			now,
+			now
+		);
+		return notificationId;
+	}
+
+	private String queryString(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(sql, String.class, args);
+	}
+
+	private Integer queryInteger(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(sql, Integer.class, args);
+	}
+}


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-24`
- Jira: 없음
- GitHub: Related #22
- GitHub: Closes #22

> PR 제목: `NF-24 MVP 담당 범위 백엔드 보완 API 구현`
> 브랜치: `feat/NF-24-mvp-backend-gaps`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #22의 1/1 단계
- 선행 PR: develop에 병합된 도메인/스키마, 온보딩, 홈, 위시, 결정 결과 API
- 후속 PR: 실제 푸시 발송 워커, 소셜 피드 API, 마이페이지 상세 API는 별도 이슈에서 진행

### 이 PR에서 변경한 것
- 숙려 화면에서 사용할 상품/예산 시뮬레이션/동일 카테고리 소비 요약 API를 추가했습니다.
- 알림 목록 조회와 읽음 처리 API를 추가했습니다.
- 7일 후 후회 여부 응답을 저장하는 구매 회고 API를 추가했습니다.
- 마이페이지 소비기록에서 GO/STOP 재결정 시 예산, 위시 상태, 셀프체크 결과, 7일 후 알림 예약 상태, 변경 이력을 함께 갱신하도록 추가했습니다.
- 재결정은 기획 문서대로 너굴 반응을 새로 만들지 않고, 소비기록 변경 이력만 남기도록 했습니다.

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
- AC1: 구매 숙려 화면 진입용 요약 API가 저장 상품, 현재 예산, 구매 시 예상 예산, 동일 카테고리 소비 금액을 반환한다.
- AC2: 알림 목록 조회와 읽음 처리가 가능하다.
- AC3: GO 결정 건에 한해 7일 후 후회 응답을 purchase_reflections에 저장한다.
- AC4: 소비기록에서 GO/STOP 재결정 시 예산 금액과 reminder_schedules 상태가 함께 바뀐다.
- AC5: 재결정 시 mascot_state_events를 새로 만들지 않고 purchase_decision_change_logs에 변경 이력을 남긴다.

### Not covered (후속 작업)
- 실제 푸시 발송 워커: 발송 인프라와 스케줄러 정책이 필요해서 별도 작업으로 둡니다.
- 소셜 피드 API: 이번 PR은 사용자 담당 범위인 온보딩/홈/상품저장/결과처리 보완에 집중합니다.
- 관리자/신고/가격 변동 추적: MVP 후속 범위입니다.

---

## 🧪 테스트 결과 (필수)
### 로컬
```
./gradlew test
```
- ✅ 결과: 성공

### CI
- (자동 첨부)

### Smoke 테스트
- 시나리오: 숙려 요약 조회, 알림 목록/읽음 처리, 후회 응답 저장, GO→STOP 재결정 시 예산 차감/알림 취소/변경 로그 저장/너굴 반응 미생성
- 결과: ✅ 통합 테스트로 검증

---

## 🧭 영향 범위 체크 (필수)
- [x] API 변경 (요약: 숙려 요약, 알림 목록/읽음, 구매 회고, 소비기록 재결정 API 추가)
- [ ] DB 변경 (마이그레이션: 없음. 기존 NF-12 스키마 사용)
- [ ] 설정 변경 (항목: 없음)
- [ ] Breaking change (무엇: 없음)

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인: `DecisionService.updateResult`, `DeliberationService`, `NotificationService`, `PurchaseReflectionService`
- 트레이드오프/대안: 새 테이블을 추가하지 않고 기존 도메인 스키마를 그대로 사용했습니다. 실제 푸시 발송은 예약/응답 저장과 분리해 후속 작업으로 남겼습니다.