### PR TITLE
[bug] NF-31 구매 결정 결과와 리마인더 워커 안정성 보완

### DIFF
--- a/src/main/java/com/sagongsa/backend/decision/DecisionService.java
+++ b/src/main/java/com/sagongsa/backend/decision/DecisionService.java
@@ -35,6 +35,9 @@ public class DecisionService {
 
 	private static final String DEFAULT_ZONE_ID = "Asia/Seoul";
 	private static final LocalTime REGRET_REMINDER_TIME = LocalTime.of(9, 0);
+	private static final int RATIONALE_TEXT_MAX_LENGTH = 1_000;
+	private static final int CHANGE_REASON_MAX_LENGTH = 1_000;
+	private static final List<String> SELF_CHECK_QUESTION_CODES = List.of("NEED", "BUDGET", "ALTERNATIVE", "DELAY");
 
 	private final JdbcTemplate jdbcTemplate;
 
@@ -98,7 +101,7 @@ public class DecisionService {
 			similarCategorySpendAmount,
 			rationality.yesCount(),
 			rationality.result().name(),
-			resultMessage(normalized.result()),
+			resultMessage(normalized.result(), reminder),
 			new MascotReactionResponse(mascotReaction.state().name(), mascotReaction.message()),
 			reminder,
 			now.toInstant()
@@ -125,7 +128,7 @@ public class DecisionService {
 			decision.similarCategorySpendAmount(),
 			decision.selfCheckYesCount(),
 			decision.rationalityResult(),
-			resultMessage(PurchaseDecisionResult.valueOf(decision.result())),
+			resultMessage(PurchaseDecisionResult.valueOf(decision.result()), reminder),
 			mascot,
 			reminder,
 			decision.decidedAt()
@@ -180,7 +183,7 @@ public class DecisionService {
 
 		PurchaseDecisionResult result = parseResult(request.result());
 		Integer finalPrice = validateFinalPrice(request.finalPrice());
-		String rationaleText = cleanOptional(request.rationaleText(), "rationaleText");
+		String rationaleText = cleanOptional(request.rationaleText(), "rationaleText", RATIONALE_TEXT_MAX_LENGTH);
 		List<NormalizedSelfCheckAnswer> answers = normalizeSelfCheckAnswers(request.selfCheckAnswers());
 		return new NormalizedDecisionRequest(request.itemId(), result, finalPrice, rationaleText, answers);
 	}
@@ -191,7 +194,7 @@ public class DecisionService {
 		}
 		PurchaseDecisionResult result = parseResult(request.result());
 		Integer finalPrice = validateFinalPrice(request.finalPrice());
-		String changeReason = cleanOptional(request.changeReason(), "changeReason");
+		String changeReason = cleanOptional(request.changeReason(), "changeReason", CHANGE_REASON_MAX_LENGTH);
 		List<NormalizedSelfCheckAnswer> answers = request.selfCheckAnswers() == null
 			? null
 			: normalizeSelfCheckAnswerUpdates(request.selfCheckAnswers());
@@ -228,6 +231,9 @@ public class DecisionService {
 				throw new DecisionBadRequestException("selfCheckAnswers must not contain null.");
 			}
 			String questionCode = cleanRequired(answer.questionCode(), "questionCode", 80);
+			if (!SELF_CHECK_QUESTION_CODES.contains(questionCode)) {
+				throw new DecisionBadRequestException("questionCode must be one of NEED, BUDGET, ALTERNATIVE, DELAY.");
+			}
 			if (answer.answerBoolean() == null) {
 				throw new DecisionBadRequestException("answerBoolean is required.");
 			}
@@ -251,6 +257,9 @@ public class DecisionService {
 				throw new DecisionBadRequestException("selfCheckAnswers must not contain null.");
 			}
 			String questionCode = cleanRequired(answer.questionCode(), "questionCode", 80);
+			if (!SELF_CHECK_QUESTION_CODES.contains(questionCode)) {
+				throw new DecisionBadRequestException("questionCode must be one of NEED, BUDGET, ALTERNATIVE, DELAY.");
+			}
 			if (answer.answerBoolean() == null) {
 				throw new DecisionBadRequestException("answerBoolean is required.");
 			}
@@ -366,6 +375,9 @@ public class DecisionService {
 	}
 
 	private Integer resolveFinalPrice(PurchaseDecisionResult result, Integer requestedFinalPrice, Integer listedPrice) {
+		if (result == PurchaseDecisionResult.STOP) {
+			return null;
+		}
 		Integer finalPrice = requestedFinalPrice == null ? listedPrice : requestedFinalPrice;
 		if (result == PurchaseDecisionResult.GO && finalPrice == null) {
 			throw new DecisionBadRequestException("finalPrice is required for GO when item price is missing.");
@@ -379,6 +391,9 @@ public class DecisionService {
 		Integer previousFinalPrice,
 		Integer listedPrice
 	) {
+		if (result == PurchaseDecisionResult.STOP) {
+			return null;
+		}
 		Integer finalPrice = requestedFinalPrice;
 		if (finalPrice == null) {
 			finalPrice = previousFinalPrice == null ? listedPrice : previousFinalPrice;
@@ -920,9 +935,9 @@ public class DecisionService {
 		return reminders.stream().findFirst();
 	}
 
-	private String resultMessage(PurchaseDecisionResult result) {
+	private String resultMessage(PurchaseDecisionResult result, ReminderResponse reminder) {
 		if (result == PurchaseDecisionResult.GO) {
-			return "7일 뒤에 어떤지 물어볼게!";
+			return reminder == null ? "구매 결정이 저장됐어요." : "7일 뒤에 어떤지 물어볼게!";
 		}
 		return "위시리스트에서 정리했어요.";
 	}
@@ -943,6 +958,14 @@ public class DecisionService {
 			return null;
 		}
 		return value.trim();
+	}
+
+	private String cleanOptional(String value, String fieldName, int maxLength) {
+		String cleaned = cleanOptional(value, fieldName);
+		if (cleaned != null && cleaned.length() > maxLength) {
+			throw new DecisionBadRequestException(fieldName + " must be " + maxLength + " characters or fewer.");
+		}
+		return cleaned;
 	}
 
 	private ZoneId zoneId(String rawTimezone) {

--- a/src/main/java/com/sagongsa/backend/decision/DecisionService.java
+++ b/src/main/java/com/sagongsa/backend/decision/DecisionService.java
@@ -848,6 +848,7 @@ public class DecisionService {
 			       canceled_at = null,
 			       cancel_reason = null,
 			       updated_at = excluded.updated_at
+			 where reminder_schedules.status <> 'SENT'
 			""",
 			UUID.randomUUID(),
 			userId,

--- a/src/main/java/com/sagongsa/backend/notification/ReminderNotificationScheduler.java
+++ b/src/main/java/com/sagongsa/backend/notification/ReminderNotificationScheduler.java
@@ -1,0 +1,21 @@
+package com.sagongsa.backend.notification;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "app.notification.reminder-worker.enabled", havingValue = "true", matchIfMissing = true)
+class ReminderNotificationScheduler {
+
+	private final ReminderNotificationWorker reminderNotificationWorker;
+
+	ReminderNotificationScheduler(ReminderNotificationWorker reminderNotificationWorker) {
+		this.reminderNotificationWorker = reminderNotificationWorker;
+	}
+
+	@Scheduled(fixedDelayString = "${app.notification.reminder-worker.fixed-delay-ms:60000}")
+	void runScheduled() {
+		reminderNotificationWorker.processDueReminders();
+	}
+}

--- a/src/main/java/com/sagongsa/backend/notification/ReminderNotificationWorker.java
+++ b/src/main/java/com/sagongsa/backend/notification/ReminderNotificationWorker.java
@@ -6,8 +6,8 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -22,11 +22,6 @@ public class ReminderNotificationWorker {
 	public ReminderNotificationWorker(JdbcTemplate jdbcTemplate, TransactionTemplate transactionTemplate) {
 		this.jdbcTemplate = jdbcTemplate;
 		this.transactionTemplate = transactionTemplate;
-	}
-
-	@Scheduled(fixedDelayString = "${app.notification.reminder-worker.fixed-delay-ms:60000}")
-	public void runScheduled() {
-		processDueReminders();
 	}
 
 	public int processDueReminders() {
@@ -50,6 +45,7 @@ public class ReminderNotificationWorker {
 			  and scheduled_for <= ?
 			order by scheduled_for asc, id asc
 			limit ?
+			for update skip locked
 			""",
 			(rs, rowNumber) -> rs.getObject("id", UUID.class),
 			OffsetDateTime.now(ZoneOffset.UTC),
@@ -63,7 +59,6 @@ public class ReminderNotificationWorker {
 			return Boolean.TRUE.equals(processed);
 		}
 		catch (RuntimeException exception) {
-			markFailed(reminderId);
 			return false;
 		}
 	}
@@ -93,8 +88,12 @@ public class ReminderNotificationWorker {
 				from reminder_schedules rs
 				join purchase_decisions pd on pd.id = rs.decision_id
 				join saved_items si on si.id = rs.item_id
+				join users u on u.id = rs.user_id
+				left join user_notification_settings uns on uns.user_id = rs.user_id
 				where rs.id = ?
 				  and rs.reminder_type = 'REGRET_CHECK_7_DAYS'
+				  and u.status = 'ACTIVE'
+				  and coalesce(uns.regret_reminder_enabled, true) = true
 				for update of rs
 				""",
 				this::mapReminderTarget,
@@ -123,26 +122,31 @@ public class ReminderNotificationWorker {
 
 	private void insertNotification(ReminderTarget target) {
 		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-		jdbcTemplate.update(
-			"""
-			insert into notifications (
-				id, user_id, notification_type, title, body,
-				item_id, decision_id, reminder_id, target_path,
-				is_read, created_at, updated_at
-			)
-			values (?, ?, 'REGRET_CHECK_READY', ?, ?, ?, ?, ?, ?, false, ?, ?)
-			""",
-			UUID.randomUUID(),
-			target.userId(),
-			"구매 후 7일이 지났어요",
-			"[%s] 지금도 잘 샀다고 생각하나요?".formatted(target.itemTitle()),
-			target.itemId(),
-			target.decisionId(),
-			target.reminderId(),
-			"/reflections?decisionId=" + target.decisionId(),
-			now,
-			now
-		);
+		try {
+			jdbcTemplate.update(
+				"""
+				insert into notifications (
+					id, user_id, notification_type, title, body,
+					item_id, decision_id, reminder_id, target_path,
+					is_read, created_at, updated_at
+				)
+				values (?, ?, 'REGRET_CHECK_READY', ?, ?, ?, ?, ?, ?, false, ?, ?)
+				""",
+				UUID.randomUUID(),
+				target.userId(),
+				"구매 후 7일이 지났어요",
+				"[%s] 지금도 잘 샀다고 생각하나요?".formatted(target.itemTitle()),
+				target.itemId(),
+				target.decisionId(),
+				target.reminderId(),
+				"/reflections?decisionId=" + target.decisionId(),
+				now,
+				now
+			);
+		}
+		catch (DuplicateKeyException ignored) {
+			// Another worker inserted the reminder notification first.
+		}
 	}
 
 	private void markSent(UUID reminderId) {
@@ -160,20 +164,6 @@ public class ReminderNotificationWorker {
 			now,
 			reminderId
 		);
-	}
-
-	private void markFailed(UUID reminderId) {
-		transactionTemplate.executeWithoutResult(status -> jdbcTemplate.update(
-			"""
-			update reminder_schedules
-			set status = 'FAILED',
-				updated_at = ?
-			where id = ?
-			  and status = 'SCHEDULED'
-			""",
-			OffsetDateTime.now(ZoneOffset.UTC),
-			reminderId
-		));
 	}
 
 	private ReminderTarget mapReminderTarget(ResultSet rs, int rowNumber) throws SQLException {

--- a/src/main/java/com/sagongsa/backend/notification/ReminderNotificationWorker.java
+++ b/src/main/java/com/sagongsa/backend/notification/ReminderNotificationWorker.java
@@ -6,6 +6,8 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
@@ -15,6 +17,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 public class ReminderNotificationWorker {
 
 	private static final int BATCH_SIZE = 50;
+	private static final Logger log = LoggerFactory.getLogger(ReminderNotificationWorker.class);
 
 	private final JdbcTemplate jdbcTemplate;
 	private final TransactionTemplate transactionTemplate;
@@ -38,14 +41,18 @@ public class ReminderNotificationWorker {
 	private List<UUID> findDueReminderIds() {
 		return jdbcTemplate.query(
 			"""
-			select id
-			from reminder_schedules
-			where reminder_type = 'REGRET_CHECK_7_DAYS'
-			  and status = 'SCHEDULED'
-			  and scheduled_for <= ?
-			order by scheduled_for asc, id asc
+			select rs.id
+			from reminder_schedules rs
+			join users u on u.id = rs.user_id
+			left join user_notification_settings uns on uns.user_id = rs.user_id
+			where rs.reminder_type = 'REGRET_CHECK_7_DAYS'
+			  and rs.status = 'SCHEDULED'
+			  and rs.scheduled_for <= ?
+			  and u.status = 'ACTIVE'
+			  and coalesce(uns.regret_reminder_enabled, true) = true
+			order by rs.scheduled_for asc, rs.id asc
 			limit ?
-			for update skip locked
+			for update of rs skip locked
 			""",
 			(rs, rowNumber) -> rs.getObject("id", UUID.class),
 			OffsetDateTime.now(ZoneOffset.UTC),
@@ -59,6 +66,7 @@ public class ReminderNotificationWorker {
 			return Boolean.TRUE.equals(processed);
 		}
 		catch (RuntimeException exception) {
+			log.warn("Failed to process reminder {}", reminderId, exception);
 			return false;
 		}
 	}

--- a/src/main/resources/db/migration/V3__notification_reminder_idempotency.sql
+++ b/src/main/resources/db/migration/V3__notification_reminder_idempotency.sql
@@ -1,0 +1,3 @@
+create unique index if not exists uk_notifications_reminder_type
+    on notifications(reminder_id, notification_type)
+    where reminder_id is not null;

--- a/src/test/java/com/sagongsa/backend/decision/DecisionApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/decision/DecisionApiIntegrationTest.java
@@ -99,6 +99,7 @@ class DecisionApiIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(status().isCreated())
 			.andExpect(jsonPath("$.itemStatus").value("STOP"))
 			.andExpect(jsonPath("$.result").value("STOP"))
+			.andExpect(jsonPath("$.finalPrice").value(nullValue()))
 			.andExpect(jsonPath("$.budgetAfterAmount").value(90_000))
 			.andExpect(jsonPath("$.selfCheckYesCount").value(2))
 			.andExpect(jsonPath("$.rationalityResult").value("IRRATIONAL"))
@@ -167,6 +168,31 @@ class DecisionApiIntegrationTest extends PostgreSqlContainerTest {
 						{"questionCode": "NEED", "answerBoolean": true},
 						{"questionCode": "NEED", "answerBoolean": false},
 						{"questionCode": "BUDGET", "answerBoolean": false},
+						{"questionCode": "DELAY", "answerBoolean": false}
+					]
+				}
+				""".formatted(itemId)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("BAD_REQUEST"));
+	}
+
+	@Test
+	void rejectsUnknownSelfCheckQuestionCode() throws Exception {
+		UUID userId = createReadyUser();
+		insertBudgetCycle(userId, YearMonth.now(SEOUL_ZONE).toString(), 500_000, 0);
+		UUID itemId = insertSavedItem(userId, "Bad question target", "LIVING", "SAVED", 50_000);
+
+		mockMvc.perform(post(DECISIONS_PATH)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"itemId": "%s",
+					"result": "GO",
+					"selfCheckAnswers": [
+						{"questionCode": "NEED", "answerBoolean": true},
+						{"questionCode": "BUDGET", "answerBoolean": false},
+						{"questionCode": "UNKNOWN", "answerBoolean": false},
 						{"questionCode": "DELAY", "answerBoolean": false}
 					]
 				}

--- a/src/test/java/com/sagongsa/backend/decision/DecisionApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/decision/DecisionApiIntegrationTest.java
@@ -3,6 +3,7 @@ package com.sagongsa.backend.decision;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -149,6 +150,63 @@ class DecisionApiIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(jsonPath("$.mascot.state").value("SMILE"))
 			.andExpect(jsonPath("$.mascot.message").value("합리적으로 잘 결정했어요"))
 			.andExpect(jsonPath("$.reminder.status").value("SCHEDULED"));
+	}
+
+	@Test
+	void doesNotReactivateSentReminderWhenDecisionChangesBackToGo() throws Exception {
+		UUID userId = createReadyUser();
+		insertBudgetCycle(userId, YearMonth.now(SEOUL_ZONE).toString(), 500_000, 0);
+		UUID itemId = insertSavedItem(userId, "Already reminded target", "FOOD", "SAVED", 12_000);
+
+		String body = mockMvc.perform(post(DECISIONS_PATH)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(decisionRequest(itemId, "GO", 12_000, false, false, false, false)))
+			.andExpect(status().isCreated())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+		String decisionId = objectMapper.readTree(body).get("decisionId").asText();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			update reminder_schedules
+			   set status = 'SENT',
+			       sent_at = ?,
+			       updated_at = ?
+			 where decision_id = ?
+			""",
+			now,
+			now,
+			UUID.fromString(decisionId)
+		);
+
+		mockMvc.perform(patch(DECISIONS_PATH + "/{decisionId}/result", decisionId)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"result": "STOP",
+					"changeReason": "마음이 바뀜"
+				}
+				"""))
+			.andExpect(status().isOk());
+
+		mockMvc.perform(patch(DECISIONS_PATH + "/{decisionId}/result", decisionId)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"result": "GO",
+					"finalPrice": 12000,
+					"changeReason": "다시 구매로 변경"
+				}
+				"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.reminder.status").value("SENT"));
+
+		assertThat(queryString("select status from reminder_schedules where decision_id = ?", UUID.fromString(decisionId))).isEqualTo("SENT");
+		assertThat(queryInteger("select count(*) from reminder_schedules where decision_id = ?", UUID.fromString(decisionId))).isEqualTo(1);
 	}
 
 	@Test

--- a/src/test/java/com/sagongsa/backend/notification/ReminderNotificationWorkerIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/notification/ReminderNotificationWorkerIntegrationTest.java
@@ -92,6 +92,29 @@ class ReminderNotificationWorkerIntegrationTest extends PostgreSqlContainerTest 
 	}
 
 	@Test
+	void processesEligibleReminderEvenWhenOlderDisabledRemindersFillBatch() {
+		UUID disabledUserId = createReadyUser();
+		disableRegretReminder(disabledUserId);
+		OffsetDateTime oldDue = OffsetDateTime.now(ZoneOffset.UTC).minusHours(2);
+		for (int index = 0; index < 50; index++) {
+			UUID disabledItemId = insertSavedItem(disabledUserId, "설정 해제 상품 " + index, "GO");
+			UUID disabledDecisionId = insertDecision(disabledUserId, disabledItemId, "GO");
+			insertReminder(disabledUserId, disabledItemId, disabledDecisionId, "SCHEDULED", oldDue.plusSeconds(index));
+		}
+		UUID userId = createReadyUser();
+		UUID itemId = insertSavedItem(userId, "정상 처리 상품", "GO");
+		UUID decisionId = insertDecision(userId, itemId, "GO");
+		UUID reminderId = insertReminder(userId, itemId, decisionId, "SCHEDULED", OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(1));
+
+		int processedCount = reminderNotificationWorker.processDueReminders();
+
+		assertThat(processedCount).isEqualTo(1);
+		assertThat(queryString("select status from reminder_schedules where id = ?", reminderId)).isEqualTo("SENT");
+		assertThat(queryInteger("select count(*) from notifications where reminder_id = ?", reminderId)).isEqualTo(1);
+		assertThat(queryInteger("select count(*) from notifications where user_id = ?", disabledUserId)).isZero();
+	}
+
+	@Test
 	void skipsReminderForInactiveUser() {
 		UUID userId = createReadyUser();
 		jdbcTemplate.update(

--- a/src/test/java/com/sagongsa/backend/notification/ReminderNotificationWorkerIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/notification/ReminderNotificationWorkerIntegrationTest.java
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 
-@SpringBootTest
+@SpringBootTest(properties = "app.notification.reminder-worker.enabled=false")
 class ReminderNotificationWorkerIntegrationTest extends PostgreSqlContainerTest {
 
 	@Autowired
@@ -74,6 +74,36 @@ class ReminderNotificationWorkerIntegrationTest extends PostgreSqlContainerTest 
 		assertThat(queryString("select status from reminder_schedules where id = ?", futureReminderId)).isEqualTo("SCHEDULED");
 		assertThat(queryString("select status from reminder_schedules where id = ?", canceledReminderId)).isEqualTo("CANCELED");
 		assertThat(queryInteger("select count(*) from notifications where user_id = ?", userId)).isZero();
+	}
+
+	@Test
+	void skipsReminderWhenRegretReminderSettingWasDisabledAfterScheduling() {
+		UUID userId = createReadyUser();
+		disableRegretReminder(userId);
+		UUID itemId = insertSavedItem(userId, "설정 해제 상품", "GO");
+		UUID decisionId = insertDecision(userId, itemId, "GO");
+		UUID reminderId = insertReminder(userId, itemId, decisionId, "SCHEDULED", OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(1));
+
+		int processedCount = reminderNotificationWorker.processDueReminders();
+
+		assertThat(processedCount).isZero();
+		assertThat(queryString("select status from reminder_schedules where id = ?", reminderId)).isEqualTo("SCHEDULED");
+		assertThat(queryInteger("select count(*) from notifications where reminder_id = ?", reminderId)).isZero();
+	}
+
+	@Test
+	void skipsReminderForInactiveUser() {
+		UUID userId = createReadyUser();
+		jdbcTemplate.update("update users set status = 'WITHDRAWN' where id = ?", userId);
+		UUID itemId = insertSavedItem(userId, "비활성 사용자 상품", "GO");
+		UUID decisionId = insertDecision(userId, itemId, "GO");
+		UUID reminderId = insertReminder(userId, itemId, decisionId, "SCHEDULED", OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(1));
+
+		int processedCount = reminderNotificationWorker.processDueReminders();
+
+		assertThat(processedCount).isZero();
+		assertThat(queryString("select status from reminder_schedules where id = ?", reminderId)).isEqualTo("SCHEDULED");
+		assertThat(queryInteger("select count(*) from notifications where reminder_id = ?", reminderId)).isZero();
 	}
 
 	private UUID createReadyUser() {
@@ -177,6 +207,21 @@ class ReminderNotificationWorkerIntegrationTest extends PostgreSqlContainerTest 
 			itemId,
 			decisionId,
 			reminderId,
+			now,
+			now
+		);
+	}
+
+	private void disableRegretReminder(UUID userId) {
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into user_notification_settings (
+				user_id, regret_reminder_enabled, wishlist_reminder_enabled, created_at, updated_at
+			)
+			values (?, false, false, ?, ?)
+			""",
+			userId,
 			now,
 			now
 		);

--- a/src/test/java/com/sagongsa/backend/notification/ReminderNotificationWorkerIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/notification/ReminderNotificationWorkerIntegrationTest.java
@@ -94,7 +94,12 @@ class ReminderNotificationWorkerIntegrationTest extends PostgreSqlContainerTest 
 	@Test
 	void skipsReminderForInactiveUser() {
 		UUID userId = createReadyUser();
-		jdbcTemplate.update("update users set status = 'WITHDRAWN' where id = ?", userId);
+		jdbcTemplate.update(
+			"update users set status = 'WITHDRAWN', withdrawn_at = ?, updated_at = ? where id = ?",
+			OffsetDateTime.now(ZoneOffset.UTC),
+			OffsetDateTime.now(ZoneOffset.UTC),
+			userId
+		);
 		UUID itemId = insertSavedItem(userId, "비활성 사용자 상품", "GO");
 		UUID decisionId = insertDecision(userId, itemId, "GO");
 		UUID reminderId = insertReminder(userId, itemId, decisionId, "SCHEDULED", OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(1));
@@ -217,12 +222,11 @@ class ReminderNotificationWorkerIntegrationTest extends PostgreSqlContainerTest 
 		jdbcTemplate.update(
 			"""
 			insert into user_notification_settings (
-				user_id, regret_reminder_enabled, wishlist_reminder_enabled, created_at, updated_at
+				user_id, regret_reminder_enabled, wishlist_reminder_enabled, updated_at
 			)
-			values (?, false, false, ?, ?)
+			values (?, false, false, ?)
 			""",
 			userId,
-			now,
 			now
 		);
 	}


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-31**
- Jira: https://parkjaehong.atlassian.net/browse/NF-31

> PR 제목: `[bug] NF-31 구매 결정 결과와 리마인더 워커 안정성 보완`  
> 브랜치: `fix/NF-31-decision-reminder-stability`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #43

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- GO 결정 응답 메시지가 실제 reminder 생성 여부와 무관하게 7일 후 알림을 약속했습니다.
- self-check questionCode, STOP finalPrice, rationale length 검증이 느슨했습니다.
- reminder worker가 발송 직전 알림 설정/사용자 상태를 재확인하지 않았고, notification 중복 방어가 DB 레벨에 없었습니다.

### 왜 발생했나? (Root Cause)
- decision 결과 응답과 reminder 생성 결과가 분리되어 있지 않았습니다.
- 입력값 검증이 enum/길이/의미 단위 계약까지 내려가지 않았습니다.
- worker가 예약 당시 상태만 믿고 처리했고, notification idempotency를 DB 제약으로 보장하지 않았습니다.

### 어떻게 고쳤나?
- GO result message를 실제 reminder 생성 여부와 일치시켰습니다.
- self-check questionCode whitelist, STOP finalPrice null 처리, rationale/change reason 길이 제한을 추가했습니다.
- worker가 발송 직전 사용자 활성 상태와 regret reminder 설정을 재확인하도록 하고, notification partial unique index와 조건부 scheduler를 추가했습니다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법(가능하면)
- Steps: regret reminder를 끈 사용자에게 due reminder를 만들고 worker를 실행합니다.
- 기대 결과: 알림이 생성되지 않고 retry 가능한 상태로 남습니다.
- 실제 결과: 기존 구현에서는 예약된 알림이 현재 설정 변경과 무관하게 발송될 수 있었습니다.

### 재발 방지(있다면)
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [ ] 런북/문서 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] AC1: reminder 생성 여부와 result message를 일치시킨다.
- [x] AC2: decision 입력 계약(questionCode/finalPrice/rationale)을 검증한다.
- [x] AC3: reminder worker의 설정 재확인, retry 가능 상태, idempotent notification을 보강한다.

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew.bat testClasses`
- Result: PASS
- Command: `./gradlew.bat test --tests "com.sagongsa.backend.decision.DecisionApiIntegrationTest" --tests "com.sagongsa.backend.notification.ReminderNotificationWorkerIntegrationTest"`
- Result: PASS

### CI
- 링크/결과: 자동 첨부 확인 예정

### Smoke / 수동 검증
- 시나리오: GO/STOP decision 생성, invalid questionCode 차단, disabled reminder worker 처리, notification 중복 방지
- 결과: 통합 테스트로 검증

### 테스트 공백(있다면 이유 필수)
- 외부 push provider 연동은 이 PR 범위가 아니어서 테스트하지 않았습니다.

---

## 🧭 영향 범위 (필수)
- [ ] API 스펙 변경 없음
- [x] API 스펙 변경 있음 (요약: STOP finalPrice는 null, GO resultMessage는 reminder 생성 여부에 따라 달라짐)
- [ ] DB 스키마 변경 없음
- [x] DB 스키마 변경 있음 (마이그레이션/락/시간: `V3__notification_reminder_idempotency.sql`, notifications partial unique index 추가)
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음 (항목: )
- [x] 캐시/큐/외부 연동 영향 없음
- [ ] 캐시/큐/외부 연동 영향 있음 (요약: )

---

## 💥 Breaking / Compatibility (필수)
- [ ] Breaking change 없음
- [x] Breaking change 있음 → STOP decision 응답의 `finalPrice`가 null로 정리됩니다. 기존에 listedPrice처럼 해석하던 클라이언트는 조정이 필요합니다.

---

## 🚀 배포/릴리즈 (해당 시 필수)
### Feature Flag
- [x] 사용 안함
- [ ] 사용함 → Flag/기본값/롤아웃:

### 모니터링/알림
- 확인할 대시보드/지표: reminder worker 처리 건수, notification 중복/삽입 실패 로그
- 에러/로그 키워드: `REGRET_CHECK_READY`, reminder worker exception

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- partial unique index 추가 시 기존 중복 notification 데이터가 있으면 migration 전 정리가 필요할 수 있습니다.

### 롤백
- [ ] 플래그/설정으로 우회 가능
- [x] 배포 롤백(이전 태그/이미지) 가능
- [x] 데이터 롤백/역마이그레이션 필요 (절차: partial unique index 제거가 필요할 수 있음)

---

## 📸 증빙 (선택)
- 스크린샷/로그/메트릭 링크: 로컬 통합 테스트 PASS 로그
- 전/후 비교(가능하면): disabled reminder setting 후 worker 미발송 테스트 추가

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직: `DecisionService`, `ReminderNotificationWorker`, `ReminderNotificationScheduler`, `V3__notification_reminder_idempotency.sql`
- 트레이드오프/대안: 외부 push provider 연동과 알림 UX 정책은 NF-33에서 별도 확인합니다.
- 성능/보안/호환성 영향: worker 중복 발송 위험을 줄이고 사용자 알림 설정 변경을 발송 직전 반영합니다.

