### PR TITLE
NF-25 7일 후 알림 발송 워커 구현

### DIFF
--- a/src/main/java/com/sagongsa/backend/SagongsaBackendApplication.java
+++ b/src/main/java/com/sagongsa/backend/SagongsaBackendApplication.java
@@ -2,7 +2,9 @@ package com.sagongsa.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class SagongsaBackendApplication {
 

--- a/src/main/java/com/sagongsa/backend/notification/ReminderNotificationWorker.java
+++ b/src/main/java/com/sagongsa/backend/notification/ReminderNotificationWorker.java
@@ -1,0 +1,199 @@
+package com.sagongsa.backend.notification;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Service
+public class ReminderNotificationWorker {
+
+	private static final int BATCH_SIZE = 50;
+
+	private final JdbcTemplate jdbcTemplate;
+	private final TransactionTemplate transactionTemplate;
+
+	public ReminderNotificationWorker(JdbcTemplate jdbcTemplate, TransactionTemplate transactionTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+		this.transactionTemplate = transactionTemplate;
+	}
+
+	@Scheduled(fixedDelayString = "${app.notification.reminder-worker.fixed-delay-ms:60000}")
+	public void runScheduled() {
+		processDueReminders();
+	}
+
+	public int processDueReminders() {
+		List<UUID> reminderIds = findDueReminderIds();
+		int processedCount = 0;
+		for (UUID reminderId : reminderIds) {
+			if (processReminder(reminderId)) {
+				processedCount++;
+			}
+		}
+		return processedCount;
+	}
+
+	private List<UUID> findDueReminderIds() {
+		return jdbcTemplate.query(
+			"""
+			select id
+			from reminder_schedules
+			where reminder_type = 'REGRET_CHECK_7_DAYS'
+			  and status = 'SCHEDULED'
+			  and scheduled_for <= ?
+			order by scheduled_for asc, id asc
+			limit ?
+			""",
+			(rs, rowNumber) -> rs.getObject("id", UUID.class),
+			OffsetDateTime.now(ZoneOffset.UTC),
+			BATCH_SIZE
+		);
+	}
+
+	private boolean processReminder(UUID reminderId) {
+		try {
+			Boolean processed = transactionTemplate.execute(status -> processReminderInTransaction(reminderId));
+			return Boolean.TRUE.equals(processed);
+		}
+		catch (RuntimeException exception) {
+			markFailed(reminderId);
+			return false;
+		}
+	}
+
+	private boolean processReminderInTransaction(UUID reminderId) {
+		ReminderTarget target = lockReminderTarget(reminderId);
+		if (target == null || !"SCHEDULED".equals(target.status())) {
+			return false;
+		}
+		if (!notificationExists(target.reminderId())) {
+			insertNotification(target);
+		}
+		markSent(target.reminderId());
+		return true;
+	}
+
+	private ReminderTarget lockReminderTarget(UUID reminderId) {
+		return jdbcTemplate.query(
+				"""
+				select
+					rs.id as reminder_id,
+					rs.user_id,
+					rs.item_id,
+					rs.decision_id,
+					rs.status,
+					si.title as item_title
+				from reminder_schedules rs
+				join purchase_decisions pd on pd.id = rs.decision_id
+				join saved_items si on si.id = rs.item_id
+				where rs.id = ?
+				  and rs.reminder_type = 'REGRET_CHECK_7_DAYS'
+				for update of rs
+				""",
+				this::mapReminderTarget,
+				reminderId
+			)
+			.stream()
+			.findFirst()
+			.orElse(null);
+	}
+
+	private boolean notificationExists(UUID reminderId) {
+		Boolean exists = jdbcTemplate.queryForObject(
+			"""
+			select exists(
+				select 1
+				from notifications
+				where reminder_id = ?
+				  and notification_type = 'REGRET_CHECK_READY'
+			)
+			""",
+			Boolean.class,
+			reminderId
+		);
+		return Boolean.TRUE.equals(exists);
+	}
+
+	private void insertNotification(ReminderTarget target) {
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into notifications (
+				id, user_id, notification_type, title, body,
+				item_id, decision_id, reminder_id, target_path,
+				is_read, created_at, updated_at
+			)
+			values (?, ?, 'REGRET_CHECK_READY', ?, ?, ?, ?, ?, ?, false, ?, ?)
+			""",
+			UUID.randomUUID(),
+			target.userId(),
+			"구매 후 7일이 지났어요",
+			"[%s] 지금도 잘 샀다고 생각하나요?".formatted(target.itemTitle()),
+			target.itemId(),
+			target.decisionId(),
+			target.reminderId(),
+			"/reflections?decisionId=" + target.decisionId(),
+			now,
+			now
+		);
+	}
+
+	private void markSent(UUID reminderId) {
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			update reminder_schedules
+			set status = 'SENT',
+				sent_at = ?,
+				updated_at = ?
+			where id = ?
+			  and status = 'SCHEDULED'
+			""",
+			now,
+			now,
+			reminderId
+		);
+	}
+
+	private void markFailed(UUID reminderId) {
+		transactionTemplate.executeWithoutResult(status -> jdbcTemplate.update(
+			"""
+			update reminder_schedules
+			set status = 'FAILED',
+				updated_at = ?
+			where id = ?
+			  and status = 'SCHEDULED'
+			""",
+			OffsetDateTime.now(ZoneOffset.UTC),
+			reminderId
+		));
+	}
+
+	private ReminderTarget mapReminderTarget(ResultSet rs, int rowNumber) throws SQLException {
+		return new ReminderTarget(
+			rs.getObject("reminder_id", UUID.class),
+			rs.getObject("user_id", UUID.class),
+			rs.getObject("item_id", UUID.class),
+			rs.getObject("decision_id", UUID.class),
+			rs.getString("status"),
+			rs.getString("item_title")
+		);
+	}
+
+	private record ReminderTarget(
+		UUID reminderId,
+		UUID userId,
+		UUID itemId,
+		UUID decisionId,
+		String status,
+		String itemTitle
+	) {
+	}
+}

--- a/src/test/java/com/sagongsa/backend/notification/ReminderNotificationWorkerIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/notification/ReminderNotificationWorkerIntegrationTest.java
@@ -1,0 +1,192 @@
+package com.sagongsa.backend.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@SpringBootTest
+class ReminderNotificationWorkerIntegrationTest extends PostgreSqlContainerTest {
+
+	@Autowired
+	private ReminderNotificationWorker reminderNotificationWorker;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.execute("truncate table users cascade");
+	}
+
+	@Test
+	void createsNotificationAndMarksDueReminderSent() {
+		UUID userId = createReadyUser();
+		UUID itemId = insertSavedItem(userId, "만족도 확인 상품", "GO");
+		UUID decisionId = insertDecision(userId, itemId, "GO");
+		UUID reminderId = insertReminder(userId, itemId, decisionId, "SCHEDULED", OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(1));
+
+		int processedCount = reminderNotificationWorker.processDueReminders();
+
+		assertThat(processedCount).isEqualTo(1);
+		assertThat(queryString("select status from reminder_schedules where id = ?", reminderId)).isEqualTo("SENT");
+		assertThat(queryInteger("select count(*) from notifications where reminder_id = ?", reminderId)).isEqualTo(1);
+		assertThat(queryString("select notification_type from notifications where reminder_id = ?", reminderId)).isEqualTo("REGRET_CHECK_READY");
+		assertThat(queryString("select target_path from notifications where reminder_id = ?", reminderId))
+			.isEqualTo("/reflections?decisionId=" + decisionId);
+	}
+
+	@Test
+	void doesNotCreateDuplicateNotificationForSameReminder() {
+		UUID userId = createReadyUser();
+		UUID itemId = insertSavedItem(userId, "중복 방지 상품", "GO");
+		UUID decisionId = insertDecision(userId, itemId, "GO");
+		UUID reminderId = insertReminder(userId, itemId, decisionId, "SCHEDULED", OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(1));
+		insertNotification(userId, itemId, decisionId, reminderId);
+
+		int processedCount = reminderNotificationWorker.processDueReminders();
+
+		assertThat(processedCount).isEqualTo(1);
+		assertThat(queryString("select status from reminder_schedules where id = ?", reminderId)).isEqualTo("SENT");
+		assertThat(queryInteger("select count(*) from notifications where reminder_id = ?", reminderId)).isEqualTo(1);
+	}
+
+	@Test
+	void ignoresFutureAndCanceledReminders() {
+		UUID userId = createReadyUser();
+		UUID futureItemId = insertSavedItem(userId, "미래 알림 상품", "GO");
+		UUID futureDecisionId = insertDecision(userId, futureItemId, "GO");
+		UUID canceledItemId = insertSavedItem(userId, "취소 알림 상품", "GO");
+		UUID canceledDecisionId = insertDecision(userId, canceledItemId, "GO");
+		UUID futureReminderId = insertReminder(userId, futureItemId, futureDecisionId, "SCHEDULED", OffsetDateTime.now(ZoneOffset.UTC).plusDays(1));
+		UUID canceledReminderId = insertReminder(userId, canceledItemId, canceledDecisionId, "CANCELED", OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(1));
+
+		int processedCount = reminderNotificationWorker.processDueReminders();
+
+		assertThat(processedCount).isZero();
+		assertThat(queryString("select status from reminder_schedules where id = ?", futureReminderId)).isEqualTo("SCHEDULED");
+		assertThat(queryString("select status from reminder_schedules where id = ?", canceledReminderId)).isEqualTo("CANCELED");
+		assertThat(queryInteger("select count(*) from notifications where user_id = ?", userId)).isZero();
+	}
+
+	private UUID createReadyUser() {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into users (id, status, onboarding_status, created_at, updated_at)
+			values (?, 'ACTIVE', 'COMPLETED', ?, ?)
+			""",
+			userId,
+			now,
+			now
+		);
+		return userId;
+	}
+
+	private UUID insertSavedItem(UUID userId, String title, String status) {
+		UUID itemId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into saved_items (
+				id, user_id, input_source, title, listed_price, currency_code,
+				category, category_locked_by_user, status, created_at, updated_at
+			)
+			values (?, ?, 'DIRECT_INPUT', ?, 30000, 'KRW', 'BEAUTY', false, ?, ?, ?)
+			""",
+			itemId,
+			userId,
+			title,
+			status,
+			now,
+			now
+		);
+		return itemId;
+	}
+
+	private UUID insertDecision(UUID userId, UUID itemId, String result) {
+		UUID decisionId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusDays(7);
+		jdbcTemplate.update(
+			"""
+			insert into purchase_decisions (
+				id, user_id, item_id, result, final_price, budget_after_amount,
+				similar_category_spend_amount, rationality_result, self_check_yes_count,
+				decided_at, created_at, updated_at
+			)
+			values (?, ?, ?, ?, 30000, 30000, 0, 'RATIONAL', 1, ?, ?, ?)
+			""",
+			decisionId,
+			userId,
+			itemId,
+			result,
+			now,
+			now,
+			now
+		);
+		return decisionId;
+	}
+
+	private UUID insertReminder(UUID userId, UUID itemId, UUID decisionId, String status, OffsetDateTime scheduledFor) {
+		UUID reminderId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		OffsetDateTime sentAt = status.equals("SENT") ? now : null;
+		OffsetDateTime canceledAt = status.equals("CANCELED") ? now : null;
+		jdbcTemplate.update(
+			"""
+			insert into reminder_schedules (
+				id, user_id, item_id, decision_id, reminder_type, scheduled_for,
+				status, sent_at, canceled_at, created_at, updated_at
+			)
+			values (?, ?, ?, ?, 'REGRET_CHECK_7_DAYS', ?, ?, ?, ?, ?, ?)
+			""",
+			reminderId,
+			userId,
+			itemId,
+			decisionId,
+			scheduledFor,
+			status,
+			sentAt,
+			canceledAt,
+			now,
+			now
+		);
+		return reminderId;
+	}
+
+	private void insertNotification(UUID userId, UUID itemId, UUID decisionId, UUID reminderId) {
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into notifications (
+				id, user_id, notification_type, title, body, item_id,
+				decision_id, reminder_id, target_path, is_read, created_at, updated_at
+			)
+			values (?, ?, 'REGRET_CHECK_READY', '이미 생성됨', '이미 생성됨', ?, ?, ?, '/reflections', false, ?, ?)
+			""",
+			UUID.randomUUID(),
+			userId,
+			itemId,
+			decisionId,
+			reminderId,
+			now,
+			now
+		);
+	}
+
+	private String queryString(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(sql, String.class, args);
+	}
+
+	private Integer queryInteger(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(sql, Integer.class, args);
+	}
+}


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-25`
- Jira: 없음
- GitHub: Related #24
- GitHub: Closes #24

> PR 제목: `NF-25 7일 후 알림 발송 워커 구현`
> 브랜치: `feat/NF-25-reminder-notification-worker`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #24의 1/1 단계
- 선행 PR: #23 머지 완료
- 후속 PR: 실제 FCM/APNs 기기 푸시 연동은 별도 작업

### 이 PR에서 변경한 것
- Spring Scheduling을 활성화했습니다.
- `REGRET_CHECK_7_DAYS` reminder 중 `SCHEDULED` 상태이고 발송 시간이 지난 건을 주기적으로 처리하는 워커를 추가했습니다.
- 처리 대상 reminder에 대해 `REGRET_CHECK_READY` 인앱 알림을 생성하고 reminder 상태를 `SENT`로 바꿉니다.
- 이미 생성된 알림이 있으면 중복 생성하지 않고 reminder만 `SENT` 처리합니다.
- 처리 중 예외가 발생한 reminder는 `FAILED`로 바꾸도록 했습니다.

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
- AC1: `SCHEDULED` + `scheduled_for <= now()`인 7일 후 reminder를 주기적으로 처리한다.
- AC2: decision/item 정보를 바탕으로 `REGRET_CHECK_READY` notification을 생성한다.
- AC3: notification에 `item_id`, `decision_id`, `reminder_id`, `target_path`를 포함한다.
- AC4: 정상 처리된 reminder를 `SENT`로 갱신한다.
- AC5: 같은 reminder에 대해 notification을 중복 생성하지 않는다.
- AC6: 미래 reminder와 취소 reminder는 처리하지 않는다.

### Not covered (후속 작업)
- 실제 FCM/APNs 기기 푸시 발송: 앱 푸시 설정과 토큰 정책 확정 후 별도 작업으로 진행합니다.
- 실패 건 재시도/backoff 정책: 운영 정책이 필요해서 후속으로 둡니다.

---

## 🧪 테스트 결과 (필수)
### 로컬
```
./gradlew test
```
- ✅ 결과: 성공

### CI
- (자동 첨부)

### Smoke 테스트
- 시나리오: 도래한 7일 후 reminder 처리, notification 생성, reminder SENT 처리, 중복 방지, 미래/취소 reminder 제외
- 결과: ✅ Testcontainers 통합 테스트로 검증

---

## 🧭 영향 범위 체크 (필수)
- [x] API 변경 (요약: 없음. 백그라운드 워커 추가)
- [ ] DB 변경 (마이그레이션: 없음)
- [x] 설정 변경 (항목: `app.notification.reminder-worker.fixed-delay-ms`로 실행 주기 조정 가능, 기본 60000ms)
- [ ] Breaking change (무엇: 없음)

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인: `ReminderNotificationWorker`
- 트레이드오프/대안: 실제 기기 푸시 전 단계로 인앱 알림 발행과 상태 갱신을 먼저 닫았습니다. FCM/APNs 연동은 앱 토큰 정책이 안정된 뒤 붙이는 편이 안전합니다.