### PR TITLE
[bug] NF-29 인증/OAuth 보안 계약 보완

### DIFF
--- a/src/main/java/com/sagongsa/backend/auth/AppRedirectUriSupport.java
+++ b/src/main/java/com/sagongsa/backend/auth/AppRedirectUriSupport.java
@@ -153,10 +153,10 @@ public class AppRedirectUriSupport {
 
 		String allowedPath = Optional.ofNullable(allowedUri.getPath()).orElse("");
 		String requestedPath = Optional.ofNullable(requestedUri.getPath()).orElse("");
-		return allowedPath.isBlank()
-			|| "/".equals(allowedPath)
-			|| requestedPath.equals(allowedPath)
-			|| requestedPath.startsWith(allowedPath.endsWith("/") ? allowedPath : allowedPath + "/");
+		if (allowedPath.isBlank() || "/".equals(allowedPath)) {
+			return requestedPath.isBlank() || "/".equals(requestedPath);
+		}
+		return requestedPath.equals(allowedPath);
 	}
 
 	private boolean sameText(String first, String second) {

--- a/src/main/java/com/sagongsa/backend/auth/AuthApiController.java
+++ b/src/main/java/com/sagongsa/backend/auth/AuthApiController.java
@@ -42,8 +42,7 @@ public class AuthApiController {
 			profile.email(),
 			profile.profileImageUrl(),
 			authentication.getName(),
-			authorities,
-			profile.rawAttributes()
+			authorities
 		);
 	}
 
@@ -86,8 +85,7 @@ public class AuthApiController {
 		String email,
 		String profileImageUrl,
 		String principalName,
-		List<String> authorities,
-		Object rawAttributes
+		List<String> authorities
 	) {
 	}
 

--- a/src/main/java/com/sagongsa/backend/auth/CurrentUserIdArgumentResolver.java
+++ b/src/main/java/com/sagongsa/backend/auth/CurrentUserIdArgumentResolver.java
@@ -5,6 +5,8 @@ import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -40,14 +42,15 @@ class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResolver {
 		NativeWebRequest webRequest,
 		WebDataBinderFactory binderFactory
 	) {
+		Principal principal = webRequest.getUserPrincipal();
+		UUID principalUserId = resolvePrincipalUserId(principal);
+		if (principalUserId != null) {
+			return principalUserId;
+		}
+
 		String rawUserId = webRequest.getHeader(trustedHeaderName);
 		if (trustedHeaderEnabled && StringUtils.hasText(rawUserId)) {
 			return parseUserId(rawUserId, trustedHeaderName + " header");
-		}
-
-		Principal principal = webRequest.getUserPrincipal();
-		if (principal != null && StringUtils.hasText(principal.getName())) {
-			return parseUserId(principal.getName(), "authenticated principal");
 		}
 
 		if (trustedHeaderEnabled) {
@@ -63,5 +66,24 @@ class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResolver {
 		} catch (IllegalArgumentException exception) {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, source + " must be a UUID.");
 		}
+	}
+
+	private UUID resolvePrincipalUserId(Principal principal) {
+		if (principal == null) {
+			return null;
+		}
+		if (principal instanceof Authentication authentication && authentication.getPrincipal() instanceof Jwt jwt) {
+			String claimUserId = jwt.getClaimAsString("userId");
+			if (StringUtils.hasText(claimUserId)) {
+				return parseUserId(claimUserId, "authenticated JWT userId claim");
+			}
+			if (StringUtils.hasText(jwt.getSubject())) {
+				return parseUserId(jwt.getSubject(), "authenticated JWT subject");
+			}
+		}
+		if (StringUtils.hasText(principal.getName())) {
+			return parseUserId(principal.getName(), "authenticated principal");
+		}
+		return null;
 	}
 }

--- a/src/main/java/com/sagongsa/backend/auth/JwtTokenService.java
+++ b/src/main/java/com/sagongsa/backend/auth/JwtTokenService.java
@@ -1,12 +1,17 @@
 package com.sagongsa.backend.auth;
 
 import com.sagongsa.backend.config.AppAuthProperties;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.HexFormat;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.UUID;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -17,6 +22,7 @@ import org.springframework.security.oauth2.jwt.JwtClaimsSet;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -26,11 +32,18 @@ public class JwtTokenService {
 	private final JwtEncoder jwtEncoder;
 	private final JwtDecoder jwtDecoder;
 	private final AppAuthProperties properties;
+	private final JdbcTemplate jdbcTemplate;
 
-	public JwtTokenService(JwtEncoder jwtEncoder, JwtDecoder jwtDecoder, AppAuthProperties properties) {
+	public JwtTokenService(
+		JwtEncoder jwtEncoder,
+		JwtDecoder jwtDecoder,
+		AppAuthProperties properties,
+		JdbcTemplate jdbcTemplate
+	) {
 		this.jwtEncoder = jwtEncoder;
 		this.jwtDecoder = jwtDecoder;
 		this.properties = properties;
+		this.jdbcTemplate = jdbcTemplate;
 	}
 
 	public TokenPair issueTokenPair(SocialUserProfile profile, Collection<? extends GrantedAuthority> authorities) {
@@ -39,13 +52,16 @@ public class JwtTokenService {
 
 		String accessToken = encodeToken(buildClaims(profile, authorityNames, issuedAt, issuedAt.plus(properties.getAccessTokenTtl()), "access"));
 		String refreshToken = encodeToken(buildClaims(profile, authorityNames, issuedAt, issuedAt.plus(properties.getRefreshTokenTtl()), "refresh"));
+		Instant refreshTokenExpiresAt = issuedAt.plus(properties.getRefreshTokenTtl());
+
+		storeRefreshToken(profile.userId(), refreshToken, refreshTokenExpiresAt, issuedAt);
 
 		return new TokenPair(
 			"Bearer",
 			accessToken,
 			issuedAt.plus(properties.getAccessTokenTtl()),
 			refreshToken,
-			issuedAt.plus(properties.getRefreshTokenTtl()),
+			refreshTokenExpiresAt,
 			profile
 		);
 	}
@@ -60,6 +76,7 @@ public class JwtTokenService {
 		if (!"refresh".equals(tokenType)) {
 			throw new BadCredentialsException("Invalid refresh token");
 		}
+		assertRefreshTokenActive(refreshToken);
 
 		SocialUserProfile profile = SocialUserProfile.fromTokenClaims(jwt.getClaims());
 		List<String> authorityNames = jwt.getClaimAsStringList("authorities");
@@ -70,6 +87,7 @@ public class JwtTokenService {
 				.map(GrantedAuthority.class::cast)
 				.toList();
 
+		revokeRefreshToken(refreshToken);
 		return issueTokenPair(profile, authorities);
 	}
 
@@ -117,6 +135,72 @@ public class JwtTokenService {
 		}
 		authorityNames.add("ROLE_USER");
 		return List.copyOf(authorityNames);
+	}
+
+	private void storeRefreshToken(UUID userId, String refreshToken, Instant expiresAt, Instant issuedAt) {
+		if (userId == null) {
+			throw new BadCredentialsException("Refresh token requires persisted user");
+		}
+		jdbcTemplate.update(
+			"""
+			insert into refresh_tokens (id, user_id, token_hash, expires_at, created_at, updated_at)
+			values (?, ?, ?, ?, ?, ?)
+			""",
+			UUID.randomUUID(),
+			userId,
+			hashToken(refreshToken),
+			expiresAt,
+			issuedAt,
+			issuedAt
+		);
+	}
+
+	private void assertRefreshTokenActive(String refreshToken) {
+		Boolean active = jdbcTemplate.queryForObject(
+			"""
+			select exists(
+				select 1
+				from refresh_tokens
+				where token_hash = ?
+				  and revoked_at is null
+				  and expires_at > ?
+			)
+			""",
+			Boolean.class,
+			hashToken(refreshToken),
+			Instant.now()
+		);
+		if (!Boolean.TRUE.equals(active)) {
+			throw new BadCredentialsException("Invalid refresh token");
+		}
+	}
+
+	private void revokeRefreshToken(String refreshToken) {
+		Instant now = Instant.now();
+		jdbcTemplate.update(
+			"""
+			update refresh_tokens
+			set revoked_at = ?,
+				last_used_at = ?,
+				updated_at = ?
+			where token_hash = ?
+			  and revoked_at is null
+			""",
+			now,
+			now,
+			now,
+			hashToken(refreshToken)
+		);
+	}
+
+	private String hashToken(String token) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			return HexFormat.of().formatHex(digest.digest(token.getBytes(StandardCharsets.UTF_8)));
+		}
+		catch (NoSuchAlgorithmException exception) {
+			throw new IllegalStateException("SHA-256 digest is not available", exception);
+		}
 	}
 
 	public record TokenPair(

--- a/src/main/java/com/sagongsa/backend/auth/JwtTokenService.java
+++ b/src/main/java/com/sagongsa/backend/auth/JwtTokenService.java
@@ -4,6 +4,7 @@ import com.sagongsa.backend.config.AppAuthProperties;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.HexFormat;
@@ -24,6 +25,7 @@ import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 @Service
@@ -66,6 +68,7 @@ public class JwtTokenService {
 		);
 	}
 
+	@Transactional
 	public TokenPair refresh(String refreshToken) {
 		if (!StringUtils.hasText(refreshToken)) {
 			throw new BadCredentialsException("Refresh token is required");
@@ -76,7 +79,7 @@ public class JwtTokenService {
 		if (!"refresh".equals(tokenType)) {
 			throw new BadCredentialsException("Invalid refresh token");
 		}
-		assertRefreshTokenActive(refreshToken);
+		consumeRefreshToken(refreshToken);
 
 		SocialUserProfile profile = SocialUserProfile.fromTokenClaims(jwt.getClaims());
 		List<String> authorityNames = jwt.getClaimAsStringList("authorities");
@@ -87,7 +90,6 @@ public class JwtTokenService {
 				.map(GrantedAuthority.class::cast)
 				.toList();
 
-		revokeRefreshToken(refreshToken);
 		return issueTokenPair(profile, authorities);
 	}
 
@@ -105,22 +107,30 @@ public class JwtTokenService {
 	) {
 		JwtClaimsSet.Builder builder = JwtClaimsSet.builder()
 			.issuer(properties.getIssuer())
+			.id(UUID.randomUUID().toString())
 			.issuedAt(issuedAt)
 			.expiresAt(expiresAt)
 			.subject(profile.userId() != null ? profile.userId().toString() : profile.provider() + ":" + profile.providerUserId())
 			.claim("provider", profile.provider())
 			.claim("providerUserId", profile.providerUserId())
 			.claim("name", profile.name())
-			.claim("email", profile.email())
-			.claim("profileImageUrl", profile.profileImageUrl())
 			.claim("authorities", authorities)
 			.claim("token_type", tokenType);
+
+		claimIfPresent(builder, "email", profile.email());
+		claimIfPresent(builder, "profileImageUrl", profile.profileImageUrl());
 
 		if (profile.userId() != null) {
 			builder.claim("userId", profile.userId().toString());
 		}
 
 		return builder.build();
+	}
+
+	private void claimIfPresent(JwtClaimsSet.Builder builder, String name, Object value) {
+		if (value != null) {
+			builder.claim(name, value);
+		}
 	}
 
 	private List<String> normalizeAuthorities(Collection<? extends GrantedAuthority> authorities) {
@@ -149,35 +159,16 @@ public class JwtTokenService {
 			UUID.randomUUID(),
 			userId,
 			hashToken(refreshToken),
-			expiresAt,
-			issuedAt,
-			issuedAt
+			Timestamp.from(expiresAt),
+			Timestamp.from(issuedAt),
+			Timestamp.from(issuedAt)
 		);
 	}
 
-	private void assertRefreshTokenActive(String refreshToken) {
-		Boolean active = jdbcTemplate.queryForObject(
-			"""
-			select exists(
-				select 1
-				from refresh_tokens
-				where token_hash = ?
-				  and revoked_at is null
-				  and expires_at > ?
-			)
-			""",
-			Boolean.class,
-			hashToken(refreshToken),
-			Instant.now()
-		);
-		if (!Boolean.TRUE.equals(active)) {
-			throw new BadCredentialsException("Invalid refresh token");
-		}
-	}
-
-	private void revokeRefreshToken(String refreshToken) {
+	private void consumeRefreshToken(String refreshToken) {
 		Instant now = Instant.now();
-		jdbcTemplate.update(
+		Timestamp nowTimestamp = Timestamp.from(now);
+		int updated = jdbcTemplate.update(
 			"""
 			update refresh_tokens
 			set revoked_at = ?,
@@ -185,12 +176,17 @@ public class JwtTokenService {
 				updated_at = ?
 			where token_hash = ?
 			  and revoked_at is null
+			  and expires_at > ?
 			""",
-			now,
-			now,
-			now,
-			hashToken(refreshToken)
+			nowTimestamp,
+			nowTimestamp,
+			nowTimestamp,
+			hashToken(refreshToken),
+			nowTimestamp
 		);
+		if (updated != 1) {
+			throw new BadCredentialsException("Invalid refresh token");
+		}
 	}
 
 	private String hashToken(String token) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,4 +51,4 @@ app:
     jwt-secret: ${APP_JWT_SECRET:local-development-jwt-secret-change-me}
     access-token-ttl: ${APP_ACCESS_TOKEN_TTL:PT2H}
     refresh-token-ttl: ${APP_REFRESH_TOKEN_TTL:P30D}
-    allowed-redirect-uri-prefixes: ${APP_ALLOWED_REDIRECT_URI_PREFIXES:sagongsa404://auth/callback,http://localhost,http://127.0.0.1,https://localhost,https://127.0.0.1}
+    allowed-redirect-uri-prefixes: ${APP_ALLOWED_REDIRECT_URI_PREFIXES:sagongsa404://auth/callback,http://localhost/auth/callback,http://127.0.0.1/auth/callback,https://localhost/auth/callback,https://127.0.0.1/auth/callback}

--- a/src/test/java/com/sagongsa/backend/auth/AppRedirectUriSupportTest.java
+++ b/src/test/java/com/sagongsa/backend/auth/AppRedirectUriSupportTest.java
@@ -30,6 +30,17 @@ class AppRedirectUriSupportTest {
 	}
 
 	@Test
+	void rejectsLocalhostRedirectOutsideAllowedCallbackPath() {
+		assertThat(support.parseAllowedRedirectUri("http://localhost/oauth/callback")).isEmpty();
+	}
+
+	@Test
+	void acceptsLocalhostRedirectOnAllowedCallbackPath() {
+		assertThat(support.parseAllowedRedirectUri("http://localhost/auth/callback"))
+			.contains(URI.create("http://localhost/auth/callback"));
+	}
+
+	@Test
 	void buildsSuccessRedirectIntoFragment() {
 		JwtTokenService.TokenPair tokenPair = new JwtTokenService.TokenPair(
 			"Bearer",
@@ -60,10 +71,10 @@ class AppRedirectUriSupportTest {
 		AppAuthProperties properties = new AppAuthProperties();
 		properties.setAllowedRedirectUriPrefixes(java.util.List.of(
 			"sagongsa404://auth/callback",
-			"http://localhost",
-			"http://127.0.0.1",
-			"https://localhost",
-			"https://127.0.0.1"
+			"http://localhost/auth/callback",
+			"http://127.0.0.1/auth/callback",
+			"https://localhost/auth/callback",
+			"https://127.0.0.1/auth/callback"
 		));
 		return properties;
 	}

--- a/src/test/java/com/sagongsa/backend/auth/AppRedirectUriSupportTest.java
+++ b/src/test/java/com/sagongsa/backend/auth/AppRedirectUriSupportTest.java
@@ -41,6 +41,11 @@ class AppRedirectUriSupportTest {
 	}
 
 	@Test
+	void rejectsLocalhostRedirectBelowAllowedCallbackPath() {
+		assertThat(support.parseAllowedRedirectUri("http://localhost/auth/callback/extra")).isEmpty();
+	}
+
+	@Test
 	void buildsSuccessRedirectIntoFragment() {
 		JwtTokenService.TokenPair tokenPair = new JwtTokenService.TokenPair(
 			"Bearer",

--- a/src/test/java/com/sagongsa/backend/auth/AuthApiControllerTest.java
+++ b/src/test/java/com/sagongsa/backend/auth/AuthApiControllerTest.java
@@ -50,7 +50,8 @@ class AuthApiControllerTest extends PostgreSqlContainerTest {
 			.andExpect(jsonPath("$.userId").value(userId.toString()))
 			.andExpect(jsonPath("$.provider").value("google"))
 			.andExpect(jsonPath("$.providerUserId").value("google-123"))
-			.andExpect(jsonPath("$.email").value("google@test.dev"));
+			.andExpect(jsonPath("$.email").value("google@test.dev"))
+			.andExpect(jsonPath("$.rawAttributes").doesNotExist());
 	}
 
 	@Test

--- a/src/test/java/com/sagongsa/backend/auth/JwtTokenServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/auth/JwtTokenServiceTest.java
@@ -1,0 +1,108 @@
+package com.sagongsa.backend.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+@SpringBootTest
+class JwtTokenServiceTest extends PostgreSqlContainerTest {
+
+	@Autowired
+	private JwtTokenService jwtTokenService;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void cleanDatabase() {
+		jdbcTemplate.execute("truncate table users cascade");
+	}
+
+	@Test
+	void refreshConsumesOldRefreshTokenAndStoresNewOne() {
+		UUID userId = UUID.fromString("10000000-0000-0000-0000-000000000001");
+		insertUser(userId);
+		JwtTokenService.TokenPair issued = jwtTokenService.issueTokenPair(
+			profile(userId),
+			List.of(new SimpleGrantedAuthority("ROLE_USER"))
+		);
+
+		JwtTokenService.TokenPair refreshed = jwtTokenService.refresh(issued.refreshToken());
+
+		assertThat(refreshed.refreshToken()).isNotEqualTo(issued.refreshToken());
+		assertThat(countRefreshTokens(userId)).isEqualTo(2);
+		assertThat(countRevokedRefreshTokens(userId)).isEqualTo(1);
+		assertThatThrownBy(() -> jwtTokenService.refresh(issued.refreshToken()))
+			.isInstanceOf(BadCredentialsException.class);
+	}
+
+	@Test
+	void refreshRejectsValidJwtThatIsNotStoredAsActiveRefreshToken() {
+		UUID userId = UUID.fromString("10000000-0000-0000-0000-000000000002");
+		insertUser(userId);
+		JwtTokenService.TokenPair issued = jwtTokenService.issueTokenPair(
+			profile(userId),
+			List.of(new SimpleGrantedAuthority("ROLE_USER"))
+		);
+		jdbcTemplate.update("delete from refresh_tokens where user_id = ?", userId);
+
+		assertThatThrownBy(() -> jwtTokenService.refresh(issued.refreshToken()))
+			.isInstanceOf(BadCredentialsException.class);
+	}
+
+	private void insertUser(UUID userId) {
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into users (id, status, onboarding_status, created_at, updated_at)
+			values (?, 'ACTIVE', 'COMPLETED', ?, ?)
+			""",
+			userId,
+			now,
+			now
+		);
+	}
+
+	private SocialUserProfile profile(UUID userId) {
+		return new SocialUserProfile(
+			"google",
+			"google-" + userId,
+			"Google Tester",
+			"google@test.dev",
+			null,
+			Map.of(),
+			userId
+		);
+	}
+
+	private int countRefreshTokens(UUID userId) {
+		Integer count = jdbcTemplate.queryForObject(
+			"select count(*) from refresh_tokens where user_id = ?",
+			Integer.class,
+			userId
+		);
+		return count == null ? 0 : count;
+	}
+
+	private int countRevokedRefreshTokens(UUID userId) {
+		Integer count = jdbcTemplate.queryForObject(
+			"select count(*) from refresh_tokens where user_id = ? and revoked_at is not null and last_used_at is not null",
+			Integer.class,
+			userId
+		);
+		return count == null ? 0 : count;
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -35,6 +35,6 @@ spring:
 app:
   auth:
     jwt-secret: test-jwt-secret
-    allowed-redirect-uri-prefixes: sagongsa404://auth/callback,http://localhost,http://127.0.0.1,https://localhost,https://127.0.0.1
+    allowed-redirect-uri-prefixes: sagongsa404://auth/callback,http://localhost/auth/callback,http://127.0.0.1/auth/callback,https://localhost/auth/callback,https://127.0.0.1/auth/callback
     trusted-user-id-header:
       enabled: true


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-29**
- Jira: https://parkjaehong.atlassian.net/browse/NF-29

> PR 제목: `[bug] NF-29 인증/OAuth 보안 계약 보완`  
> 브랜치: `fix/NF-29-auth-oauth-contract`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #41

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- 테스트/내부용 trusted user header가 인증 principal보다 먼저 해석될 수 있었습니다.
- refresh token 재발급이 DB의 저장/폐기 상태와 연결되지 않았습니다.
- `/api/auth/me` 응답과 OAuth redirect allowlist가 필요한 범위보다 넓었습니다.

### 왜 발생했나? (Root Cause)
- `@CurrentUserId` 해석 경로에서 운영 인증 principal과 trusted header fallback의 우선순위가 명확히 분리되지 않았습니다.
- refresh token JWT 자체 검증과 `refresh_tokens` 테이블의 token hash/revoked 상태 검증이 함께 수행되지 않았습니다.
- OAuth 응답/redirect 계약이 최소 공개, 최소 허용 원칙으로 좁혀져 있지 않았습니다.

### 어떻게 고쳤나?
- 인증 principal/JWT userId claim을 우선하고 trusted header는 fallback으로만 사용하도록 정리했습니다.
- refresh token 발급/재발급 시 token hash 저장, active 검증, 기존 token revoke를 수행하도록 연결했습니다.
- `/api/auth/me`에서 provider raw attributes를 제거하고 localhost redirect 기본 허용 path를 `/auth/callback`로 제한했습니다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법(가능하면)
- Steps: 인증 principal과 `X-User-Id`를 함께 전달하거나, revoke된 refresh token으로 재발급을 시도합니다.
- 기대 결과: principal이 우선되고 active refresh token만 재발급됩니다.
- 실제 결과: 기존 구현에서는 trusted header 우선/DB revoke 미검증 위험이 있었습니다.

### 재발 방지(있다면)
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [ ] 런북/문서 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] AC1: 인증 principal/JWT userId claim을 trusted header보다 우선한다.
- [x] AC2: refresh token 저장/검증/revoke/rotation을 DB token hash와 연결한다.
- [x] AC3: `/api/auth/me` raw attributes 제거와 redirect URI 허용 범위 축소를 반영한다.

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew.bat testClasses test --tests "com.sagongsa.backend.auth.AppRedirectUriSupportTest"`
- Result: PASS
- Command: `./gradlew.bat test --tests "com.sagongsa.backend.auth.AuthApiControllerTest" --tests "com.sagongsa.backend.auth.AppRedirectUriSupportTest"`
- Result: PASS

### CI
- 링크/결과: 자동 첨부 확인 예정

### Smoke / 수동 검증
- 시나리오: OAuth redirect allowlist, refresh token rotation, trusted header fallback 경로 확인
- 결과: 통합 테스트로 검증

### 테스트 공백(있다면 이유 필수)
- 없음

---

## 🧭 영향 범위 (필수)
- [ ] API 스펙 변경 없음
- [x] API 스펙 변경 있음 (요약: `/api/auth/me` 응답에서 `rawAttributes` 제거)
- [x] DB 스키마 변경 없음
- [ ] DB 스키마 변경 있음 (마이그레이션/락/시간: )
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음 (항목: )
- [x] 캐시/큐/외부 연동 영향 없음
- [ ] 캐시/큐/외부 연동 영향 있음 (요약: )

---

## 💥 Breaking / Compatibility (필수)
- [ ] Breaking change 없음
- [x] Breaking change 있음 → `/api/auth/me` 응답에서 provider raw attributes가 제거됩니다. 해당 필드를 쓰는 클라이언트는 응답 계약 조정이 필요합니다.

---

## 🚀 배포/릴리즈 (해당 시 필수)
### Feature Flag
- [x] 사용 안함
- [ ] 사용함 → Flag/기본값/롤아웃:

### 모니터링/알림
- 확인할 대시보드/지표: refresh token 재발급 실패율, OAuth callback 실패율
- 에러/로그 키워드: `Invalid refresh token`, redirect URI rejection

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- redirect allowlist 축소로 기존 로컬/테스트 콜백 path가 계약과 다르면 OAuth callback이 거절될 수 있습니다.

### 롤백
- [ ] 플래그/설정으로 우회 가능
- [x] 배포 롤백(이전 태그/이미지) 가능
- [ ] 데이터 롤백/역마이그레이션 필요 (절차: )

---

## 📸 증빙 (선택)
- 스크린샷/로그/메트릭 링크: 로컬 테스트 로그
- 전/후 비교(가능하면): raw attributes 제거, refresh token DB 검증 연결, redirect prefix 축소

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직: `CurrentUserIdArgumentResolver`, `JwtTokenService`, `AuthApiController`, `AppRedirectUriSupportTest`
- 트레이드오프/대안: 운영 redirect domain 정책은 NF-33에서 별도 확인합니다.
- 성능/보안/호환성 영향: 인증 spoofing 위험과 refresh token 재사용 위험을 줄이는 보안 변경입니다.


