### PR TITLE
[feat] 마이페이지 API 구현

### DIFF
--- a/src/main/java/com/sagongsa/backend/deliberation/DeliberationService.java
+++ b/src/main/java/com/sagongsa/backend/deliberation/DeliberationService.java
@@ -2,6 +2,7 @@ package com.sagongsa.backend.deliberation;
 
 import com.sagongsa.backend.deliberation.DeliberationSummaryResponse.BudgetProjection;
 import com.sagongsa.backend.deliberation.DeliberationSummaryResponse.ItemSummary;
+import com.sagongsa.backend.deliberation.DeliberationSummaryResponse.SelfCheckQuestion;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.sql.ResultSet;
@@ -9,6 +10,7 @@ import java.sql.SQLException;
 import java.time.DateTimeException;
 import java.time.YearMonth;
 import java.time.ZoneId;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -21,6 +23,13 @@ import org.springframework.web.server.ResponseStatusException;
 public class DeliberationService {
 
 	private static final ZoneId DEFAULT_ZONE_ID = ZoneId.of("Asia/Seoul");
+
+	static final List<SelfCheckQuestion> SELF_CHECK_QUESTIONS = List.of(
+		new SelfCheckQuestion("Q1", "오늘 갑자기 갖고 싶어진 건가요?"),
+		new SelfCheckQuestion("Q2", "비슷한 물건을 이미 갖고 있나요?"),
+		new SelfCheckQuestion("Q3", "구매하지 않아도 일상생활에 불편함이 없나요?"),
+		new SelfCheckQuestion("Q4", "한 달 뒤에는 필요하지 않을 것 같나요?")
+	);
 
 	private final JdbcTemplate jdbcTemplate;
 
@@ -48,7 +57,8 @@ public class DeliberationService {
 				projectedUsageRate
 			),
 			similarCategorySpendAmount(userId, item.category(), yearMonth, zoneId),
-			opportunityCostMessage(item)
+			opportunityCostMessage(item),
+			SELF_CHECK_QUESTIONS
 		);
 	}
 

--- a/src/main/java/com/sagongsa/backend/deliberation/DeliberationSummaryResponse.java
+++ b/src/main/java/com/sagongsa/backend/deliberation/DeliberationSummaryResponse.java
@@ -1,13 +1,15 @@
 package com.sagongsa.backend.deliberation;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
 
 public record DeliberationSummaryResponse(
 	ItemSummary item,
 	BudgetProjection budget,
 	int similarCategorySpendAmount,
-	String opportunityCostMessage
+	String opportunityCostMessage,
+	List<SelfCheckQuestion> questions
 ) {
 
 	public record ItemSummary(
@@ -27,6 +29,12 @@ public record DeliberationSummaryResponse(
 		int spentAmount,
 		int projectedSpentAmount,
 		BigDecimal projectedUsageRate
+	) {
+	}
+
+	public record SelfCheckQuestion(
+		String code,
+		String text
 	) {
 	}
 }

--- a/src/main/java/com/sagongsa/backend/dev/DevController.java
+++ b/src/main/java/com/sagongsa/backend/dev/DevController.java
@@ -1,0 +1,60 @@
+package com.sagongsa.backend.dev;
+
+import com.sagongsa.backend.auth.CurrentUserId;
+import com.sagongsa.backend.domain.auth.UserAccount;
+import com.sagongsa.backend.domain.auth.UserAccountRepository;
+import com.sagongsa.backend.domain.enums.ItemCategory;
+import com.sagongsa.backend.domain.enums.ItemInputSource;
+import com.sagongsa.backend.domain.item.SavedItem;
+import com.sagongsa.backend.domain.item.SavedItemRepository;
+import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/dev")
+@Profile("!prod")
+public class DevController {
+
+	private final UserAccountRepository userAccountRepository;
+	private final SavedItemRepository savedItemRepository;
+	private final EntityManager em;
+
+	public DevController(UserAccountRepository userAccountRepository,
+		SavedItemRepository savedItemRepository,
+		EntityManager em) {
+		this.userAccountRepository = userAccountRepository;
+		this.savedItemRepository = savedItemRepository;
+		this.em = em;
+	}
+
+	@PostMapping("/wishes/test")
+	@Transactional
+	public ResponseEntity<Map<String, String>> createTestWish(@CurrentUserId UUID userId) {
+		UserAccount user = userAccountRepository.findById(userId)
+			.orElseThrow(() -> new RuntimeException("로그인 유저를 찾을 수 없음"));
+
+		SavedItem item = SavedItem.create(user,
+			"테스트 상품 (에어팟 프로)", 350000, null, null,
+			ItemCategory.DIGITAL, ItemInputSource.DIRECT_INPUT);
+		savedItemRepository.save(item);
+
+		em.createNativeQuery("UPDATE saved_items SET created_at = :ts WHERE id = :id")
+			.setParameter("ts", Instant.now().minus(25, ChronoUnit.HOURS))
+			.setParameter("id", item.getId().toString())
+			.executeUpdate();
+
+		return ResponseEntity.ok(Map.of(
+			"itemId", item.getId().toString(),
+			"tip", "GET /api/v1/deliberations/items/" + item.getId() + " 으로 숙려 화면 조회 가능"
+		));
+	}
+}

--- a/src/main/java/com/sagongsa/backend/domain/auth/SocialAccountRepository.java
+++ b/src/main/java/com/sagongsa/backend/domain/auth/SocialAccountRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface SocialAccountRepository extends JpaRepository<SocialAccount, UUID> {
 
 	Optional<SocialAccount> findByProviderAndProviderUserId(SocialProvider provider, String providerUserId);
+
+	Optional<SocialAccount> findByUserId(UUID userId);
 }

--- a/src/main/java/com/sagongsa/backend/domain/auth/UserAccount.java
+++ b/src/main/java/com/sagongsa/backend/domain/auth/UserAccount.java
@@ -43,4 +43,9 @@ public class UserAccount extends BaseEntity {
 	public Instant getWithdrawnAt() {
 		return withdrawnAt;
 	}
+
+	public void withdraw() {
+		this.status = UserStatus.WITHDRAWN;
+		this.withdrawnAt = Instant.now();
+	}
 }

--- a/src/main/java/com/sagongsa/backend/domain/budget/BudgetCycle.java
+++ b/src/main/java/com/sagongsa/backend/domain/budget/BudgetCycle.java
@@ -1,5 +1,6 @@
 package com.sagongsa.backend.domain.budget;
 
+import com.sagongsa.backend.domain.auth.UserAccount;
 import com.sagongsa.backend.domain.common.UserScopedEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -33,4 +34,23 @@ public class BudgetCycle extends UserScopedEntity {
 
 	protected BudgetCycle() {
 	}
+
+	private BudgetCycle(UserAccount user) {
+		super(user);
+	}
+
+	public static BudgetCycle create(UserAccount user, String yearMonth, int monthlyBudgetAmount) {
+		BudgetCycle b = new BudgetCycle(user);
+		b.yearMonth = yearMonth;
+		b.monthlyBudgetAmount = monthlyBudgetAmount;
+		b.spentAmount = 0;
+		b.warningThresholdRate = new BigDecimal("80.00");
+		return b;
+	}
+
+	public String getYearMonth() { return yearMonth; }
+	public int getMonthlyBudgetAmount() { return monthlyBudgetAmount; }
+	public int getSpentAmount() { return spentAmount; }
+
+	public void updateBudgetAmount(int amount) { this.monthlyBudgetAmount = amount; }
 }

--- a/src/main/java/com/sagongsa/backend/domain/budget/BudgetCycleRepository.java
+++ b/src/main/java/com/sagongsa/backend/domain/budget/BudgetCycleRepository.java
@@ -1,0 +1,21 @@
+package com.sagongsa.backend.domain.budget;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface BudgetCycleRepository extends JpaRepository<BudgetCycle, UUID> {
+
+	Optional<BudgetCycle> findByUserIdAndYearMonth(UUID userId, String yearMonth);
+
+	@Query("SELECT b.yearMonth FROM BudgetCycle b WHERE b.user.id = :userId ORDER BY b.yearMonth DESC")
+	List<String> findYearMonthsByUserId(@Param("userId") UUID userId);
+
+	@Modifying
+	@Query("DELETE FROM BudgetCycle b WHERE b.user.id = :userId")
+	void deleteByUserId(@Param("userId") UUID userId);
+}

--- a/src/main/java/com/sagongsa/backend/domain/item/SavedItem.java
+++ b/src/main/java/com/sagongsa/backend/domain/item/SavedItem.java
@@ -63,4 +63,12 @@ public class SavedItem extends UserScopedEntity {
 
 	protected SavedItem() {
 	}
+
+	public String getTitle() { return title; }
+	public String getImageUrl() { return imageUrl; }
+	public Integer getListedPrice() { return listedPrice; }
+	public ItemCategory getCategory() { return category; }
+	public ItemStatus getStatus() { return status; }
+
+	public void decide(ItemStatus decision) { this.status = decision; }
 }

--- a/src/main/java/com/sagongsa/backend/domain/item/SavedItem.java
+++ b/src/main/java/com/sagongsa/backend/domain/item/SavedItem.java
@@ -64,6 +64,26 @@ public class SavedItem extends UserScopedEntity {
 	protected SavedItem() {
 	}
 
+	public static SavedItem create(com.sagongsa.backend.domain.auth.UserAccount user,
+		String title, Integer listedPrice, String imageUrl, String originalUrl,
+		ItemCategory category, ItemInputSource inputSource) {
+		SavedItem item = new SavedItem(user);
+		item.title = title;
+		item.listedPrice = listedPrice;
+		item.imageUrl = imageUrl;
+		item.originalUrl = originalUrl;
+		item.normalizedUrl = originalUrl;
+		item.category = category;
+		item.inputSource = inputSource != null ? inputSource : ItemInputSource.DIRECT_INPUT;
+		item.status = ItemStatus.SAVED;
+		item.categoryLockedByUser = false;
+		return item;
+	}
+
+	private SavedItem(com.sagongsa.backend.domain.auth.UserAccount user) {
+		super(user);
+	}
+
 	public String getTitle() { return title; }
 	public String getImageUrl() { return imageUrl; }
 	public Integer getListedPrice() { return listedPrice; }

--- a/src/main/java/com/sagongsa/backend/domain/item/SavedItemRepository.java
+++ b/src/main/java/com/sagongsa/backend/domain/item/SavedItemRepository.java
@@ -1,0 +1,59 @@
+package com.sagongsa.backend.domain.item;
+
+import com.sagongsa.backend.domain.enums.ItemStatus;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SavedItemRepository extends JpaRepository<SavedItem, UUID> {
+
+	@Query("""
+		SELECT s FROM SavedItem s
+		WHERE s.user.id = :userId
+		  AND (:status IS NULL OR s.status = :status)
+		  AND s.updatedAt >= :from
+		  AND s.updatedAt < :to
+		ORDER BY s.updatedAt DESC
+		""")
+	List<SavedItem> findByUserIdAndStatusBetween(
+		@Param("userId") UUID userId,
+		@Param("status") ItemStatus status,
+		@Param("from") Instant from,
+		@Param("to") Instant to,
+		Pageable pageable);
+
+	@Query("""
+		SELECT COALESCE(SUM(s.listedPrice), 0) FROM SavedItem s
+		WHERE s.user.id = :userId
+		  AND s.status = :status
+		  AND s.updatedAt >= :from
+		  AND s.updatedAt < :to
+		""")
+	Integer sumPriceByUserIdAndStatusBetween(
+		@Param("userId") UUID userId,
+		@Param("status") ItemStatus status,
+		@Param("from") Instant from,
+		@Param("to") Instant to);
+
+	@Query("""
+		SELECT COUNT(s) FROM SavedItem s
+		WHERE s.user.id = :userId
+		  AND s.status = :status
+		  AND s.updatedAt >= :from
+		  AND s.updatedAt < :to
+		""")
+	long countByUserIdAndStatusBetween(
+		@Param("userId") UUID userId,
+		@Param("status") ItemStatus status,
+		@Param("from") Instant from,
+		@Param("to") Instant to);
+
+	@Modifying
+	@Query("DELETE FROM SavedItem s WHERE s.user.id = :userId")
+	void deleteByUserId(@Param("userId") UUID userId);
+}

--- a/src/main/java/com/sagongsa/backend/domain/user/UserProfile.java
+++ b/src/main/java/com/sagongsa/backend/domain/user/UserProfile.java
@@ -40,12 +40,25 @@ public class UserProfile {
 	private String profileImageUrl;
 
 	@Column(nullable = false)
+	private boolean notificationEnabled = true;
+
+	@Column(nullable = false)
 	private Instant createdAt;
 
 	@Column(nullable = false)
 	private Instant updatedAt;
 
 	protected UserProfile() {
+	}
+
+	public static UserProfile create(UserAccount user, String nickname, String mascotName) {
+		UserProfile p = new UserProfile();
+		p.user = user;
+		p.nickname = nickname;
+		p.mascotName = mascotName != null ? mascotName : "너구리";
+		p.timezone = "Asia/Seoul";
+		p.notificationEnabled = true;
+		return p;
 	}
 
 	@PrePersist
@@ -61,5 +74,23 @@ public class UserProfile {
 	@PreUpdate
 	void onUpdate() {
 		updatedAt = Instant.now();
+	}
+
+	public UUID getId() { return id; }
+	public UserAccount getUser() { return user; }
+	public String getNickname() { return nickname; }
+	public String getMascotName() { return mascotName; }
+	public String getTimezone() { return timezone; }
+	public String getProfileImageUrl() { return profileImageUrl; }
+	public boolean isNotificationEnabled() { return notificationEnabled; }
+	public Instant getCreatedAt() { return createdAt; }
+
+	public void updateProfile(String nickname, String mascotName) {
+		if (nickname != null) this.nickname = nickname;
+		if (mascotName != null) this.mascotName = mascotName;
+	}
+
+	public void updateNotificationEnabled(boolean enabled) {
+		this.notificationEnabled = enabled;
 	}
 }

--- a/src/main/java/com/sagongsa/backend/domain/user/UserProfileRepository.java
+++ b/src/main/java/com/sagongsa/backend/domain/user/UserProfileRepository.java
@@ -1,0 +1,17 @@
+package com.sagongsa.backend.domain.user;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface UserProfileRepository extends JpaRepository<UserProfile, UUID> {
+
+	Optional<UserProfile> findByUserId(UUID userId);
+
+	@Modifying
+	@Query("DELETE FROM UserProfile p WHERE p.user.id = :userId")
+	void deleteByUserId(@Param("userId") UUID userId);
+}

--- a/src/main/java/com/sagongsa/backend/mypage/AvailableMonthsResponse.java
+++ b/src/main/java/com/sagongsa/backend/mypage/AvailableMonthsResponse.java
@@ -1,0 +1,8 @@
+package com.sagongsa.backend.mypage;
+
+import java.util.List;
+
+record AvailableMonthsResponse(
+	List<String> months,
+	String currentMonth
+) {}

--- a/src/main/java/com/sagongsa/backend/mypage/MyProfileResponse.java
+++ b/src/main/java/com/sagongsa/backend/mypage/MyProfileResponse.java
@@ -1,0 +1,35 @@
+package com.sagongsa.backend.mypage;
+
+import com.sagongsa.backend.domain.auth.UserAccount;
+import com.sagongsa.backend.domain.auth.SocialAccount;
+import com.sagongsa.backend.domain.enums.OnboardingStatus;
+import com.sagongsa.backend.domain.enums.UserStatus;
+import com.sagongsa.backend.domain.user.UserProfile;
+import java.time.Instant;
+import java.util.UUID;
+
+record MyProfileResponse(
+	UUID id,
+	String nickname,
+	String mascotName,
+	String profileImageUrl,
+	String provider,
+	UserStatus status,
+	OnboardingStatus onboardingStatus,
+	long postCount,
+	Instant createdAt
+) {
+	static MyProfileResponse of(UserAccount user, UserProfile profile, SocialAccount social, long postCount) {
+		return new MyProfileResponse(
+			user.getId(),
+			profile != null ? profile.getNickname() : null,
+			profile != null ? profile.getMascotName() : null,
+			profile != null ? profile.getProfileImageUrl() : (social != null ? social.getProfileImageUrl() : null),
+			social != null ? social.getProvider().name().toLowerCase() : null,
+			user.getStatus(),
+			user.getOnboardingStatus(),
+			postCount,
+			user.getCreatedAt()
+		);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/mypage/MypageController.java
+++ b/src/main/java/com/sagongsa/backend/mypage/MypageController.java
@@ -1,0 +1,102 @@
+package com.sagongsa.backend.mypage;
+
+import com.sagongsa.backend.auth.CurrentUserId;
+import com.sagongsa.backend.domain.enums.ItemStatus;
+import com.sagongsa.backend.social.PostListResponse;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users/me")
+public class MypageController {
+
+	private final MypageService mypageService;
+
+	public MypageController(MypageService mypageService) {
+		this.mypageService = mypageService;
+	}
+
+	@GetMapping
+	public ResponseEntity<MyProfileResponse> getMyProfile(@CurrentUserId UUID userId) {
+		return ResponseEntity.ok(mypageService.getMyProfile(userId));
+	}
+
+	@PatchMapping("/profile")
+	public ResponseEntity<MyProfileResponse> updateProfile(
+		@CurrentUserId UUID userId,
+		@Valid @RequestBody UpdateProfileRequest request) {
+		return ResponseEntity.ok(mypageService.updateProfile(userId, request));
+	}
+
+	@PatchMapping("/budget")
+	public ResponseEntity<MypageService.BudgetUpdateResponse> updateBudget(
+		@CurrentUserId UUID userId,
+		@Valid @RequestBody UpdateBudgetRequest request) {
+		return ResponseEntity.ok(mypageService.updateBudget(userId, request));
+	}
+
+	@GetMapping("/notification-settings")
+	public ResponseEntity<MypageService.NotificationSettingsResponse> getNotificationSettings(
+		@CurrentUserId UUID userId) {
+		return ResponseEntity.ok(mypageService.getNotificationSettings(userId));
+	}
+
+	@PatchMapping("/notification-settings")
+	public ResponseEntity<MypageService.NotificationSettingsResponse> updateNotificationSettings(
+		@CurrentUserId UUID userId,
+		@Valid @RequestBody NotificationSettingsRequest request) {
+		return ResponseEntity.ok(mypageService.updateNotificationSettings(userId, request));
+	}
+
+	@DeleteMapping
+	public ResponseEntity<Void> deleteAccount(@CurrentUserId UUID userId) {
+		mypageService.deleteAccount(userId);
+		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping("/stats/months")
+	public ResponseEntity<AvailableMonthsResponse> getAvailableMonths(@CurrentUserId UUID userId) {
+		return ResponseEntity.ok(mypageService.getAvailableMonths(userId));
+	}
+
+	@GetMapping("/stats")
+	public ResponseEntity<StatsResponse> getStats(
+		@CurrentUserId UUID userId,
+		@RequestParam(required = false) String yearMonth) {
+		return ResponseEntity.ok(mypageService.getStats(userId, yearMonth));
+	}
+
+	@GetMapping("/wishes/history")
+	public ResponseEntity<WishHistoryResponse> getWishHistory(
+		@CurrentUserId UUID userId,
+		@RequestParam(required = false) ItemStatus status,
+		@RequestParam(required = false) String yearMonth,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "20") int size) {
+		return ResponseEntity.ok(mypageService.getWishHistory(userId, status, yearMonth, page, size));
+	}
+
+	@GetMapping("/posts")
+	public ResponseEntity<PostListResponse> getMyPosts(
+		@CurrentUserId UUID userId,
+		@RequestParam(required = false) UUID cursor,
+		@RequestParam(defaultValue = "20") int size) {
+		return ResponseEntity.ok(mypageService.getMyPosts(userId, cursor, size));
+	}
+
+	@GetMapping("/votes")
+	public ResponseEntity<PostListResponse> getMyVotedPosts(
+		@CurrentUserId UUID userId,
+		@RequestParam(required = false) UUID cursor,
+		@RequestParam(defaultValue = "20") int size) {
+		return ResponseEntity.ok(mypageService.getMyVotedPosts(userId, cursor, size));
+	}
+}

--- a/src/main/java/com/sagongsa/backend/mypage/MypageExceptionHandler.java
+++ b/src/main/java/com/sagongsa/backend/mypage/MypageExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.sagongsa.backend.mypage;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(assignableTypes = MypageController.class)
+class MypageExceptionHandler {
+
+	record ErrorBody(String code, String message) {}
+
+	@ExceptionHandler(MypageNotFoundException.class)
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	ErrorBody handleNotFound(MypageNotFoundException ex) {
+		return new ErrorBody("NOT_FOUND", ex.getMessage());
+	}
+}

--- a/src/main/java/com/sagongsa/backend/mypage/MypageNotFoundException.java
+++ b/src/main/java/com/sagongsa/backend/mypage/MypageNotFoundException.java
@@ -1,0 +1,7 @@
+package com.sagongsa.backend.mypage;
+
+class MypageNotFoundException extends RuntimeException {
+	MypageNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/mypage/MypageService.java
+++ b/src/main/java/com/sagongsa/backend/mypage/MypageService.java
@@ -1,0 +1,232 @@
+package com.sagongsa.backend.mypage;
+
+import com.sagongsa.backend.domain.auth.SocialAccount;
+import com.sagongsa.backend.domain.auth.SocialAccountRepository;
+import com.sagongsa.backend.domain.auth.UserAccount;
+import com.sagongsa.backend.domain.auth.UserAccountRepository;
+import com.sagongsa.backend.domain.budget.BudgetCycle;
+import com.sagongsa.backend.domain.budget.BudgetCycleRepository;
+import com.sagongsa.backend.domain.enums.ItemStatus;
+import com.sagongsa.backend.domain.item.SavedItem;
+import com.sagongsa.backend.domain.item.SavedItemRepository;
+import com.sagongsa.backend.domain.social.FeedPostRepository;
+import com.sagongsa.backend.domain.social.PostCommentRepository;
+import com.sagongsa.backend.domain.social.PostVote;
+import com.sagongsa.backend.domain.social.PostVoteRepository;
+import com.sagongsa.backend.domain.user.UserProfile;
+import com.sagongsa.backend.domain.user.UserProfileRepository;
+import com.sagongsa.backend.social.PostListResponse;
+import com.sagongsa.backend.social.PostResponse;
+import java.time.Instant;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+class MypageService {
+
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+	private final UserAccountRepository userAccountRepository;
+	private final UserProfileRepository userProfileRepository;
+	private final SocialAccountRepository socialAccountRepository;
+	private final FeedPostRepository feedPostRepository;
+	private final PostVoteRepository postVoteRepository;
+	private final PostCommentRepository postCommentRepository;
+	private final SavedItemRepository savedItemRepository;
+	private final BudgetCycleRepository budgetCycleRepository;
+
+	MypageService(UserAccountRepository userAccountRepository,
+		UserProfileRepository userProfileRepository,
+		SocialAccountRepository socialAccountRepository,
+		FeedPostRepository feedPostRepository,
+		PostVoteRepository postVoteRepository,
+		PostCommentRepository postCommentRepository,
+		SavedItemRepository savedItemRepository,
+		BudgetCycleRepository budgetCycleRepository) {
+		this.userAccountRepository = userAccountRepository;
+		this.userProfileRepository = userProfileRepository;
+		this.socialAccountRepository = socialAccountRepository;
+		this.feedPostRepository = feedPostRepository;
+		this.postVoteRepository = postVoteRepository;
+		this.postCommentRepository = postCommentRepository;
+		this.savedItemRepository = savedItemRepository;
+		this.budgetCycleRepository = budgetCycleRepository;
+	}
+
+	MyProfileResponse getMyProfile(UUID userId) {
+		UserAccount user = findUserOrThrow(userId);
+		UserProfile profile = userProfileRepository.findByUserId(userId).orElse(null);
+		SocialAccount social = socialAccountRepository.findByUserId(userId).orElse(null);
+		long postCount = feedPostRepository.countByUserIdAndDeletedAtIsNull(userId);
+		return MyProfileResponse.of(user, profile, social, postCount);
+	}
+
+	@Transactional
+	MyProfileResponse updateProfile(UUID userId, UpdateProfileRequest request) {
+		UserAccount user = findUserOrThrow(userId);
+		UserProfile profile = userProfileRepository.findByUserId(userId)
+			.orElseGet(() -> userProfileRepository.save(
+				UserProfile.create(user,
+					request.nickname() != null ? request.nickname() : "사용자",
+					request.raccoonName() != null ? request.raccoonName() : "너구리")));
+		profile.updateProfile(request.nickname(), request.raccoonName());
+		SocialAccount social = socialAccountRepository.findByUserId(userId).orElse(null);
+		long postCount = feedPostRepository.countByUserIdAndDeletedAtIsNull(userId);
+		return MyProfileResponse.of(user, profile, social, postCount);
+	}
+
+	@Transactional
+	record BudgetUpdateResponse(Integer monthlyBudget) {}
+
+	@Transactional
+	BudgetUpdateResponse updateBudget(UUID userId, UpdateBudgetRequest request) {
+		UserAccount user = findUserOrThrow(userId);
+		String yearMonth = YearMonth.now(KST).toString();
+		BudgetCycle cycle = budgetCycleRepository.findByUserIdAndYearMonth(userId, yearMonth)
+			.orElseGet(() -> budgetCycleRepository.save(
+				BudgetCycle.create(user, yearMonth, request.monthlyBudget())));
+		cycle.updateBudgetAmount(request.monthlyBudget());
+		return new BudgetUpdateResponse(request.monthlyBudget());
+	}
+
+	record NotificationSettingsResponse(boolean notificationEnabled) {}
+
+	NotificationSettingsResponse getNotificationSettings(UUID userId) {
+		findUserOrThrow(userId);
+		UserProfile profile = userProfileRepository.findByUserId(userId).orElse(null);
+		return new NotificationSettingsResponse(profile == null || profile.isNotificationEnabled());
+	}
+
+	@Transactional
+	NotificationSettingsResponse updateNotificationSettings(UUID userId, NotificationSettingsRequest request) {
+		UserAccount user = findUserOrThrow(userId);
+		UserProfile profile = userProfileRepository.findByUserId(userId)
+			.orElseGet(() -> userProfileRepository.save(
+				UserProfile.create(user, "사용자", "너구리")));
+		profile.updateNotificationEnabled(request.notificationEnabled());
+		return new NotificationSettingsResponse(request.notificationEnabled());
+	}
+
+	@Transactional
+	void deleteAccount(UUID userId) {
+		UserAccount user = findUserOrThrow(userId);
+		postVoteRepository.deleteByUserId(userId);
+		postCommentRepository.deleteByUserId(userId);
+		postVoteRepository.deleteByPostUserId(userId);
+		postCommentRepository.deleteByPostUserId(userId);
+		feedPostRepository.softDeleteByUserId(userId);
+		savedItemRepository.deleteByUserId(userId);
+		budgetCycleRepository.deleteByUserId(userId);
+		userProfileRepository.deleteByUserId(userId);
+		user.withdraw();
+	}
+
+	AvailableMonthsResponse getAvailableMonths(UUID userId) {
+		findUserOrThrow(userId);
+		Set<String> months = new LinkedHashSet<>(budgetCycleRepository.findYearMonthsByUserId(userId));
+		String current = YearMonth.now(KST).toString();
+		months.add(current);
+		List<String> sorted = new ArrayList<>(months);
+		sorted.sort((a, b) -> b.compareTo(a));
+		return new AvailableMonthsResponse(sorted, current);
+	}
+
+	StatsResponse getStats(UUID userId, String yearMonth) {
+		if (yearMonth == null || yearMonth.isBlank()) {
+			yearMonth = YearMonth.now(KST).toString();
+		}
+		findUserOrThrow(userId);
+		YearMonth ym = YearMonth.parse(yearMonth);
+		Instant from = ym.atDay(1).atStartOfDay(KST).toInstant();
+		Instant to = ym.atEndOfMonth().plusDays(1).atStartOfDay(KST).toInstant();
+
+		BudgetCycle budget = budgetCycleRepository.findByUserIdAndYearMonth(userId, yearMonth).orElse(null);
+		Integer budgetAmount = budget != null ? budget.getMonthlyBudgetAmount() : null;
+		Integer spent = savedItemRepository.sumPriceByUserIdAndStatusBetween(userId, ItemStatus.GO, from, to);
+		Integer restrained = savedItemRepository.sumPriceByUserIdAndStatusBetween(userId, ItemStatus.STOP, from, to);
+		long boughtCount = savedItemRepository.countByUserIdAndStatusBetween(userId, ItemStatus.GO, from, to);
+		long restrainedCount = savedItemRepository.countByUserIdAndStatusBetween(userId, ItemStatus.STOP, from, to);
+
+		Double usageRate = null;
+		int spentVal = spent != null ? spent : 0;
+		if (budgetAmount != null && budgetAmount > 0) {
+			usageRate = Math.round((double) spentVal / budgetAmount * 1000.0) / 10.0;
+		}
+
+		return new StatsResponse(yearMonth, budgetAmount, spentVal,
+			restrained != null ? restrained : 0, usageRate, boughtCount, restrainedCount);
+	}
+
+	WishHistoryResponse getWishHistory(UUID userId, ItemStatus status, String yearMonth, int page, int size) {
+		if (yearMonth == null || yearMonth.isBlank()) {
+			yearMonth = YearMonth.now(KST).toString();
+		}
+		YearMonth ym = YearMonth.parse(yearMonth);
+		Instant from = ym.atDay(1).atStartOfDay(KST).toInstant();
+		Instant to = ym.atEndOfMonth().plusDays(1).atStartOfDay(KST).toInstant();
+
+		List<SavedItem> items = savedItemRepository.findByUserIdAndStatusBetween(
+			userId, status, from, to, PageRequest.of(page, size));
+
+		long total = (status != null)
+			? savedItemRepository.countByUserIdAndStatusBetween(userId, status, from, to)
+			: savedItemRepository.countByUserIdAndStatusBetween(userId, ItemStatus.GO, from, to)
+			+ savedItemRepository.countByUserIdAndStatusBetween(userId, ItemStatus.STOP, from, to);
+
+		List<WishSummaryResponse> wishes = items.stream().map(WishSummaryResponse::of).toList();
+		return new WishHistoryResponse(wishes, total, page, size);
+	}
+
+	PostListResponse getMyPosts(UUID userId, UUID cursor, int size) {
+		PageRequest pageable = PageRequest.of(0, size + 1);
+		var posts = cursor != null
+			? feedPostRepository.findByUserIdVisibleBefore(userId, cursor, pageable)
+			: feedPostRepository.findByUserIdVisible(userId, pageable);
+
+		boolean hasMore = posts.size() > size;
+		if (hasMore) posts = posts.subList(0, size);
+
+		var items = posts.stream().map(post -> {
+			long cc = postCommentRepository.countByPostIdAndDeletedAtIsNull(post.getId());
+			var myVote = postVoteRepository.findByPostIdAndUserId(post.getId(), userId)
+				.filter(PostVote::isActive).map(PostVote::getVoteType).orElse(null);
+			return PostResponse.of(post, cc, myVote);
+		}).toList();
+
+		UUID nextCursor = hasMore && !posts.isEmpty() ? posts.get(posts.size() - 1).getId() : null;
+		return new PostListResponse(items, nextCursor, hasMore);
+	}
+
+	PostListResponse getMyVotedPosts(UUID userId, UUID cursor, int size) {
+		PageRequest pageable = PageRequest.of(0, size + 1);
+		var votes = cursor != null
+			? postVoteRepository.findActiveByUserIdBefore(userId, cursor, pageable)
+			: postVoteRepository.findActiveByUserId(userId, pageable);
+
+		boolean hasMore = votes.size() > size;
+		if (hasMore) votes = votes.subList(0, size);
+
+		var items = votes.stream().map(vote -> {
+			var post = vote.getPost();
+			long cc = postCommentRepository.countByPostIdAndDeletedAtIsNull(post.getId());
+			return PostResponse.of(post, cc, vote.getVoteType());
+		}).toList();
+
+		UUID nextCursor = hasMore && !votes.isEmpty() ? votes.get(votes.size() - 1).getPost().getId() : null;
+		return new PostListResponse(items, nextCursor, hasMore);
+	}
+
+	private UserAccount findUserOrThrow(UUID userId) {
+		return userAccountRepository.findById(userId)
+			.orElseThrow(() -> new MypageNotFoundException("사용자를 찾을 수 없습니다."));
+	}
+}

--- a/src/main/java/com/sagongsa/backend/mypage/NotificationSettingsRequest.java
+++ b/src/main/java/com/sagongsa/backend/mypage/NotificationSettingsRequest.java
@@ -1,0 +1,8 @@
+package com.sagongsa.backend.mypage;
+
+import jakarta.validation.constraints.NotNull;
+
+record NotificationSettingsRequest(
+	@NotNull(message = "알림 수신 여부는 필수입니다.")
+	Boolean notificationEnabled
+) {}

--- a/src/main/java/com/sagongsa/backend/mypage/StatsResponse.java
+++ b/src/main/java/com/sagongsa/backend/mypage/StatsResponse.java
@@ -1,0 +1,11 @@
+package com.sagongsa.backend.mypage;
+
+record StatsResponse(
+	String yearMonth,
+	Integer budgetAmount,
+	int spentAmount,
+	int restrainedAmount,
+	Double usageRate,
+	long boughtCount,
+	long restrainedCount
+) {}

--- a/src/main/java/com/sagongsa/backend/mypage/UpdateBudgetRequest.java
+++ b/src/main/java/com/sagongsa/backend/mypage/UpdateBudgetRequest.java
@@ -1,0 +1,10 @@
+package com.sagongsa.backend.mypage;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+record UpdateBudgetRequest(
+	@NotNull(message = "월 예산은 필수입니다.")
+	@Min(value = 1, message = "월 예산은 1원 이상이어야 합니다.")
+	Integer monthlyBudget
+) {}

--- a/src/main/java/com/sagongsa/backend/mypage/UpdateProfileRequest.java
+++ b/src/main/java/com/sagongsa/backend/mypage/UpdateProfileRequest.java
@@ -1,0 +1,13 @@
+package com.sagongsa.backend.mypage;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+record UpdateProfileRequest(
+	@Size(min = 1, max = 10, message = "닉네임은 1~10자여야 합니다.")
+	@Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "닉네임은 한글, 영문, 숫자만 허용됩니다.")
+	String nickname,
+
+	@Size(min = 1, max = 10, message = "너구리 이름은 1~10자여야 합니다.")
+	String raccoonName
+) {}

--- a/src/main/java/com/sagongsa/backend/mypage/WishHistoryResponse.java
+++ b/src/main/java/com/sagongsa/backend/mypage/WishHistoryResponse.java
@@ -1,0 +1,10 @@
+package com.sagongsa.backend.mypage;
+
+import java.util.List;
+
+record WishHistoryResponse(
+	List<WishSummaryResponse> wishes,
+	long total,
+	int page,
+	int size
+) {}

--- a/src/main/java/com/sagongsa/backend/mypage/WishSummaryResponse.java
+++ b/src/main/java/com/sagongsa/backend/mypage/WishSummaryResponse.java
@@ -1,0 +1,26 @@
+package com.sagongsa.backend.mypage;
+
+import com.sagongsa.backend.domain.enums.ItemCategory;
+import com.sagongsa.backend.domain.enums.ItemStatus;
+import com.sagongsa.backend.domain.item.SavedItem;
+import java.util.UUID;
+
+record WishSummaryResponse(
+	UUID id,
+	String title,
+	Integer price,
+	String imageUrl,
+	ItemCategory category,
+	ItemStatus status
+) {
+	static WishSummaryResponse of(SavedItem item) {
+		return new WishSummaryResponse(
+			item.getId(),
+			item.getTitle(),
+			item.getListedPrice(),
+			item.getImageUrl(),
+			item.getCategory(),
+			item.getStatus()
+		);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/social/PostListResponse.java
+++ b/src/main/java/com/sagongsa/backend/social/PostListResponse.java
@@ -3,7 +3,7 @@ package com.sagongsa.backend.social;
 import java.util.List;
 import java.util.UUID;
 
-record PostListResponse(
+public record PostListResponse(
 	List<PostResponse> posts,
 	UUID nextCursor,
 	boolean hasMore

--- a/src/main/java/com/sagongsa/backend/social/PostResponse.java
+++ b/src/main/java/com/sagongsa/backend/social/PostResponse.java
@@ -5,7 +5,7 @@ import com.sagongsa.backend.domain.social.FeedPost;
 import java.time.Instant;
 import java.util.UUID;
 
-record PostResponse(
+public record PostResponse(
 	UUID id,
 	UUID userId,
 	String title,
@@ -18,7 +18,7 @@ record PostResponse(
 	PostVoteType myVote,
 	Instant createdAt
 ) {
-	static PostResponse of(FeedPost post, long commentCount, PostVoteType myVote) {
+	public static PostResponse of(FeedPost post, long commentCount, PostVoteType myVote) {
 		return new PostResponse(
 			post.getId(),
 			post.getUser().getId(),

--- a/src/main/java/com/sagongsa/backend/terms/TermsController.java
+++ b/src/main/java/com/sagongsa/backend/terms/TermsController.java
@@ -1,0 +1,74 @@
+package com.sagongsa.backend.terms;
+
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/v1/terms")
+public class TermsController {
+
+	private static final List<TermsSummaryResponse> TERMS_LIST = List.of(
+		new TermsSummaryResponse(TermsType.SERVICE, "서비스 이용약관", true),
+		new TermsSummaryResponse(TermsType.PRIVACY, "개인정보처리방침", true),
+		new TermsSummaryResponse(TermsType.MARKETING, "마케팅 수신 동의", false)
+	);
+
+	private static final Map<TermsType, TermsDetailResponse> TERMS_DETAIL = Map.of(
+		TermsType.SERVICE, new TermsDetailResponse(TermsType.SERVICE, "서비스 이용약관", true,
+			"""
+			제1조 (목적)
+			본 약관은 위굴(Wigul) 서비스의 이용 조건 및 절차, 회사와 이용자 간의 권리·의무 및 책임 사항을 규정함을 목적으로 합니다.
+
+			제2조 (용어의 정의)
+			1. "서비스"란 회사가 제공하는 충동구매 방지 앱 위굴의 모든 기능을 의미합니다.
+			2. "이용자"란 본 약관에 동의하고 서비스를 이용하는 회원을 의미합니다.
+
+			제3조 (서비스 이용)
+			이용자는 소셜 로그인을 통해 회원가입 후 서비스를 이용할 수 있습니다.
+
+			제4조 (계정 탈퇴)
+			이용자는 언제든지 계정 탈퇴를 요청할 수 있으며, 탈퇴 시 모든 데이터는 즉시 삭제됩니다.
+			"""),
+		TermsType.PRIVACY, new TermsDetailResponse(TermsType.PRIVACY, "개인정보처리방침", true,
+			"""
+			1. 수집하는 개인정보 항목
+			- 소셜 로그인 시: 이름, 이메일, 프로필 이미지
+
+			2. 개인정보 수집 목적
+			- 서비스 제공 및 회원 관리
+
+			3. 개인정보 보유 기간
+			- 회원 탈퇴 시 즉시 삭제
+
+			4. 개인정보 제3자 제공
+			- 법령에 의한 경우를 제외하고 제3자에게 제공하지 않습니다.
+			"""),
+		TermsType.MARKETING, new TermsDetailResponse(TermsType.MARKETING, "마케팅 수신 동의", false,
+			"""
+			위굴 서비스의 새로운 기능 안내, 이벤트 및 혜택 정보를 푸시 알림으로 수신하는 것에 동의합니다.
+			본 동의는 선택 사항이며, 동의하지 않아도 서비스 이용에 제한이 없습니다.
+			동의 후에도 알림 설정에서 언제든지 변경 가능합니다.
+			""")
+	);
+
+	@GetMapping
+	public ResponseEntity<List<TermsSummaryResponse>> list() {
+		return ResponseEntity.ok(TERMS_LIST);
+	}
+
+	@GetMapping("/{type}")
+	public ResponseEntity<TermsDetailResponse> detail(@PathVariable TermsType type) {
+		TermsDetailResponse detail = TERMS_DETAIL.get(type);
+		if (detail == null) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "약관을 찾을 수 없습니다.");
+		}
+		return ResponseEntity.ok(detail);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/terms/TermsDetailResponse.java
+++ b/src/main/java/com/sagongsa/backend/terms/TermsDetailResponse.java
@@ -1,0 +1,8 @@
+package com.sagongsa.backend.terms;
+
+record TermsDetailResponse(
+	TermsType type,
+	String title,
+	boolean required,
+	String content
+) {}

--- a/src/main/java/com/sagongsa/backend/terms/TermsSummaryResponse.java
+++ b/src/main/java/com/sagongsa/backend/terms/TermsSummaryResponse.java
@@ -1,0 +1,7 @@
+package com.sagongsa.backend.terms;
+
+record TermsSummaryResponse(
+	TermsType type,
+	String title,
+	boolean required
+) {}

--- a/src/main/java/com/sagongsa/backend/terms/TermsType.java
+++ b/src/main/java/com/sagongsa/backend/terms/TermsType.java
@@ -1,0 +1,7 @@
+package com.sagongsa.backend.terms;
+
+public enum TermsType {
+	SERVICE,
+	PRIVACY,
+	MARKETING
+}

--- a/src/main/resources/static/app.html
+++ b/src/main/resources/static/app.html
@@ -1,0 +1,582 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Wigul</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; background: #111; color: #fff; min-height: 100vh; }
+
+        /* 헤더 */
+        .header { position: fixed; top: 0; left: 0; right: 0; z-index: 100; background: #1a1a1a; border-bottom: 1px solid #222; padding: 0 20px; display: flex; align-items: center; justify-content: space-between; height: 52px; }
+        .header-logo { font-size: 20px; font-weight: 800; }
+        .header-user { font-size: 13px; color: #888; display: flex; align-items: center; gap: 10px; }
+        .logout-btn { padding: 5px 12px; border-radius: 8px; border: 1px solid #444; background: transparent; color: #888; font-size: 12px; cursor: pointer; }
+        .logout-btn:hover { color: #fff; border-color: #888; }
+
+        /* 탭 */
+        .tab-bar { position: fixed; top: 52px; left: 0; right: 0; z-index: 100; background: #1a1a1a; border-bottom: 1px solid #222; display: flex; }
+        .tab-btn { flex: 1; padding: 12px 0; border: none; background: transparent; color: #888; font-size: 14px; font-weight: 500; cursor: pointer; border-bottom: 2px solid transparent; transition: all 0.15s; }
+        .tab-btn.active { color: #fff; border-bottom-color: #4a90d9; }
+
+        /* 콘텐츠 */
+        .content { padding-top: 100px; padding-bottom: 40px; max-width: 480px; margin: 0 auto; }
+        .tab-panel { display: none; padding: 0 16px; }
+        .tab-panel.active { display: block; }
+
+        /* 공통 카드 */
+        .card { background: #1a1a1a; border-radius: 14px; padding: 18px; margin-bottom: 12px; }
+        .card-title { font-size: 13px; color: #888; margin-bottom: 12px; text-transform: uppercase; letter-spacing: 0.5px; }
+        .input-row { display: flex; gap: 8px; margin-bottom: 8px; align-items: center; }
+        .input-row label { font-size: 13px; color: #aaa; width: 80px; flex-shrink: 0; }
+        .input-row input, .input-row select, .input-row textarea {
+            flex: 1; padding: 8px 10px; border-radius: 8px; border: 1px solid #333;
+            background: #222; color: #fff; font-size: 13px; outline: none;
+        }
+        .input-row textarea { height: 60px; resize: vertical; }
+        .btn { padding: 10px 18px; border-radius: 10px; border: none; font-size: 14px; font-weight: 600; cursor: pointer; transition: opacity 0.15s; }
+        .btn:active { opacity: 0.8; }
+        .btn-primary { background: #4a90d9; color: #fff; }
+        .btn-danger { background: #e74c3c; color: #fff; }
+        .btn-success { background: #27ae60; color: #fff; }
+        .btn-outline { background: transparent; border: 1px solid #444; color: #aaa; }
+        .btn:disabled { opacity: 0.4; cursor: not-allowed; }
+        .result-box { background: #222; border-radius: 10px; padding: 14px; margin-top: 10px; font-size: 13px; font-family: monospace; white-space: pre-wrap; word-break: break-all; color: #0f0; max-height: 300px; overflow-y: auto; display: none; }
+        .result-box.visible { display: block; }
+
+        /* ─── 소셜 피드 ─────────── */
+        .feed-list { }
+        .feed-card { background: #1a1a1a; border-radius: 14px; margin-bottom: 12px; overflow: hidden; }
+        .feed-img { width: 100%; height: 180px; object-fit: cover; display: block; }
+        .feed-body { padding: 14px; }
+        .feed-title { font-size: 16px; font-weight: 600; margin-bottom: 6px; }
+        .feed-desc { font-size: 13px; color: #aaa; margin-bottom: 10px; }
+        .feed-price { font-size: 16px; font-weight: 700; color: #ffd700; margin-bottom: 12px; }
+        .vote-row { display: flex; gap: 8px; margin-bottom: 8px; }
+        .vote-btn { flex: 1; padding: 10px; border-radius: 10px; border: 2px solid; font-size: 14px; font-weight: 700; cursor: pointer; background: transparent; transition: all 0.15s; }
+        .vote-btn.go { color: #27ae60; border-color: #27ae60; }
+        .vote-btn.go.active { background: #27ae60; color: #fff; }
+        .vote-btn.stop { color: #e74c3c; border-color: #e74c3c; }
+        .vote-btn.stop.active { background: #e74c3c; color: #fff; }
+        .feed-meta { font-size: 12px; color: #666; }
+        .comment-area { border-top: 1px solid #222; padding: 10px 14px; }
+        .comment-item { font-size: 13px; padding: 6px 0; border-bottom: 1px solid #222; color: #bbb; display: flex; justify-content: space-between; }
+        .comment-form { display: flex; gap: 6px; margin-top: 8px; }
+        .comment-form input { flex: 1; padding: 8px 10px; border-radius: 8px; border: 1px solid #333; background: #222; color: #fff; font-size: 13px; }
+        .comment-form button { padding: 8px 14px; border-radius: 8px; border: none; background: #4a90d9; color: #fff; font-size: 13px; cursor: pointer; }
+        .load-more { width: 100%; padding: 12px; border-radius: 10px; border: 1px solid #333; background: transparent; color: #888; font-size: 13px; cursor: pointer; margin-top: 4px; }
+        .empty { text-align: center; color: #555; padding: 40px 0; font-size: 14px; }
+
+        /* ─── 구매 숙려 ─────────── */
+        .question-card { background: #1a1a1a; border-radius: 14px; padding: 16px; margin-bottom: 8px; display: flex; justify-content: space-between; align-items: center; gap: 12px; }
+        .question-text { font-size: 14px; line-height: 1.5; flex: 1; }
+        .yn-buttons { display: flex; gap: 6px; flex-shrink: 0; }
+        .yn-btn { width: 42px; height: 34px; border-radius: 8px; border: 1px solid #444; background: transparent; color: #888; font-size: 13px; font-weight: 600; cursor: pointer; }
+        .yn-btn.y.sel { background: #e74c3c; border-color: #e74c3c; color: #fff; }
+        .yn-btn.n.sel { background: #27ae60; border-color: #27ae60; color: #fff; }
+        .warning-banner { border-radius: 10px; padding: 12px 16px; margin: 12px 0; font-size: 13px; font-weight: 600; text-align: center; display: none; }
+        .warning-banner.warn { background: rgba(231,76,60,.15); border: 1px solid #e74c3c; color: #e74c3c; display: block; }
+        .warning-banner.safe { background: rgba(39,174,96,.15); border: 1px solid #27ae60; color: #27ae60; display: block; }
+        .stat-row { display: flex; justify-content: space-between; padding: 10px 0; border-bottom: 1px solid #222; font-size: 14px; }
+        .stat-row:last-child { border-bottom: none; }
+        .stat-val { font-weight: 700; }
+        .decision-row { display: flex; gap: 10px; margin-top: 16px; }
+        .decision-row .btn { flex: 1; padding: 14px; font-size: 15px; }
+
+        /* ─── 마이페이지 ─────────── */
+        .profile-row { display: flex; justify-content: space-between; padding: 8px 0; border-bottom: 1px solid #222; font-size: 14px; }
+        .profile-row:last-child { border-bottom: none; }
+        .profile-label { color: #888; }
+        .profile-val { font-weight: 600; }
+    </style>
+</head>
+<body>
+
+<!-- 헤더 -->
+<div class="header">
+    <div class="header-logo">Wigul</div>
+    <div class="header-user">
+        <span id="headerNickname">로딩중...</span>
+        <button class="logout-btn" onclick="logout()">로그아웃</button>
+    </div>
+</div>
+
+<!-- 탭바 -->
+<div class="tab-bar">
+    <button class="tab-btn active" onclick="switchTab('feed')">소셜 피드</button>
+    <button class="tab-btn" onclick="switchTab('deliberation')">구매 숙려</button>
+    <button class="tab-btn" onclick="switchTab('mypage')">마이페이지</button>
+</div>
+
+<!-- 콘텐츠 -->
+<div class="content">
+
+    <!-- ── 소셜 피드 탭 ── -->
+    <div id="tab-feed" class="tab-panel active">
+
+        <!-- 게시글 작성 -->
+        <div class="card">
+            <div class="card-title">게시글 작성</div>
+            <div class="input-row"><label>제목</label><input id="postTitle" placeholder="무엇을 살까 고민 중인가요?"></div>
+            <div class="input-row"><label>내용</label><textarea id="postBody" placeholder="자세한 내용 (선택)"></textarea></div>
+            <div class="input-row"><label>가격</label><input id="postPrice" type="number" placeholder="원 (선택)"></div>
+            <div class="input-row"><label>이미지 URL</label><input id="postImage" placeholder="https://... (선택)"></div>
+            <button class="btn btn-primary" onclick="createPost()" style="width:100%;margin-top:4px">게시글 올리기</button>
+        </div>
+
+        <!-- 피드 목록 -->
+        <div id="feedList" class="feed-list">
+            <div class="empty">피드 로딩 중...</div>
+        </div>
+        <button class="load-more" id="loadMoreBtn" onclick="loadMoreFeed()" style="display:none">더 보기</button>
+    </div>
+
+    <!-- ── 구매 숙려 탭 ── -->
+    <div id="tab-deliberation" class="tab-panel">
+
+        <!-- Step 1: 아이템 생성 -->
+        <div class="card" id="stepCreate">
+            <div class="card-title">구매 숙려 테스트</div>
+            <p style="font-size:14px;color:#888;margin-bottom:16px">24시간이 경과한 테스트 아이템을 생성합니다.</p>
+            <button class="btn btn-primary" onclick="createTestItem()" id="createItemBtn" style="width:100%">테스트 아이템 만들기</button>
+            <p id="createMsg" style="font-size:12px;color:#888;margin-top:8px;text-align:center"></p>
+        </div>
+
+        <!-- Step 2: 숙려 화면 (아이템 생성 후 표시) -->
+        <div id="stepDeliberation" style="display:none">
+
+            <!-- 상품 정보 -->
+            <div class="card">
+                <div class="card-title">구매 예정 상품</div>
+                <div class="profile-row"><span class="profile-label">상품명</span><span class="profile-val" id="dItemTitle"></span></div>
+                <div class="profile-row"><span class="profile-label">가격</span><span class="profile-val" id="dItemPrice"></span></div>
+                <div class="profile-row"><span class="profile-label">카테고리</span><span class="profile-val" id="dItemCategory"></span></div>
+            </div>
+
+            <!-- 예산 -->
+            <div class="card">
+                <div class="card-title">이번 달 예산</div>
+                <div class="profile-row"><span class="profile-label">월 예산</span><span class="profile-val" id="dBudget"></span></div>
+                <div class="profile-row"><span class="profile-label">사용 금액</span><span class="profile-val" id="dSpent"></span></div>
+                <div class="profile-row"><span class="profile-label">남은 예산</span><span class="profile-val" id="dRemaining" style="color:#4a90d9"></span></div>
+            </div>
+
+            <!-- 질문 -->
+            <div class="card-title" style="padding:0 4px 8px">충동구매 점검</div>
+            <div id="dQuestions"></div>
+            <div class="warning-banner" id="dWarning"></div>
+
+            <!-- 이달 통계 -->
+            <div class="card">
+                <div class="card-title">이번 달 소비 현황</div>
+                <div class="stat-row"><span>이번 달 소비</span><span class="stat-val" id="dStatSpent" style="color:#e74c3c"></span></div>
+                <div class="stat-row"><span>비합리적 선택</span><span class="stat-val" id="dStatIrrational" style="color:#ffd700"></span></div>
+                <div class="stat-row"><span>기회비용</span><span class="stat-val" id="dStatOpportunity" style="color:#4a90d9"></span></div>
+            </div>
+
+            <!-- 결정 버튼 -->
+            <div class="decision-row">
+                <button class="btn btn-primary decision-btn" id="restrainBtn" onclick="decide('STOP')" disabled>참을게요</button>
+                <button class="btn btn-danger decision-btn" id="buyBtn" onclick="decide('GO')" disabled>살게요</button>
+            </div>
+        </div>
+
+        <!-- Step 3: 결과 -->
+        <div id="stepResult" style="display:none">
+            <div class="card" style="text-align:center;padding:32px">
+                <div style="font-size:48px;margin-bottom:12px" id="rEmoji"></div>
+                <div style="font-size:22px;font-weight:700;margin-bottom:8px" id="rTitle"></div>
+                <div style="font-size:13px;color:#888;margin-bottom:24px" id="rDesc"></div>
+                <div class="stat-row"><span>Yes 응답</span><span class="stat-val" id="rYes"></span></div>
+                <div class="stat-row"><span>이번 달 소비</span><span class="stat-val" id="rSpent" style="color:#e74c3c"></span></div>
+                <div class="stat-row"><span>비합리적 선택</span><span class="stat-val" id="rIrrational" style="color:#ffd700"></span></div>
+                <div class="stat-row"><span>기회비용</span><span class="stat-val" id="rOpportunity" style="color:#4a90d9"></span></div>
+                <button class="btn btn-outline" onclick="resetDeliberation()" style="margin-top:20px">다시 테스트</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- ── 마이페이지 탭 ── -->
+    <div id="tab-mypage" class="tab-panel">
+
+        <!-- 프로필 -->
+        <div class="card">
+            <div class="card-title">내 프로필</div>
+            <div id="profileInfo"></div>
+            <div style="margin-top:12px;display:flex;flex-direction:column;gap:8px">
+                <div class="input-row"><label>닉네임</label><input id="mpNickname" placeholder="새 닉네임"></div>
+                <div class="input-row"><label>마스코트</label><input id="mpMascot" placeholder="마스코트 이름"></div>
+                <button class="btn btn-primary" onclick="updateProfile()" style="width:100%">프로필 수정</button>
+            </div>
+        </div>
+
+        <!-- 예산 설정 -->
+        <div class="card">
+            <div class="card-title">월 예산 설정</div>
+            <div class="input-row"><label>예산 (원)</label><input id="mpBudget" type="number" placeholder="예: 300000"></div>
+            <button class="btn btn-primary" onclick="updateBudget()" style="width:100%">설정</button>
+        </div>
+
+        <!-- 소비 통계 -->
+        <div class="card">
+            <div class="card-title">이번 달 통계</div>
+            <button class="btn btn-outline" onclick="loadStats()" style="width:100%;margin-bottom:10px">통계 조회</button>
+            <div id="statsResult"></div>
+        </div>
+
+        <!-- 결과 박스 -->
+        <div class="result-box" id="mpResult"></div>
+
+        <!-- 계정 -->
+        <div class="card" style="margin-top:20px">
+            <div class="card-title">계정</div>
+            <button class="btn btn-danger" onclick="deleteAccount()" style="width:100%">회원 탈퇴</button>
+        </div>
+    </div>
+
+</div><!-- /content -->
+
+<script>
+// ── 전역 상태 ─────────────────────────────────────────
+let me = null;
+let feedCursor = null;
+let feedHasMore = false;
+let currentItemId = null;
+let dAnswers = {};
+let dQuestions = [];
+
+const fmt = n => n == null ? '미설정' : n.toLocaleString() + '원';
+
+// ── API 헬퍼 ──────────────────────────────────────────
+async function api(method, path, body) {
+    const opts = { method, headers: {} };
+    if (body) { opts.headers['Content-Type'] = 'application/json'; opts.body = JSON.stringify(body); }
+    const res = await fetch(path, opts);
+    if (res.status === 401) { location.replace('/login.html'); return null; }
+    const text = await res.text();
+    try { return { ok: res.ok, status: res.status, data: text ? JSON.parse(text) : null }; }
+    catch { return { ok: res.ok, status: res.status, data: text }; }
+}
+
+// ── 초기화 ────────────────────────────────────────────
+async function init() {
+    const r = await api('GET', '/api/users/me');
+    if (!r || !r.ok) { location.replace('/login.html'); return; }
+    me = r.data;
+    document.getElementById('headerNickname').textContent = me.nickname || '사용자';
+    loadFeed();
+    loadMyProfile();
+}
+
+async function logout() {
+    await fetch('/api/logout', { method: 'POST' });
+    location.replace('/login.html');
+}
+
+// ── 탭 전환 ───────────────────────────────────────────
+function switchTab(name) {
+    document.querySelectorAll('.tab-btn').forEach((b, i) => {
+        const tabs = ['feed', 'deliberation', 'mypage'];
+        b.classList.toggle('active', tabs[i] === name);
+    });
+    document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+    document.getElementById('tab-' + name).classList.add('active');
+}
+
+// ══ 소셜 피드 탭 ═══════════════════════════════════════
+
+async function loadFeed(reset = true) {
+    if (reset) { feedCursor = null; document.getElementById('feedList').innerHTML = ''; }
+    const path = feedCursor ? `/social/posts?cursor=${feedCursor}&size=10` : '/social/posts?size=10';
+    const r = await api('GET', path);
+    if (!r || !r.ok) return;
+    const { posts, nextCursor, hasMore } = r.data;
+    feedCursor = nextCursor;
+    feedHasMore = hasMore;
+    document.getElementById('loadMoreBtn').style.display = hasMore ? 'block' : 'none';
+    if (!posts.length && reset) {
+        document.getElementById('feedList').innerHTML = '<div class="empty">게시글이 없습니다.</div>';
+        return;
+    }
+    posts.forEach(p => renderFeedCard(p));
+}
+
+function renderFeedCard(p) {
+    const el = document.createElement('div');
+    el.className = 'feed-card';
+    el.id = `post-${p.id}`;
+    const myGo = p.myVote === 'GO', myStop = p.myVote === 'STOP';
+    el.innerHTML = `
+        ${p.imageUrl ? `<img class="feed-img" src="${p.imageUrl}" alt="">` : ''}
+        <div class="feed-body">
+            <div class="feed-title">${esc(p.title)}</div>
+            ${p.body ? `<div class="feed-desc">${esc(p.body)}</div>` : ''}
+            ${p.price ? `<div class="feed-price">${p.price.toLocaleString()}원</div>` : ''}
+            <div class="vote-row">
+                <button class="vote-btn go ${myGo ? 'active' : ''}" onclick="vote('${p.id}','GO')">GO ${p.goCount}</button>
+                <button class="vote-btn stop ${myStop ? 'active' : ''}" onclick="vote('${p.id}','STOP')">STOP ${p.stopCount}</button>
+            </div>
+            <div class="feed-meta">댓글 ${p.commentCount}개 · ${fmtDate(p.createdAt)}</div>
+        </div>
+        <div class="comment-area" id="comments-${p.id}">
+            <div id="commentList-${p.id}" style="display:none"></div>
+            <button onclick="toggleComments('${p.id}')" style="background:none;border:none;color:#888;font-size:12px;cursor:pointer;padding:4px 0">댓글 보기</button>
+            <div class="comment-form">
+                <input id="ci-${p.id}" placeholder="댓글 입력...">
+                <button onclick="submitComment('${p.id}')">등록</button>
+            </div>
+        </div>
+    `;
+    document.getElementById('feedList').appendChild(el);
+}
+
+async function loadMoreFeed() { await loadFeed(false); }
+
+async function createPost() {
+    const title = document.getElementById('postTitle').value.trim();
+    if (!title) { alert('제목을 입력해주세요.'); return; }
+    const r = await api('POST', '/social/posts', {
+        title,
+        body: document.getElementById('postBody').value.trim() || null,
+        price: document.getElementById('postPrice').value ? parseInt(document.getElementById('postPrice').value) : null,
+        imageUrl: document.getElementById('postImage').value.trim() || null,
+    });
+    if (!r) return;
+    if (!r.ok) { alert('게시글 작성 실패: ' + JSON.stringify(r.data)); return; }
+    document.getElementById('postTitle').value = '';
+    document.getElementById('postBody').value = '';
+    document.getElementById('postPrice').value = '';
+    document.getElementById('postImage').value = '';
+    await loadFeed();
+}
+
+async function vote(postId, type) {
+    const r = await api('POST', `/social/posts/${postId}/votes`, { voteType: type });
+    if (!r || !r.ok) { alert('투표 실패 (로그인 필요)'); return; }
+    const { goCount, stopCount, myVote } = r.data;
+    const card = document.getElementById(`post-${postId}`);
+    if (!card) return;
+    card.querySelector('.vote-btn.go').className = `vote-btn go ${myVote === 'GO' ? 'active' : ''}`;
+    card.querySelector('.vote-btn.go').textContent = `GO ${goCount}`;
+    card.querySelector('.vote-btn.stop').className = `vote-btn stop ${myVote === 'STOP' ? 'active' : ''}`;
+    card.querySelector('.vote-btn.stop').textContent = `STOP ${stopCount}`;
+}
+
+async function toggleComments(postId) {
+    const list = document.getElementById(`commentList-${postId}`);
+    if (list.style.display === 'none') {
+        list.style.display = 'block';
+        await loadComments(postId);
+    } else {
+        list.style.display = 'none';
+    }
+}
+
+async function loadComments(postId) {
+    const r = await api('GET', `/social/posts/${postId}/comments?page=1&size=20`);
+    if (!r || !r.ok) return;
+    const list = document.getElementById(`commentList-${postId}`);
+    list.innerHTML = r.data.comments.map(c => `
+        <div class="comment-item">
+            <span>${esc(c.body)}</span>
+            ${c.mine ? `<button onclick="deleteComment('${postId}','${c.id}')" style="background:none;border:none;color:#e74c3c;font-size:11px;cursor:pointer">삭제</button>` : ''}
+        </div>
+    `).join('') || '<div style="color:#555;font-size:13px;padding:8px 0">댓글 없음</div>';
+}
+
+async function submitComment(postId) {
+    const input = document.getElementById(`ci-${postId}`);
+    if (!input.value.trim()) return;
+    const r = await api('POST', `/social/posts/${postId}/comments`, { body: input.value.trim() });
+    if (!r || !r.ok) { alert('댓글 작성 실패 (로그인 필요)'); return; }
+    input.value = '';
+    await loadComments(postId);
+}
+
+async function deleteComment(postId, commentId) {
+    const r = await api('DELETE', `/social/posts/${postId}/comments/${commentId}`);
+    if (!r) return;
+    await loadComments(postId);
+}
+
+// ══ 구매 숙려 탭 ═══════════════════════════════════════
+
+async function createTestItem() {
+    const btn = document.getElementById('createItemBtn');
+    btn.disabled = true; btn.textContent = '생성 중...';
+    const r = await api('POST', '/api/dev/wishes/test');
+    if (!r || !r.ok) {
+        document.getElementById('createMsg').textContent = '오류: ' + JSON.stringify(r?.data);
+        btn.disabled = false; btn.textContent = '테스트 아이템 만들기';
+        return;
+    }
+    currentItemId = r.data.itemId;
+    document.getElementById('createMsg').textContent = `itemId: ${currentItemId}`;
+    await loadDeliberation();
+}
+
+async function loadDeliberation() {
+    const r = await api('GET', `/api/wishes/${currentItemId}/deliberation`);
+    if (!r || !r.ok) { alert('숙려 화면 로드 실패: ' + r?.status); return; }
+    const d = r.data;
+
+    document.getElementById('dItemTitle').textContent = d.wish.title;
+    document.getElementById('dItemPrice').textContent = fmt(d.wish.price);
+    document.getElementById('dItemCategory').textContent = d.wish.category;
+    document.getElementById('dBudget').textContent = fmt(d.budget.monthlyBudget);
+    document.getElementById('dSpent').textContent = fmt(d.budget.spentAmount);
+    document.getElementById('dRemaining').textContent = fmt(d.budget.remainingBudget);
+    document.getElementById('dStatSpent').textContent = fmt(d.monthStats.spentAmount);
+    document.getElementById('dStatIrrational').textContent = d.monthStats.irrationalCount + '회';
+    document.getElementById('dStatOpportunity').textContent = fmt(d.monthStats.opportunityCost);
+
+    dQuestions = d.questions;
+    dAnswers = {};
+    document.getElementById('dQuestions').innerHTML = dQuestions.map(q => `
+        <div class="question-card">
+            <div class="question-text">${q.text}</div>
+            <div class="yn-buttons">
+                <button class="yn-btn y" onclick="selectAnswer(${q.id}, true, this)">Y</button>
+                <button class="yn-btn n" onclick="selectAnswer(${q.id}, false, this)">N</button>
+            </div>
+        </div>
+    `).join('');
+
+    document.getElementById('stepCreate').style.display = 'none';
+    document.getElementById('stepDeliberation').style.display = 'block';
+}
+
+function selectAnswer(qId, val, btn) {
+    dAnswers[qId] = val;
+    document.querySelectorAll(`[onclick*="selectAnswer(${qId},"]`).forEach(b => b.classList.remove('sel'));
+    btn.classList.add('sel');
+    updateWarning();
+    updateDecisionBtns();
+}
+
+function updateWarning() {
+    const yes = Object.values(dAnswers).filter(Boolean).length;
+    const total = Object.keys(dAnswers).length;
+    const banner = document.getElementById('dWarning');
+    if (total < dQuestions.length) { banner.className = 'warning-banner'; return; }
+    if (yes >= 2) { banner.className = 'warning-banner warn'; banner.textContent = `⚠️ Yes ${yes}개 — 충동구매일 가능성이 높아요!`; }
+    else { banner.className = 'warning-banner safe'; banner.textContent = `✅ Yes ${yes}개 — 신중한 구매예요.`; }
+}
+
+function updateDecisionBtns() {
+    const done = Object.keys(dAnswers).length === dQuestions.length;
+    document.getElementById('restrainBtn').disabled = !done;
+    document.getElementById('buyBtn').disabled = !done;
+}
+
+async function decide(decision) {
+    document.getElementById('restrainBtn').disabled = true;
+    document.getElementById('buyBtn').disabled = true;
+    const answers = dQuestions.map(q => dAnswers[q.id]);
+    const r = await api('POST', `/api/wishes/${currentItemId}/deliberation`, { answers, decision });
+    if (!r || !r.ok) {
+        alert('오류: ' + JSON.stringify(r?.data));
+        document.getElementById('restrainBtn').disabled = false;
+        document.getElementById('buyBtn').disabled = false;
+        return;
+    }
+    const d = r.data;
+    document.getElementById('rEmoji').textContent = decision === 'GO' ? '🛍️' : '💪';
+    document.getElementById('rTitle').textContent = decision === 'GO' ? '구매했어요' : '참았어요!';
+    document.getElementById('rDesc').textContent = d.warningTriggered ? `⚠️ Yes ${d.yesCount}개 — 충동구매 경고가 있었어요` : `✅ Yes ${d.yesCount}개 — 신중한 선택이었어요`;
+    document.getElementById('rYes').textContent = `${d.yesCount}개`;
+    document.getElementById('rSpent').textContent = fmt(d.monthStats.spentAmount);
+    document.getElementById('rIrrational').textContent = `${d.monthStats.irrationalCount}회`;
+    document.getElementById('rOpportunity').textContent = fmt(d.monthStats.opportunityCost);
+    document.getElementById('stepDeliberation').style.display = 'none';
+    document.getElementById('stepResult').style.display = 'block';
+}
+
+function resetDeliberation() {
+    currentItemId = null; dAnswers = {}; dQuestions = [];
+    document.getElementById('stepCreate').style.display = 'block';
+    document.getElementById('stepDeliberation').style.display = 'none';
+    document.getElementById('stepResult').style.display = 'none';
+    document.getElementById('createItemBtn').disabled = false;
+    document.getElementById('createItemBtn').textContent = '테스트 아이템 만들기';
+    document.getElementById('createMsg').textContent = '';
+}
+
+// ══ 마이페이지 탭 ══════════════════════════════════════
+
+async function loadMyProfile() {
+    const r = await api('GET', '/api/users/me');
+    if (!r || !r.ok) return;
+    me = r.data;
+    document.getElementById('headerNickname').textContent = me.nickname || '사용자';
+    document.getElementById('profileInfo').innerHTML = `
+        <div class="profile-row"><span class="profile-label">닉네임</span><span class="profile-val">${me.nickname || '-'}</span></div>
+        <div class="profile-row"><span class="profile-label">마스코트</span><span class="profile-val">${me.mascotName || '-'}</span></div>
+        <div class="profile-row"><span class="profile-label">상태</span><span class="profile-val">${me.status}</span></div>
+        <div class="profile-row"><span class="profile-label">게시글</span><span class="profile-val">${me.postCount}개</span></div>
+    `;
+}
+
+async function updateProfile() {
+    const nickname = document.getElementById('mpNickname').value.trim();
+    const raccoonName = document.getElementById('mpMascot').value.trim();
+    if (!nickname && !raccoonName) { alert('닉네임 또는 마스코트 이름을 입력해주세요.'); return; }
+    const r = await api('PATCH', '/api/users/me/profile', { nickname: nickname || null, raccoonName: raccoonName || null });
+    if (!r) return;
+    showMpResult(r);
+    if (r.ok) await loadMyProfile();
+}
+
+async function updateBudget() {
+    const budget = parseInt(document.getElementById('mpBudget').value);
+    if (!budget || budget < 0) { alert('유효한 예산을 입력해주세요.'); return; }
+    const r = await api('PATCH', '/api/users/me/budget', { monthlyBudget: budget });
+    if (!r) return;
+    showMpResult(r);
+}
+
+async function loadStats() {
+    const r = await api('GET', '/api/users/me/stats');
+    if (!r || !r.ok) { showMpResult(r); return; }
+    const d = r.data;
+    document.getElementById('statsResult').innerHTML = `
+        <div class="stat-row"><span>이번 달 예산</span><span class="stat-val">${fmt(d.budgetAmount)}</span></div>
+        <div class="stat-row"><span>소비 금액</span><span class="stat-val" style="color:#e74c3c">${fmt(d.spentAmount)}</span></div>
+        <div class="stat-row"><span>절제 금액</span><span class="stat-val" style="color:#4a90d9">${fmt(d.restrainedAmount)}</span></div>
+        <div class="stat-row"><span>구매 횟수</span><span class="stat-val">${d.boughtCount}회</span></div>
+        <div class="stat-row"><span>절제 횟수</span><span class="stat-val">${d.restrainedCount}회</span></div>
+        ${d.usageRate != null ? `<div class="stat-row"><span>예산 사용률</span><span class="stat-val">${d.usageRate}%</span></div>` : ''}
+    `;
+}
+
+async function deleteAccount() {
+    if (!confirm('정말 탈퇴하시겠습니까? 모든 데이터가 삭제됩니다.')) return;
+    const r = await api('DELETE', '/api/users/me');
+    if (!r) return;
+    if (r.status === 204) { alert('탈퇴 완료'); location.replace('/login.html'); }
+    else showMpResult(r);
+}
+
+function showMpResult(r) {
+    if (!r) return;
+    const box = document.getElementById('mpResult');
+    box.textContent = JSON.stringify(r.data, null, 2);
+    box.className = 'result-box visible';
+}
+
+// ── 유틸 ──────────────────────────────────────────────
+function esc(s) {
+    if (!s) return '';
+    const d = document.createElement('div'); d.textContent = s; return d.innerHTML;
+}
+function fmtDate(s) {
+    if (!s) return '';
+    return new Date(s).toLocaleDateString('ko-KR', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+}
+
+// ── 시작 ──────────────────────────────────────────────
+init();
+</script>
+</body>
+</html>

--- a/src/main/resources/static/deliberation.html
+++ b/src/main/resources/static/deliberation.html
@@ -1,0 +1,424 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>구매 숙려 테스트</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; background: #111; color: #fff; min-height: 100vh; }
+
+        /* 로그인 화면 */
+        .login-screen { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100vh; gap: 16px; }
+        .login-screen h1 { font-size: 24px; margin-bottom: 8px; }
+        .login-screen p { color: #888; font-size: 14px; margin-bottom: 16px; }
+        .login-btn { padding: 12px 32px; border-radius: 24px; border: none; font-size: 16px; font-weight: 600; cursor: pointer; }
+        .kakao { background: #FEE500; color: #000; }
+        .google { background: #fff; color: #333; }
+        .naver { background: #03C75A; color: #fff; }
+
+        /* 셋업 화면 */
+        .setup-screen { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100vh; gap: 16px; padding: 24px; }
+        .setup-screen h2 { font-size: 20px; }
+        .setup-screen p { color: #888; font-size: 14px; text-align: center; }
+        .create-btn { padding: 14px 36px; border-radius: 24px; border: none; background: #4a90d9; color: #fff; font-size: 16px; font-weight: 600; cursor: pointer; }
+        .create-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+        /* 숙려 화면 */
+        .deliberation-screen { display: none; max-width: 420px; margin: 0 auto; padding: 24px 20px 80px; }
+
+        /* 상품 카드 */
+        .product-card { background: #1a1a1a; border-radius: 16px; padding: 20px; margin-bottom: 16px; }
+        .product-card img { width: 100%; height: 180px; object-fit: cover; border-radius: 10px; margin-bottom: 12px; display: none; }
+        .product-card img.loaded { display: block; }
+        .product-category { font-size: 12px; color: #888; margin-bottom: 4px; }
+        .product-title { font-size: 20px; font-weight: 700; margin-bottom: 6px; }
+        .product-price { font-size: 22px; font-weight: 700; color: #ffd700; }
+
+        /* 예산 카드 */
+        .budget-card { background: #1a1a1a; border-radius: 16px; padding: 20px; margin-bottom: 16px; }
+        .budget-card h3 { font-size: 14px; color: #888; margin-bottom: 12px; }
+        .budget-row { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
+        .budget-row:last-child { margin-bottom: 0; }
+        .budget-label { font-size: 14px; color: #aaa; }
+        .budget-value { font-size: 16px; font-weight: 600; }
+        .budget-remaining { color: #4a90d9; }
+        .budget-bar { width: 100%; height: 6px; background: #333; border-radius: 3px; margin-top: 12px; }
+        .budget-bar-fill { height: 100%; border-radius: 3px; background: #4a90d9; transition: width 0.5s; }
+
+        /* 구분선 */
+        .section-title { font-size: 13px; font-weight: 600; color: #888; text-transform: uppercase; letter-spacing: 0.5px; margin: 24px 0 12px; }
+
+        /* 질문 카드 */
+        .question-card { background: #1a1a1a; border-radius: 16px; padding: 18px 20px; margin-bottom: 10px; display: flex; justify-content: space-between; align-items: center; gap: 12px; }
+        .question-text { font-size: 15px; line-height: 1.4; flex: 1; }
+        .yn-buttons { display: flex; gap: 6px; flex-shrink: 0; }
+        .yn-btn { width: 44px; height: 36px; border-radius: 8px; border: 1px solid #444; background: transparent; color: #888; font-size: 13px; font-weight: 600; cursor: pointer; transition: all 0.15s; }
+        .yn-btn.yes.selected { background: #e74c3c; border-color: #e74c3c; color: #fff; }
+        .yn-btn.no.selected { background: #27ae60; border-color: #27ae60; color: #fff; }
+
+        /* 경고 배너 */
+        .warning-banner { border-radius: 12px; padding: 14px 16px; margin: 16px 0; font-size: 14px; font-weight: 600; text-align: center; display: none; }
+        .warning-banner.danger { background: rgba(231, 76, 60, 0.15); border: 1px solid #e74c3c; color: #e74c3c; }
+        .warning-banner.safe { background: rgba(39, 174, 96, 0.15); border: 1px solid #27ae60; color: #27ae60; }
+
+        /* 이달 통계 */
+        .stats-card { background: #1a1a1a; border-radius: 16px; padding: 20px; margin-bottom: 16px; }
+        .stats-card h3 { font-size: 14px; color: #888; margin-bottom: 14px; }
+        .stat-row { display: flex; justify-content: space-between; align-items: center; padding: 8px 0; border-bottom: 1px solid #222; }
+        .stat-row:last-child { border-bottom: none; padding-bottom: 0; }
+        .stat-label { font-size: 14px; color: #aaa; }
+        .stat-value { font-size: 16px; font-weight: 700; }
+        .stat-value.red { color: #e74c3c; }
+        .stat-value.yellow { color: #ffd700; }
+        .stat-value.blue { color: #4a90d9; }
+
+        /* 결정 버튼 */
+        .decision-area { position: fixed; bottom: 0; left: 0; right: 0; padding: 16px 20px; background: #111; border-top: 1px solid #222; display: none; }
+        .decision-buttons { display: flex; gap: 10px; max-width: 420px; margin: 0 auto; }
+        .decision-btn { flex: 1; padding: 16px; border-radius: 14px; border: none; font-size: 16px; font-weight: 700; cursor: pointer; transition: all 0.2s; }
+        .decision-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+        .decision-btn.restrain { background: #4a90d9; color: #fff; }
+        .decision-btn.buy { background: #e74c3c; color: #fff; }
+        .decision-btn:not(:disabled):active { transform: scale(0.97); }
+
+        /* 결과 화면 */
+        .result-screen { display: none; flex-direction: column; align-items: center; justify-content: center; min-height: 100vh; padding: 40px 24px; text-align: center; }
+        .result-screen h2 { font-size: 28px; margin-bottom: 8px; }
+        .result-screen p { color: #888; font-size: 14px; margin-bottom: 32px; }
+        .result-stats { background: #1a1a1a; border-radius: 16px; padding: 24px; width: 100%; max-width: 340px; margin-bottom: 24px; }
+        .result-row { display: flex; justify-content: space-between; padding: 10px 0; border-bottom: 1px solid #222; }
+        .result-row:last-child { border-bottom: none; }
+        .reset-btn { padding: 12px 32px; border-radius: 24px; border: 1px solid #444; background: transparent; color: #aaa; font-size: 14px; cursor: pointer; }
+
+        .hidden { display: none !important; }
+        .loading { color: #888; font-size: 14px; text-align: center; padding: 40px; }
+    </style>
+</head>
+<body>
+
+<!-- 로그인 화면 -->
+<div id="loginScreen" class="login-screen">
+    <h1>구매 숙려 테스트</h1>
+    <p>테스트를 위해 소셜 로그인이 필요합니다</p>
+    <button class="login-btn kakao" onclick="login('kakao')">카카오로 시작</button>
+    <button class="login-btn google" onclick="login('google')">Google로 시작</button>
+    <button class="login-btn naver" onclick="login('naver')">네이버로 시작</button>
+</div>
+
+<!-- 셋업 화면 -->
+<div id="setupScreen" class="setup-screen hidden">
+    <h2>구매 숙려 화면 테스트</h2>
+    <p>24시간이 경과한 테스트 위시를<br>자동으로 생성합니다</p>
+    <button class="create-btn" id="createBtn" onclick="createTestWish()">테스트 위시 만들기</button>
+    <p id="setupMsg" style="color:#888;font-size:13px;margin-top:8px"></p>
+</div>
+
+<!-- 숙려 화면 -->
+<div id="deliberationScreen" class="deliberation-screen hidden">
+
+    <div class="section-title">구매 예정 상품</div>
+    <div class="product-card">
+        <img id="productImg" alt="상품 이미지">
+        <div class="product-category" id="productCategory"></div>
+        <div class="product-title" id="productTitle"></div>
+        <div class="product-price" id="productPrice"></div>
+    </div>
+
+    <div class="section-title">이번 달 예산</div>
+    <div class="budget-card">
+        <div class="budget-row">
+            <span class="budget-label">이번 달 예산</span>
+            <span class="budget-value" id="budgetMonthly">-</span>
+        </div>
+        <div class="budget-row">
+            <span class="budget-label">사용한 금액</span>
+            <span class="budget-value" id="budgetSpent">-</span>
+        </div>
+        <div class="budget-row">
+            <span class="budget-label">남은 예산</span>
+            <span class="budget-value budget-remaining" id="budgetRemaining">-</span>
+        </div>
+        <div class="budget-bar"><div class="budget-bar-fill" id="budgetBarFill" style="width:0%"></div></div>
+    </div>
+
+    <div class="section-title">충동구매 점검</div>
+    <div id="questionList"></div>
+
+    <div class="warning-banner" id="warningBanner"></div>
+
+    <div class="section-title">이번 달 소비 현황</div>
+    <div class="stats-card">
+        <div class="stat-row">
+            <span class="stat-label">이번 달 사용 금액</span>
+            <span class="stat-value red" id="statSpent">-</span>
+        </div>
+        <div class="stat-row">
+            <span class="stat-label">비합리적 선택</span>
+            <span class="stat-value yellow" id="statIrrational">-</span>
+        </div>
+        <div class="stat-row">
+            <span class="stat-label">기회비용 (절제한 금액)</span>
+            <span class="stat-value blue" id="statOpportunity">-</span>
+        </div>
+    </div>
+
+</div>
+
+<!-- 결정 버튼 (하단 고정) -->
+<div class="decision-area" id="decisionArea">
+    <div class="decision-buttons">
+        <button class="decision-btn restrain" id="restrainBtn" onclick="decide('RESTRAINED')" disabled>참을게요</button>
+        <button class="decision-btn buy" id="buyBtn" onclick="decide('BOUGHT')" disabled>살게요</button>
+    </div>
+</div>
+
+<!-- 결과 화면 -->
+<div id="resultScreen" class="result-screen hidden">
+    <h2 id="resultEmoji"></h2>
+    <h2 id="resultTitle"></h2>
+    <p id="resultDesc"></p>
+    <div class="result-stats">
+        <div class="result-row">
+            <span style="color:#aaa;font-size:14px">Yes 응답 수</span>
+            <span style="font-weight:700" id="resYesCount"></span>
+        </div>
+        <div class="result-row">
+            <span style="color:#aaa;font-size:14px">이번 달 소비</span>
+            <span style="font-weight:700;color:#e74c3c" id="resSpent"></span>
+        </div>
+        <div class="result-row">
+            <span style="color:#aaa;font-size:14px">비합리적 선택</span>
+            <span style="font-weight:700;color:#ffd700" id="resIrrational"></span>
+        </div>
+        <div class="result-row">
+            <span style="color:#aaa;font-size:14px">기회비용</span>
+            <span style="font-weight:700;color:#4a90d9" id="resOpportunity"></span>
+        </div>
+    </div>
+    <button class="reset-btn" onclick="location.reload()">다시 테스트</button>
+</div>
+
+<script>
+    let wishId = null;
+    let questions = [];
+    let answers = {};   // {1: true/false, 2: ..., 3: ..., 4: ...}
+
+    const fmt = n => n == null ? '미설정' : n.toLocaleString() + '원';
+
+    // ─── 로그인 ──────────────────────────────────────────
+    function login(provider) {
+        // 로그인 후 이 페이지로 돌아오도록 세션스토리지에 저장
+        sessionStorage.setItem('returnTo', '/deliberation.html');
+        location.href = `/oauth2/authorization/${provider}`;
+    }
+
+    // ─── 초기화 ──────────────────────────────────────────
+    async function init() {
+        // 로그인 여부 확인 — 200 외에는 모두 미로그인으로 처리
+        try {
+            const res = await fetch('/api/users/me');
+            if (!res.ok) {
+                show('loginScreen');
+                return;
+            }
+        } catch (e) {
+            show('loginScreen');
+            return;
+        }
+        show('setupScreen');
+    }
+
+    // ─── 테스트 위시 생성 ─────────────────────────────────
+    async function createTestWish() {
+        const btn = document.getElementById('createBtn');
+        const msg = document.getElementById('setupMsg');
+        btn.disabled = true;
+        btn.textContent = '생성 중...';
+
+        const res = await fetch('/api/dev/wishes/test', { method: 'POST' });
+        if (!res.ok) {
+            msg.textContent = '오류: ' + (await res.text());
+            btn.disabled = false;
+            btn.textContent = '테스트 위시 만들기';
+            return;
+        }
+        const data = await res.json();
+        wishId = data.wishId;
+        msg.textContent = `wishId: ${wishId}`;
+
+        await loadDeliberation();
+    }
+
+    // ─── 숙려 화면 로드 ───────────────────────────────────
+    async function loadDeliberation() {
+        const res = await fetch(`/api/wishes/${wishId}/deliberation`);
+        if (!res.ok) {
+            alert('숙려 화면 로드 실패: ' + res.status);
+            return;
+        }
+        const data = await res.json();
+
+        // 상품 정보
+        document.getElementById('productCategory').textContent = data.wish.category;
+        document.getElementById('productTitle').textContent = data.wish.title;
+        document.getElementById('productPrice').textContent = fmt(data.wish.price);
+        if (data.wish.imageUrl) {
+            const img = document.getElementById('productImg');
+            img.src = data.wish.imageUrl;
+            img.onload = () => img.classList.add('loaded');
+        }
+
+        // 예산 정보
+        document.getElementById('budgetMonthly').textContent = fmt(data.budget.monthlyBudget);
+        document.getElementById('budgetSpent').textContent = fmt(data.budget.spentAmount);
+        document.getElementById('budgetRemaining').textContent = fmt(data.budget.remainingBudget);
+        if (data.budget.monthlyBudget) {
+            const pct = Math.min(100, (data.budget.spentAmount / data.budget.monthlyBudget) * 100);
+            document.getElementById('budgetBarFill').style.width = pct + '%';
+        }
+
+        // 통계
+        document.getElementById('statSpent').textContent = fmt(data.monthStats.spentAmount);
+        document.getElementById('statIrrational').textContent = data.monthStats.irrationalCount + '회';
+        document.getElementById('statOpportunity').textContent = fmt(data.monthStats.opportunityCost);
+
+        // 질문 렌더링
+        questions = data.questions;
+        const list = document.getElementById('questionList');
+        list.innerHTML = questions.map(q => `
+            <div class="question-card">
+                <div class="question-text">${q.text}</div>
+                <div class="yn-buttons">
+                    <button class="yn-btn yes" data-q="${q.id}" data-v="true" onclick="selectAnswer(${q.id}, true, this)">Y</button>
+                    <button class="yn-btn no"  data-q="${q.id}" data-v="false" onclick="selectAnswer(${q.id}, false, this)">N</button>
+                </div>
+            </div>
+        `).join('');
+
+        show('deliberationScreen');
+        document.getElementById('decisionArea').style.display = 'block';
+    }
+
+    // ─── 답변 선택 ────────────────────────────────────────
+    function selectAnswer(qId, value, btn) {
+        answers[qId] = value;
+
+        // 같은 질문 버튼 스타일 리셋
+        document.querySelectorAll(`[data-q="${qId}"]`).forEach(b => {
+            b.classList.remove('selected');
+        });
+        btn.classList.add('selected');
+
+        updateWarning();
+        updateDecisionBtns();
+    }
+
+    function updateWarning() {
+        const yesCount = Object.values(answers).filter(v => v === true).length;
+        const answeredCount = Object.keys(answers).length;
+        const banner = document.getElementById('warningBanner');
+
+        if (answeredCount < questions.length) {
+            banner.style.display = 'none';
+            return;
+        }
+
+        banner.style.display = 'block';
+        if (yesCount >= 2) {
+            banner.className = 'warning-banner danger';
+            banner.textContent = `⚠️ Yes ${yesCount}개 — 충동구매일 가능성이 높아요!`;
+        } else {
+            banner.className = 'warning-banner safe';
+            banner.textContent = `✅ Yes ${yesCount}개 — 신중한 구매예요.`;
+        }
+    }
+
+    function updateDecisionBtns() {
+        const allAnswered = Object.keys(answers).length === questions.length;
+        document.getElementById('restrainBtn').disabled = !allAnswered;
+        document.getElementById('buyBtn').disabled = !allAnswered;
+    }
+
+    // ─── 결정 제출 ────────────────────────────────────────
+    async function decide(decision) {
+        document.getElementById('restrainBtn').disabled = true;
+        document.getElementById('buyBtn').disabled = true;
+
+        const answersArr = questions.map(q => answers[q.id]);
+
+        try {
+            const res = await fetch(`/api/wishes/${wishId}/deliberation`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ answers: answersArr, decision })
+            });
+
+            const text = await res.text();
+            console.log('[decide] status:', res.status, 'body:', text);
+
+            if (!res.ok) {
+                showError(`서버 오류 ${res.status}: ${text}`);
+                return;
+            }
+
+            const data = JSON.parse(text);
+            showResult(data);
+        } catch (e) {
+            console.error('[decide] 예외:', e);
+            showError('네트워크 오류: ' + e.message);
+        }
+    }
+
+    function showError(msg) {
+        document.getElementById('restrainBtn').disabled = false;
+        document.getElementById('buyBtn').disabled = false;
+        const banner = document.getElementById('warningBanner');
+        banner.style.display = 'block';
+        banner.className = 'warning-banner danger';
+        banner.textContent = '❌ ' + msg;
+    }
+
+    // ─── 결과 화면 ────────────────────────────────────────
+    function showResult(data) {
+        const isBought = data.decision === 'BOUGHT';
+        document.getElementById('resultEmoji').textContent = isBought ? '🛍️' : '💪';
+        document.getElementById('resultTitle').textContent = isBought ? '구매했어요' : '참았어요!';
+        document.getElementById('resultDesc').textContent = data.warningTriggered
+            ? `⚠️ Yes ${data.yesCount}개 — 충동구매 경고가 있었어요`
+            : `✅ Yes ${data.yesCount}개 — 신중한 선택이었어요`;
+
+        document.getElementById('resYesCount').textContent = `${data.yesCount}개`;
+        document.getElementById('resSpent').textContent = fmt(data.monthStats.spentAmount);
+        document.getElementById('resIrrational').textContent = `${data.monthStats.irrationalCount}회`;
+        document.getElementById('resOpportunity').textContent = fmt(data.monthStats.opportunityCost);
+
+        document.getElementById('decisionArea').style.display = 'none';
+        show('resultScreen');
+    }
+
+    // ─── 화면 전환 ────────────────────────────────────────
+    const SCREEN_DISPLAY = {
+        loginScreen: 'flex',
+        setupScreen: 'flex',
+        deliberationScreen: 'block',
+        resultScreen: 'flex'
+    };
+
+    function show(id) {
+        Object.keys(SCREEN_DISPLAY).forEach(s => {
+            const el = document.getElementById(s);
+            if (s === id) {
+                el.classList.remove('hidden');
+                el.style.display = SCREEN_DISPLAY[s];
+            } else {
+                el.classList.add('hidden');
+                el.style.display = 'none';
+            }
+        });
+    }
+
+    init();
+</script>
+</body>
+</html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Wigul</title>
+    <script>
+        // localhost:8080 진입 시 로그인 여부 체크 후 라우팅
+        fetch('/api/users/me').then(res => {
+            if (res.ok) location.replace('/app.html');
+            else location.replace('/login.html');
+        }).catch(() => location.replace('/login.html'));
+    </script>
+</head>
+<body></body>
+</html>

--- a/src/main/resources/static/login.html
+++ b/src/main/resources/static/login.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Wigul - 로그인</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+            background: #111; color: #fff;
+            display: flex; flex-direction: column;
+            align-items: center; justify-content: center;
+            height: 100vh; gap: 0;
+        }
+        .logo { font-size: 36px; font-weight: 800; letter-spacing: -1px; margin-bottom: 8px; }
+        .tagline { font-size: 14px; color: #888; margin-bottom: 48px; }
+        .login-buttons { display: flex; flex-direction: column; gap: 12px; width: 280px; }
+        .login-btn {
+            padding: 14px 24px; border-radius: 12px; border: none;
+            font-size: 15px; font-weight: 600; cursor: pointer;
+            display: flex; align-items: center; justify-content: center; gap: 8px;
+            transition: opacity 0.15s;
+        }
+        .login-btn:active { opacity: 0.8; }
+        .kakao { background: #FEE500; color: #191919; }
+        .google { background: #fff; color: #333; border: 1px solid #ddd; }
+        .naver { background: #03C75A; color: #fff; }
+        .error-msg { color: #e74c3c; font-size: 13px; margin-top: 16px; display: none; }
+    </style>
+</head>
+<body>
+    <div class="logo">Wigul</div>
+    <div class="tagline">충동구매를 줄이는 가장 현명한 방법</div>
+    <div class="login-buttons">
+        <button class="login-btn kakao" onclick="login('kakao')">카카오로 시작하기</button>
+        <button class="login-btn google" onclick="login('google')">Google로 시작하기</button>
+        <button class="login-btn naver" onclick="login('naver')">네이버로 시작하기</button>
+    </div>
+    <div class="error-msg" id="errorMsg"></div>
+
+    <script>
+        // 이미 로그인된 경우 app.html로 이동
+        fetch('/api/users/me').then(res => {
+            if (res.ok) location.replace('/app.html');
+        });
+
+        function login(provider) {
+            location.href = `/oauth2/authorization/${provider}`;
+        }
+
+        // 로그인 실패 메시지 처리
+        const params = new URLSearchParams(location.search);
+        if (params.get('error')) {
+            const msg = document.getElementById('errorMsg');
+            msg.textContent = '로그인에 실패했습니다. 다시 시도해주세요.';
+            msg.style.display = 'block';
+        }
+    </script>
+</body>
+</html>

--- a/src/main/resources/static/test-mypage.html
+++ b/src/main/resources/static/test-mypage.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>마이페이지 API 테스트</title>
+</head>
+<body>
+
+<h1>마이페이지 API 테스트</h1>
+<p>서버: <code>http://localhost:8080</code> | 로그인 먼저 해야 인증이 필요한 API가 동작합니다.</p>
+<hr>
+
+<!-- ───────────────────────────────────────────────── -->
+<h2>0. 소셜 로그인</h2>
+<button onclick="location.href='/oauth2/authorization/google'">Google 로그인</button>
+<button onclick="location.href='/oauth2/authorization/kakao'">Kakao 로그인</button>
+<button onclick="location.href='/oauth2/authorization/naver'">Naver 로그인</button>
+<button onclick="call('POST','/api/logout')">로그아웃</button>
+<hr>
+
+<!-- ───────────────────────────────────────────────── -->
+<h2>1. 내 정보 조회 GET /api/users/me</h2>
+<button onclick="call('GET','/api/users/me')">조회</button>
+<hr>
+
+<!-- ───────────────────────────────────────────────── -->
+<h2>2. 프로필 수정 PATCH /api/users/me/profile</h2>
+<label>닉네임: <input id="profile-nickname" value="테스트닉네임"></label>
+<label>너구리 이름: <input id="profile-raccoon" value="너굴이"></label>
+<button onclick="call('PATCH','/api/users/me/profile',{
+  nickname: v('profile-nickname'),
+  raccoonName: v('profile-raccoon')
+})">수정</button>
+<hr>
+
+<!-- ───────────────────────────────────────────────── -->
+<h2>3. 월 예산 설정 PATCH /api/users/me/budget</h2>
+<label>월 예산(원): <input id="budget" type="number" value="300000"></label>
+<button onclick="call('PATCH','/api/users/me/budget',{
+  monthlyBudget: Number(v('budget'))
+})">설정</button>
+<hr>
+
+<!-- ───────────────────────────────────────────────── -->
+<h2>4. 알림 설정 PATCH /api/users/me/notification-settings</h2>
+<label>알림 수신:
+  <select id="noti">
+    <option value="true">ON</option>
+    <option value="false">OFF</option>
+  </select>
+</label>
+<button onclick="call('PATCH','/api/users/me/notification-settings',{
+  notificationEnabled: document.getElementById('noti').value === 'true'
+})">변경</button>
+<hr>
+
+<!-- ───────────────────────────────────────────────── -->
+<h2>5. 소비 통계 GET /api/users/me/stats</h2>
+<label>년월(YYYY-MM): <input id="stats-ym" value="2026-04"></label>
+<button onclick="call('GET','/api/users/me/stats?year_month='+v('stats-ym'))">조회</button>
+<hr>
+
+<!-- ───────────────────────────────────────────────── -->
+<h2>6. 소비 기록 GET /api/users/me/wishes/history</h2>
+<label>상태:
+  <select id="history-status">
+    <option value="">전체</option>
+    <option value="BOUGHT">BOUGHT</option>
+    <option value="RESTRAINED">RESTRAINED</option>
+  </select>
+</label>
+<label>년월: <input id="history-ym" value="2026-04"></label>
+<label>page: <input id="history-page" type="number" value="0" style="width:40px"></label>
+<label>size: <input id="history-size" type="number" value="20" style="width:40px"></label>
+<button onclick="(function(){
+  let q='year_month='+v('history-ym')+'&page='+v('history-page')+'&size='+v('history-size');
+  let s=v('history-status'); if(s) q+='&status='+s;
+  call('GET','/api/users/me/wishes/history?'+q);
+})()">조회</button>
+<hr>
+
+<!-- ───────────────────────────────────────────────── -->
+<h2>7. 나의 게시글 GET /api/users/me/posts</h2>
+<label>size: <input id="posts-size" type="number" value="20" style="width:40px"></label>
+<button onclick="call('GET','/api/users/me/posts?size='+v('posts-size'))">조회</button>
+<hr>
+
+<!-- ───────────────────────────────────────────────── -->
+<h2>8. 내가 투표한 게시글 GET /api/users/me/votes</h2>
+<button onclick="call('GET','/api/users/me/votes')">조회</button>
+<hr>
+
+<!-- ───────────────────────────────────────────────── -->
+<h2>9. 약관 목록 GET /api/terms</h2>
+<button onclick="call('GET','/api/terms')">조회</button>
+<hr>
+
+<!-- ───────────────────────────────────────────────── -->
+<h2>10. 약관 단건 GET /api/terms/{type}</h2>
+<label>타입:
+  <select id="terms-type">
+    <option value="SERVICE">SERVICE (서비스 이용약관)</option>
+    <option value="PRIVACY">PRIVACY (개인정보처리방침)</option>
+    <option value="MARKETING">MARKETING (마케팅 수신 동의)</option>
+  </select>
+</label>
+<button onclick="call('GET','/api/terms/'+document.getElementById('terms-type').value)">조회</button>
+<hr>
+
+<!-- ───────────────────────────────────────────────── -->
+<h2>11. 계정 탈퇴 DELETE /api/users/me</h2>
+<p style="color:red">⚠ 모든 데이터가 삭제됩니다. 신중하게 누르세요.</p>
+<button onclick="if(confirm('정말 탈퇴하시겠습니까?')) call('DELETE','/api/users/me')">탈퇴</button>
+<hr>
+
+<!-- ───────────────────────────────────────────────── -->
+<h2>결과</h2>
+<pre id="result" style="background:#f4f4f4;padding:12px;min-height:60px;white-space:pre-wrap;word-break:break-all"></pre>
+
+<script>
+  function v(id) { return document.getElementById(id).value; }
+
+  async function call(method, url, body) {
+    const opts = { method, headers: { 'Content-Type': 'application/json' }, credentials: 'include' };
+    if (body) opts.body = JSON.stringify(body);
+    const res = await fetch(url, opts);
+    const text = await res.text();
+    let parsed;
+    try { parsed = JSON.parse(text); } catch(e) { parsed = text; }
+    document.getElementById('result').textContent =
+      method + ' ' + url + '\n' +
+      'HTTP ' + res.status + '\n\n' +
+      (typeof parsed === 'string' ? parsed : JSON.stringify(parsed, null, 2));
+  }
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
 ## 🔗 작업 키 / 이슈 링크                                 
  - Tracking Key: -
  - GitHub: Related -                                                        
  - GitHub: Related #34
                                                                                     
  ---                                                       

  ## 🧩 이 PR의 변경사항

  ### 전체 중 위치
  - 전체 이슈 #이슈번호의 4/5 단계
  - 선행 PR: #34(feat/3-wish-deliberation, 머지 필요)                          
                                                                                     
  ### 이 PR에서 변경한 것                                   
  - `UserAccount`: `withdraw()` 메서드 추가                                          
  - `UserProfile`: getter / factory method / `updateProfile` / `notificationEnabled` 
  필드 추가                                                                          
  - `BudgetCycle`: getter / factory method / `updateBudgetAmount` 추가               
  - `SavedItem`: getter 추가                                                         
  - `UserProfileRepository`, `BudgetCycleRepository`, `SavedItemRepository` 신규 추가
  - `SocialAccountRepository`: `findByUserId` 추가                                   
  - `mypage/` 패키지 신규: `MypageController`, `MypageService`, DTO 7개
                                                                                     
  ---                                                       
                                                                                     
  ## ✅ AC 

  ### Covers
  - AC1: 내 프로필 조회 / 닉네임·너구리 이름 수정
  - AC2: 월 예산 설정                                                                
  - AC3: 알림 수신 설정 조회 / 변경
  - AC4: 계정 탈퇴 (관련 데이터 일괄 삭제)                                           
  - AC5: 소비 기록 있는 월 목록 조회                                                 
  - AC6: 월별 소비 통계 (예산 / 지출 / 절제 금액, 사용률)                            
  - AC7: 소비/절제 기록 목록 (상태/월 필터)                                          
  - AC8: 내가 작성한 게시글 / 내가 투표한 게시글 (커서 페이징)                       
                                                                                     
  ### Not covered                                                                    
  - 카테고리별 통계 (`byCategory`): 빈 배열로 응답 → 후속 이슈로 분리 필요           
  - 프로필 이미지 직접 업로드: 범위 외                                               
                                                                                     
  ---                                                                                
                                                                                     
  ## 🧪 테스트 결과                                         

  ### 로컬
  - ✅ `./gradlew compileJava` 통과

  ### Smoke 테스트                                                                   
  - 시나리오: 로그인 → `GET /api/v1/users/me` → 예산 설정 → 통계 조회
  - 결과: 직접 확인 필요                                                             
                                                            
  ---                                                                                
                                                            
  ## 🧭 영향 범위 체크
  - [x] API 변경 (요약: `/api/v1/users/me` 신규 엔드포인트 11개)
  - [x] DB 변경 (마이그레이션: `user_profiles.notification_enabled` 컬럼 추가 필요)  
  - [ ] 설정 변경                                                                    
  - [ ] Breaking change                                                              
                                                                                     
  ---                                                       

  ## 💬 리뷰 포인트
  - `deleteAccount()` — 삭제 순서 확인 (FK 제약으로 인한 순서 의존성)
  - `UserProfile.notificationEnabled` 필드가 기존 DB 스키마에 없음 → **마이그레이션  
  추가 필요**                                                                        
  - `getStats()`의 `byCategory` 필드가 빈 배열로 반환됨 — 프론트와 빈 배열 처리 합의 
  필요