### PR TITLE
[feat] 마이페이지 API 구현

### DIFF
--- a/src/main/java/com/sagongsa/backend/deliberation/DeliberationService.java
+++ b/src/main/java/com/sagongsa/backend/deliberation/DeliberationService.java
@@ -2,6 +2,7 @@ package com.sagongsa.backend.deliberation;
 
 import com.sagongsa.backend.deliberation.DeliberationSummaryResponse.BudgetProjection;
 import com.sagongsa.backend.deliberation.DeliberationSummaryResponse.ItemSummary;
+import com.sagongsa.backend.deliberation.DeliberationSummaryResponse.SelfCheckQuestion;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.sql.ResultSet;
@@ -9,6 +10,7 @@ import java.sql.SQLException;
 import java.time.DateTimeException;
 import java.time.YearMonth;
 import java.time.ZoneId;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -21,6 +23,13 @@ import org.springframework.web.server.ResponseStatusException;
 public class DeliberationService {
 
 	private static final ZoneId DEFAULT_ZONE_ID = ZoneId.of("Asia/Seoul");
+
+	static final List<SelfCheckQuestion> SELF_CHECK_QUESTIONS = List.of(
+		new SelfCheckQuestion("Q1", "오늘 갑자기 갖고 싶어진 건가요?"),
+		new SelfCheckQuestion("Q2", "비슷한 물건을 이미 갖고 있나요?"),
+		new SelfCheckQuestion("Q3", "구매하지 않아도 일상생활에 불편함이 없나요?"),
+		new SelfCheckQuestion("Q4", "한 달 뒤에는 필요하지 않을 것 같나요?")
+	);
 
 	private final JdbcTemplate jdbcTemplate;
 
@@ -48,7 +57,8 @@ public class DeliberationService {
 				projectedUsageRate
 			),
 			similarCategorySpendAmount(userId, item.category(), yearMonth, zoneId),
-			opportunityCostMessage(item)
+			opportunityCostMessage(item),
+			SELF_CHECK_QUESTIONS
 		);
 	}
 

--- a/src/main/java/com/sagongsa/backend/deliberation/DeliberationSummaryResponse.java
+++ b/src/main/java/com/sagongsa/backend/deliberation/DeliberationSummaryResponse.java
@@ -1,13 +1,15 @@
 package com.sagongsa.backend.deliberation;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
 
 public record DeliberationSummaryResponse(
 	ItemSummary item,
 	BudgetProjection budget,
 	int similarCategorySpendAmount,
-	String opportunityCostMessage
+	String opportunityCostMessage,
+	List<SelfCheckQuestion> questions
 ) {
 
 	public record ItemSummary(
@@ -27,6 +29,12 @@ public record DeliberationSummaryResponse(
 		int spentAmount,
 		int projectedSpentAmount,
 		BigDecimal projectedUsageRate
+	) {
+	}
+
+	public record SelfCheckQuestion(
+		String code,
+		String text
 	) {
 	}
 }


### PR DESCRIPTION
 ## 🔗 작업 키 / 이슈 링크                                 
  - Tracking Key: -
  - GitHub: Related -                                        
  - GitHub: Related #34 
                                                                                     
  ---                                                       

  ## 🧩 이 PR의 변경사항

  ### 전체 중 위치
  - 전체 이슈 #이슈번호의 4/5 단계
  - 선행 PR: #34 (feat/3-wish-deliberation, 머지 필요)                          
  - 후속 PR: #36(PR 5 — DevController / 정적 화면)
                                                                                     
  ### 이 PR에서 변경한 것                                   
  - `UserAccount`: `withdraw()` 메서드 추가                                          
  - `UserProfile`: getter / factory method / `updateProfile` / `notificationEnabled` 
  필드 추가                                                                          
  - `BudgetCycle`: getter / factory method / `updateBudgetAmount` 추가               
  - `SavedItem`: getter 추가                                                         
  - `UserProfileRepository`, `BudgetCycleRepository`, `SavedItemRepository` 신규 추가
  - `SocialAccountRepository`: `findByUserId` 추가                                   
  - `mypage/` 패키지 신규: `MypageController`, `MypageService`, DTO 7개
                                                                                     
  ---                                                       
                                                                                     
  ## ✅ AC  

  ### Covers
  - AC1: 내 프로필 조회 / 닉네임·너구리 이름 수정
  - AC2: 월 예산 설정                                                                
  - AC3: 알림 수신 설정 조회 / 변경
  - AC4: 계정 탈퇴 (관련 데이터 일괄 삭제)                                           
  - AC5: 소비 기록 있는 월 목록 조회                                                 
  - AC6: 월별 소비 통계 (예산 / 지출 / 절제 금액, 사용률)                            
  - AC7: 소비/절제 기록 목록 (상태/월 필터)                                          
  - AC8: 내가 작성한 게시글 / 내가 투표한 게시글 (커서 페이징)                       
                                                                                     
  ### Not covered                                                                    
  - 카테고리별 통계 (`byCategory`): 빈 배열로 응답 → 후속 이슈로 분리 필요           
  - 프로필 이미지 직접 업로드: 범위 외                                               
                                                                                     
  ---                                                                                
                                                                                     
  ## 🧪 테스트 결과                                         

  ### 로컬
  - ✅ `./gradlew compileJava` 통과

  ### Smoke 테스트                                                                   
  - 시나리오: 로그인 → `GET /api/v1/users/me` → 예산 설정 → 통계 조회
  - 결과: 직접 확인 필요                                                             
                                                            
  ---                                                                                
                                                            
  ## 🧭 영향 범위 체크
  - [x] API 변경 (요약: `/api/v1/users/me` 신규 엔드포인트 11개)
  - [x] DB 변경 (마이그레이션: `user_profiles.notification_enabled` 컬럼 추가 필요)  
  - [ ] 설정 변경                                                                    
  - [ ] Breaking change                                                              
                                                                                     
  ---                                                       

  ## 💬 리뷰 포인트
  - `deleteAccount()` — 삭제 순서 확인 (FK 제약으로 인한 순서 의존성)
  - `UserProfile.notificationEnabled` 필드가 기존 DB 스키마에 없음 → **마이그레이션  
  추가 필요**                                                                        
  - `getStats()`의 `byCategory` 필드가 빈 배열로 반환됨 — 프론트와 빈 배열 처리 합의 
  필요