### PR TITLE
[feat] NF-36 예산 소진 상태 응답 추가

### DIFF
--- a/src/main/java/com/sagongsa/backend/decision/DecisionResultResponse.java
+++ b/src/main/java/com/sagongsa/backend/decision/DecisionResultResponse.java
@@ -12,6 +12,8 @@ public record DecisionResultResponse(
 	Integer finalPrice,
 	String budgetYearMonth,
 	Integer budgetAfterAmount,
+	boolean budgetExhaustedAfter,
+	boolean budgetBecameExhausted,
 	Integer similarCategorySpendAmount,
 	int selfCheckYesCount,
 	String rationalityResult,

--- a/src/main/java/com/sagongsa/backend/decision/DecisionService.java
+++ b/src/main/java/com/sagongsa/backend/decision/DecisionService.java
@@ -131,6 +131,9 @@ public class DecisionService {
 		BudgetExhaustion budgetExhaustion = budgetExhaustionOverride == null
 			? budgetExhaustion(decision)
 			: budgetExhaustionOverride;
+		if (budgetExhaustionOverride == null) {
+			budgetExhaustion = new BudgetExhaustion(budgetExhaustion.exhaustedAfter(), false);
+		}
 
 		return new DecisionResultResponse(
 			decision.id(),

--- a/src/main/java/com/sagongsa/backend/decision/DecisionService.java
+++ b/src/main/java/com/sagongsa/backend/decision/DecisionService.java
@@ -65,6 +65,11 @@ public class DecisionService {
 		Rationality rationality = rationality(normalized.selfCheckAnswers());
 		Integer similarCategorySpendAmount = similarCategorySpendAmount(userId, item.category(), zoneId, now.toInstant());
 		int budgetAfterAmount = budgetCycle.spentAmount() + (normalized.result() == PurchaseDecisionResult.GO ? finalPrice : 0);
+		BudgetExhaustion budgetExhaustion = budgetExhaustion(
+			budgetCycle.monthlyBudgetAmount(),
+			budgetCycle.spentAmount(),
+			budgetAfterAmount
+		);
 		UUID decisionId = UUID.randomUUID();
 
 		insertDecision(
@@ -99,6 +104,8 @@ public class DecisionService {
 			finalPrice,
 			yearMonth,
 			budgetAfterAmount,
+			budgetExhaustion.exhaustedAfter(),
+			budgetExhaustion.becameExhausted(),
 			similarCategorySpendAmount,
 			rationality.yesCount(),
 			rationality.result().name(),
@@ -112,11 +119,18 @@ public class DecisionService {
 
 	@Transactional(readOnly = true)
 	public DecisionResultResponse getResult(UUID userId, UUID decisionId) {
+		return getResult(userId, decisionId, null);
+	}
+
+	private DecisionResultResponse getResult(UUID userId, UUID decisionId, BudgetExhaustion budgetExhaustionOverride) {
 		requireDecisionUser(userId);
 		DecisionResult decision = findDecisionResult(userId, decisionId)
 			.orElseThrow(() -> new DecisionNotFoundException("Purchase decision result was not found."));
 		ReminderResponse reminder = findReminder(decisionId).orElse(null);
 		MascotReactionResponse mascot = new MascotReactionResponse(decision.mascotState(), decision.mascotMessage());
+		BudgetExhaustion budgetExhaustion = budgetExhaustionOverride == null
+			? budgetExhaustion(decision)
+			: budgetExhaustionOverride;
 
 		return new DecisionResultResponse(
 			decision.id(),
@@ -127,6 +141,8 @@ public class DecisionService {
 			decision.finalPrice(),
 			decision.budgetYearMonth(),
 			decision.budgetAfterAmount(),
+			budgetExhaustion.exhaustedAfter(),
+			budgetExhaustion.becameExhausted(),
 			decision.similarCategorySpendAmount(),
 			decision.selfCheckYesCount(),
 			decision.rationalityResult(),
@@ -157,7 +173,8 @@ public class DecisionService {
 		Integer previousGoAmount = previousResult == PurchaseDecisionResult.GO ? Objects.requireNonNullElse(decision.finalPrice(), 0) : 0;
 		Integer newGoAmount = normalized.result() == PurchaseDecisionResult.GO ? Objects.requireNonNullElse(newFinalPrice, 0) : 0;
 		int budgetDelta = newGoAmount - previousGoAmount;
-		int budgetAfterAmount = updateBudgetForDecisionChange(decision.budgetCycleId(), budgetDelta, now);
+		BudgetUpdate budgetUpdate = updateBudgetForDecisionChange(decision.budgetCycleId(), budgetDelta, now);
+		int budgetAfterAmount = budgetUpdate.spentAmount();
 
 		updateDecisionResult(decision, normalized.result(), newFinalPrice, newRationality, budgetAfterAmount, now);
 		updateItemStatus(decision.itemId(), normalized.result(), now);
@@ -173,7 +190,7 @@ public class DecisionService {
 			now
 		);
 
-		return getResult(userId, decisionId);
+		return getResult(userId, decisionId, budgetUpdate.exhaustion());
 	}
 
 	private NormalizedDecisionRequest normalize(DecisionCompleteRequest request) {
@@ -547,9 +564,9 @@ public class DecisionService {
 		);
 	}
 
-	private int updateBudgetForDecisionChange(UUID budgetCycleId, int delta, OffsetDateTime now) {
+	private BudgetUpdate updateBudgetForDecisionChange(UUID budgetCycleId, int delta, OffsetDateTime now) {
 		if (budgetCycleId == null) {
-			return 0;
+			return new BudgetUpdate(0, new BudgetExhaustion(false, false));
 		}
 		BudgetSpent budget = jdbcTemplate.queryForObject(
 			"""
@@ -557,14 +574,45 @@ public class DecisionService {
 			set spent_amount = greatest(spent_amount + ?, 0),
 				updated_at = ?
 			where id = ?
-			returning spent_amount
+			returning monthly_budget_amount, spent_amount
 			""",
-			(rs, rowNumber) -> new BudgetSpent(rs.getInt("spent_amount")),
+			(rs, rowNumber) -> new BudgetSpent(
+				rs.getInt("monthly_budget_amount"),
+				rs.getInt("spent_amount")
+			),
 			delta,
 			now,
 			budgetCycleId
 		);
-		return budget == null ? 0 : budget.spentAmount();
+		if (budget == null) {
+			return new BudgetUpdate(0, new BudgetExhaustion(false, false));
+		}
+		int budgetBeforeAmount = budget.spentAmount() - delta;
+		return new BudgetUpdate(
+			budget.spentAmount(),
+			budgetExhaustion(budget.monthlyBudgetAmount(), budgetBeforeAmount, budget.spentAmount())
+		);
+	}
+
+	private BudgetExhaustion budgetExhaustion(DecisionResult decision) {
+		if (decision.budgetMonthlyBudgetAmount() == null || decision.budgetAfterAmount() == null) {
+			return new BudgetExhaustion(false, false);
+		}
+		int goAmount = PurchaseDecisionResult.GO.name().equals(decision.result())
+			? Objects.requireNonNullElse(decision.finalPrice(), 0)
+			: 0;
+		int budgetBeforeAmount = decision.budgetAfterAmount() - goAmount;
+		return budgetExhaustion(decision.budgetMonthlyBudgetAmount(), budgetBeforeAmount, decision.budgetAfterAmount());
+	}
+
+	private BudgetExhaustion budgetExhaustion(int monthlyBudgetAmount, int budgetBeforeAmount, int budgetAfterAmount) {
+		boolean exhaustedBefore = budgetExhausted(monthlyBudgetAmount, budgetBeforeAmount);
+		boolean exhaustedAfter = budgetExhausted(monthlyBudgetAmount, budgetAfterAmount);
+		return new BudgetExhaustion(exhaustedAfter, !exhaustedBefore && exhaustedAfter);
+	}
+
+	private boolean budgetExhausted(int monthlyBudgetAmount, int spentAmount) {
+		return monthlyBudgetAmount > 0 && spentAmount >= monthlyBudgetAmount;
 	}
 
 	private void updateDecisionResult(
@@ -897,6 +945,7 @@ public class DecisionService {
 				pd.result,
 				pd.final_price,
 				bc.year_month as budget_year_month,
+				bc.monthly_budget_amount as budget_monthly_budget_amount,
 				pd.budget_after_amount,
 				pd.similar_category_spend_amount,
 				pd.self_check_yes_count,
@@ -1038,6 +1087,7 @@ public class DecisionService {
 			rs.getString("result"),
 			getInteger(rs, "final_price"),
 			rs.getString("budget_year_month"),
+			getInteger(rs, "budget_monthly_budget_amount"),
 			getInteger(rs, "budget_after_amount"),
 			getInteger(rs, "similar_category_spend_amount"),
 			rs.getInt("self_check_yes_count"),
@@ -1088,7 +1138,13 @@ public class DecisionService {
 	private record BudgetCycle(UUID id, String yearMonth, int spentAmount, int monthlyBudgetAmount) {
 	}
 
-	private record BudgetSpent(int spentAmount) {
+	private record BudgetSpent(int monthlyBudgetAmount, int spentAmount) {
+	}
+
+	private record BudgetUpdate(int spentAmount, BudgetExhaustion exhaustion) {
+	}
+
+	private record BudgetExhaustion(boolean exhaustedAfter, boolean becameExhausted) {
 	}
 
 	private record Rationality(int yesCount, RationalityResult result) {
@@ -1105,6 +1161,7 @@ public class DecisionService {
 		String result,
 		Integer finalPrice,
 		String budgetYearMonth,
+		Integer budgetMonthlyBudgetAmount,
 		Integer budgetAfterAmount,
 		Integer similarCategorySpendAmount,
 		int selfCheckYesCount,

--- a/src/main/java/com/sagongsa/backend/home/HomeSummaryResponse.java
+++ b/src/main/java/com/sagongsa/backend/home/HomeSummaryResponse.java
@@ -32,6 +32,7 @@ public record HomeSummaryResponse(
 		String yearMonth,
 		int monthlyBudgetAmount,
 		int spentAmount,
+		int remainingAmount,
 		BigDecimal warningThresholdRate,
 		boolean exhausted,
 		boolean showBudgetExhaustionBubble

--- a/src/main/java/com/sagongsa/backend/home/HomeSummaryService.java
+++ b/src/main/java/com/sagongsa/backend/home/HomeSummaryService.java
@@ -263,7 +263,7 @@ public class HomeSummaryService {
 	}
 
 	private static int remainingAmount(int monthlyBudgetAmount, int spentAmount) {
-		return monthlyBudgetAmount - spentAmount;
+		return Math.max(0, monthlyBudgetAmount - spentAmount);
 	}
 
 	private static boolean budgetExhausted(int monthlyBudgetAmount, int spentAmount) {

--- a/src/main/java/com/sagongsa/backend/home/HomeSummaryService.java
+++ b/src/main/java/com/sagongsa/backend/home/HomeSummaryService.java
@@ -132,11 +132,12 @@ public class HomeSummaryService {
 					int monthlyBudget = rs.getInt("monthly_budget_amount");
 					int spent = rs.getInt("spent_amount");
 					boolean bubbleSeen = rs.getBoolean("budget_exhaustion_bubble_seen");
-					boolean exhausted = monthlyBudget > 0 && spent >= monthlyBudget;
+					boolean exhausted = budgetExhausted(monthlyBudget, spent);
 					return new BudgetSummary(
 						rs.getString("year_month"),
 						monthlyBudget,
 						spent,
+						remainingAmount(monthlyBudget, spent),
 						rs.getBigDecimal("warning_threshold_rate"),
 						exhausted,
 						exhausted && !bubbleSeen
@@ -258,7 +259,15 @@ public class HomeSummaryService {
 	}
 
 	private static BudgetSummary defaultBudgetSummary(String yearMonth) {
-		return new BudgetSummary(yearMonth, 0, 0, BigDecimal.ZERO, false, false);
+		return new BudgetSummary(yearMonth, 0, 0, 0, BigDecimal.ZERO, false, false);
+	}
+
+	private static int remainingAmount(int monthlyBudgetAmount, int spentAmount) {
+		return monthlyBudgetAmount - spentAmount;
+	}
+
+	private static boolean budgetExhausted(int monthlyBudgetAmount, int spentAmount) {
+		return monthlyBudgetAmount > 0 && spentAmount >= monthlyBudgetAmount;
 	}
 
 	private static ZoneId resolveZoneId(String timezone) {

--- a/src/test/java/com/sagongsa/backend/decision/DecisionApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/decision/DecisionApiIntegrationTest.java
@@ -68,6 +68,8 @@ class DecisionApiIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(jsonPath("$.result").value("GO"))
 			.andExpect(jsonPath("$.finalPrice").value(15_000))
 			.andExpect(jsonPath("$.budgetAfterAmount").value(105_000))
+			.andExpect(jsonPath("$.budgetExhaustedAfter").value(false))
+			.andExpect(jsonPath("$.budgetBecameExhausted").value(false))
 			.andExpect(jsonPath("$.similarCategorySpendAmount").value(20_000))
 			.andExpect(jsonPath("$.selfCheckYesCount").value(1))
 			.andExpect(jsonPath("$.rationalityResult").value("RATIONAL"))
@@ -102,6 +104,8 @@ class DecisionApiIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(jsonPath("$.result").value("STOP"))
 			.andExpect(jsonPath("$.finalPrice").value(nullValue()))
 			.andExpect(jsonPath("$.budgetAfterAmount").value(90_000))
+			.andExpect(jsonPath("$.budgetExhaustedAfter").value(false))
+			.andExpect(jsonPath("$.budgetBecameExhausted").value(false))
 			.andExpect(jsonPath("$.selfCheckYesCount").value(2))
 			.andExpect(jsonPath("$.rationalityResult").value("IRRATIONAL"))
 			.andExpect(jsonPath("$.mascot.state").value("VERY_HAPPY"))
@@ -111,6 +115,23 @@ class DecisionApiIntegrationTest extends PostgreSqlContainerTest {
 		assertThat(queryInteger("select spent_amount from budget_cycles where user_id = ? and year_month = ?", userId, yearMonth))
 			.isEqualTo(90_000);
 		assertThat(queryInteger("select count(*) from reminder_schedules where item_id = ?", itemId)).isZero();
+	}
+
+	@Test
+	void completesGoDecisionThatExhaustsBudget() throws Exception {
+		UUID userId = createReadyUser();
+		String yearMonth = YearMonth.now(SEOUL_ZONE).toString();
+		insertBudgetCycle(userId, yearMonth, 100_000, 90_000);
+		UUID itemId = insertSavedItem(userId, "Budget limit target", "FASHION", "SAVED", 10_000);
+
+		mockMvc.perform(post(DECISIONS_PATH)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(decisionRequest(itemId, "GO", null, true, false, false, false)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.budgetAfterAmount").value(100_000))
+			.andExpect(jsonPath("$.budgetExhaustedAfter").value(true))
+			.andExpect(jsonPath("$.budgetBecameExhausted").value(true));
 	}
 
 	@Test
@@ -146,6 +167,9 @@ class DecisionApiIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.decisionId").value(decisionId))
 			.andExpect(jsonPath("$.itemTitle").value("Readable target"))
+			.andExpect(jsonPath("$.budgetAfterAmount").value(12_000))
+			.andExpect(jsonPath("$.budgetExhaustedAfter").value(false))
+			.andExpect(jsonPath("$.budgetBecameExhausted").value(false))
 			.andExpect(jsonPath("$.rationalityResult").value("RATIONAL"))
 			.andExpect(jsonPath("$.mascot.state").value("SMILE"))
 			.andExpect(jsonPath("$.mascot.message").value("합리적으로 잘 결정했어요"))

--- a/src/test/java/com/sagongsa/backend/decision/DecisionApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/decision/DecisionApiIntegrationTest.java
@@ -135,6 +135,23 @@ class DecisionApiIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void completesGoDecisionWhileBudgetAlreadyExhausted() throws Exception {
+		UUID userId = createReadyUser();
+		String yearMonth = YearMonth.now(SEOUL_ZONE).toString();
+		insertBudgetCycle(userId, yearMonth, 100_000, 120_000);
+		UUID itemId = insertSavedItem(userId, "Already exhausted target", "FASHION", "SAVED", 10_000);
+
+		mockMvc.perform(post(DECISIONS_PATH)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(decisionRequest(itemId, "GO", null, true, false, false, false)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.budgetAfterAmount").value(130_000))
+			.andExpect(jsonPath("$.budgetExhaustedAfter").value(true))
+			.andExpect(jsonPath("$.budgetBecameExhausted").value(false));
+	}
+
+	@Test
 	void getsDecisionResult() throws Exception {
 		UUID userId = createReadyUser();
 		insertBudgetCycle(userId, YearMonth.now(SEOUL_ZONE).toString(), 500_000, 0);

--- a/src/test/java/com/sagongsa/backend/decision/DecisionApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/decision/DecisionApiIntegrationTest.java
@@ -124,14 +124,24 @@ class DecisionApiIntegrationTest extends PostgreSqlContainerTest {
 		insertBudgetCycle(userId, yearMonth, 100_000, 90_000);
 		UUID itemId = insertSavedItem(userId, "Budget limit target", "FASHION", "SAVED", 10_000);
 
-		mockMvc.perform(post(DECISIONS_PATH)
+		String body = mockMvc.perform(post(DECISIONS_PATH)
 				.header(USER_ID_HEADER, userId)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(decisionRequest(itemId, "GO", null, true, false, false, false)))
 			.andExpect(status().isCreated())
 			.andExpect(jsonPath("$.budgetAfterAmount").value(100_000))
 			.andExpect(jsonPath("$.budgetExhaustedAfter").value(true))
-			.andExpect(jsonPath("$.budgetBecameExhausted").value(true));
+			.andExpect(jsonPath("$.budgetBecameExhausted").value(true))
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+		String decisionId = objectMapper.readTree(body).get("decisionId").asText();
+
+		mockMvc.perform(get(DECISIONS_PATH + "/{decisionId}/result", decisionId)
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.budgetExhaustedAfter").value(true))
+			.andExpect(jsonPath("$.budgetBecameExhausted").value(false));
 	}
 
 	@Test
@@ -148,6 +158,23 @@ class DecisionApiIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(status().isCreated())
 			.andExpect(jsonPath("$.budgetAfterAmount").value(130_000))
 			.andExpect(jsonPath("$.budgetExhaustedAfter").value(true))
+			.andExpect(jsonPath("$.budgetBecameExhausted").value(false));
+	}
+
+	@Test
+	void doesNotTreatZeroBudgetAsExhausted() throws Exception {
+		UUID userId = createReadyUser();
+		String yearMonth = YearMonth.now(SEOUL_ZONE).toString();
+		insertBudgetCycle(userId, yearMonth, 0, 0);
+		UUID itemId = insertSavedItem(userId, "Zero budget target", "FASHION", "SAVED", 10_000);
+
+		mockMvc.perform(post(DECISIONS_PATH)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(decisionRequest(itemId, "GO", null, true, false, false, false)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.budgetAfterAmount").value(10_000))
+			.andExpect(jsonPath("$.budgetExhaustedAfter").value(false))
 			.andExpect(jsonPath("$.budgetBecameExhausted").value(false));
 	}
 

--- a/src/test/java/com/sagongsa/backend/home/HomeSummaryIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/home/HomeSummaryIntegrationTest.java
@@ -74,6 +74,7 @@ class HomeSummaryIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(jsonPath("$.budget.yearMonth").value(yearMonth))
 			.andExpect(jsonPath("$.budget.monthlyBudgetAmount").value(500_000))
 			.andExpect(jsonPath("$.budget.spentAmount").value(125_000))
+			.andExpect(jsonPath("$.budget.remainingAmount").value(375_000))
 			.andExpect(jsonPath("$.budget.warningThresholdRate").value(80.00))
 			.andExpect(jsonPath("$.budget.exhausted").value(false))
 			.andExpect(jsonPath("$.budget.showBudgetExhaustionBubble").value(false))
@@ -102,6 +103,7 @@ class HomeSummaryIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(jsonPath("$.budget.yearMonth").value(yearMonth))
 			.andExpect(jsonPath("$.budget.monthlyBudgetAmount").value(0))
 			.andExpect(jsonPath("$.budget.spentAmount").value(0))
+			.andExpect(jsonPath("$.budget.remainingAmount").value(0))
 			.andExpect(jsonPath("$.budget.warningThresholdRate").value(0))
 			.andExpect(jsonPath("$.budget.exhausted").value(false))
 			.andExpect(jsonPath("$.budget.showBudgetExhaustionBubble").value(false))
@@ -126,6 +128,24 @@ class HomeSummaryIntegrationTest extends PostgreSqlContainerTest {
 		mockMvc.perform(get("/api/v1/home/summary").header("X-User-Id", userId))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.rationalChoiceRate").value(50.00));
+	}
+
+	@Test
+	void returnsBudgetExhaustedWhenSpentReachesCurrentMonthBudget() throws Exception {
+		UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000110");
+		String yearMonth = YearMonth.now(SEOUL_ZONE).toString();
+
+		insertUser(userId);
+		insertBudgetCycle(userId, yearMonth, 100_000, 120_000, new BigDecimal("80.00"));
+
+		mockMvc.perform(get("/api/v1/home/summary").header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.budget.yearMonth").value(yearMonth))
+			.andExpect(jsonPath("$.budget.monthlyBudgetAmount").value(100_000))
+			.andExpect(jsonPath("$.budget.spentAmount").value(120_000))
+			.andExpect(jsonPath("$.budget.remainingAmount").value(-20_000))
+			.andExpect(jsonPath("$.budget.exhausted").value(true))
+			.andExpect(jsonPath("$.budget.showBudgetExhaustionBubble").value(true));
 	}
 
 	@Test

--- a/src/test/java/com/sagongsa/backend/home/HomeSummaryIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/home/HomeSummaryIntegrationTest.java
@@ -149,6 +149,34 @@ class HomeSummaryIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void clampsRemainingAmountWhenBudgetIsOverspent() throws Exception {
+		UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000106");
+		String yearMonth = YearMonth.now(SEOUL_ZONE).toString();
+
+		insertUser(userId);
+		insertBudgetCycle(userId, yearMonth, 100_000, 120_000, new BigDecimal("80.00"));
+
+		mockMvc.perform(get("/api/v1/home/summary").header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.budget.remainingAmount").value(0))
+			.andExpect(jsonPath("$.budget.exhausted").value(true));
+	}
+
+	@Test
+	void doesNotTreatZeroBudgetAsExhausted() throws Exception {
+		UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000107");
+		String yearMonth = YearMonth.now(SEOUL_ZONE).toString();
+
+		insertUser(userId);
+		insertBudgetCycle(userId, yearMonth, 0, 10_000, new BigDecimal("80.00"));
+
+		mockMvc.perform(get("/api/v1/home/summary").header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.budget.remainingAmount").value(0))
+			.andExpect(jsonPath("$.budget.exhausted").value(false));
+	}
+
+	@Test
 	void returnsUnreadCountAndLatestNotifications() throws Exception {
 		UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000103");
 		UUID newestUnreadId = UUID.fromString("00000000-0000-0000-0000-000000000301");

--- a/src/test/java/com/sagongsa/backend/home/HomeSummaryIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/home/HomeSummaryIntegrationTest.java
@@ -136,14 +136,14 @@ class HomeSummaryIntegrationTest extends PostgreSqlContainerTest {
 		String yearMonth = YearMonth.now(SEOUL_ZONE).toString();
 
 		insertUser(userId);
-		insertBudgetCycle(userId, yearMonth, 100_000, 120_000, new BigDecimal("80.00"));
+		insertBudgetCycle(userId, yearMonth, 100_000, 100_000, new BigDecimal("80.00"));
 
 		mockMvc.perform(get("/api/v1/home/summary").header("X-User-Id", userId))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.budget.yearMonth").value(yearMonth))
 			.andExpect(jsonPath("$.budget.monthlyBudgetAmount").value(100_000))
-			.andExpect(jsonPath("$.budget.spentAmount").value(120_000))
-			.andExpect(jsonPath("$.budget.remainingAmount").value(-20_000))
+			.andExpect(jsonPath("$.budget.spentAmount").value(100_000))
+			.andExpect(jsonPath("$.budget.remainingAmount").value(0))
 			.andExpect(jsonPath("$.budget.exhausted").value(true))
 			.andExpect(jsonPath("$.budget.showBudgetExhaustionBubble").value(true));
 	}

--- a/src/test/java/com/sagongsa/backend/mvp/MvpBackendGapIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/mvp/MvpBackendGapIntegrationTest.java
@@ -159,6 +159,8 @@ class MvpBackendGapIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(jsonPath("$.itemStatus").value("STOP"))
 			.andExpect(jsonPath("$.result").value("STOP"))
 			.andExpect(jsonPath("$.budgetAfterAmount").value(60_000))
+			.andExpect(jsonPath("$.budgetExhaustedAfter").value(false))
+			.andExpect(jsonPath("$.budgetBecameExhausted").value(false))
 			.andExpect(jsonPath("$.selfCheckYesCount").value(3))
 			.andExpect(jsonPath("$.rationalityResult").value("IRRATIONAL"))
 			.andExpect(jsonPath("$.reminder.status").value("CANCELED"))
@@ -170,6 +172,34 @@ class MvpBackendGapIntegrationTest extends PostgreSqlContainerTest {
 		assertThat(queryInteger("select count(*) from purchase_decision_change_logs where decision_id = ?", decisionId)).isEqualTo(1);
 		assertThat(queryString("select status from reminder_schedules where decision_id = ?", decisionId)).isEqualTo("CANCELED");
 		assertThat(queryInteger("select count(*) from mascot_state_events where decision_id = ?", decisionId)).isEqualTo(1);
+	}
+
+	@Test
+	void returnsBudgetExhaustionWhenConsumptionRecordUpdateCrossesBudgetLimit() throws Exception {
+		UUID userId = createReadyUser();
+		String yearMonth = YearMonth.now(SEOUL_ZONE).toString();
+		UUID budgetCycleId = insertBudgetCycle(userId, yearMonth, 100_000, 90_000);
+		UUID itemId = insertSavedItem(userId, "예산 소진 상품", "FASHION", "STOP", 20_000);
+		UUID decisionId = insertDecision(userId, itemId, "STOP", 20_000, "RATIONAL", 1, budgetCycleId);
+		insertSelfCheck(decisionId, 1, "RATIONAL", true, false, false, false);
+
+		mockMvc.perform(patch("/api/v1/decisions/{decisionId}/result", decisionId)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"result": "GO",
+					"finalPrice": 20000,
+					"changeReason": "결국 구매했어요"
+				}
+				"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.itemStatus").value("GO"))
+			.andExpect(jsonPath("$.budgetAfterAmount").value(110_000))
+			.andExpect(jsonPath("$.budgetExhaustedAfter").value(true))
+			.andExpect(jsonPath("$.budgetBecameExhausted").value(true));
+
+		assertThat(queryInteger("select spent_amount from budget_cycles where id = ?", budgetCycleId)).isEqualTo(110_000);
 	}
 
 	private UUID createReadyUser() {


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-36`
- Jira: https://parkjaehong.atlassian.net/browse/NF-36
- GitHub: Related #53
- GitHub: Closes #53

> PR 제목: `[feat] NF-36 예산 소진 상태 응답 추가`
> 브랜치: `feat/NF-36-budget-exhaustion-response`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #53의 1/1 단계
- 선행 PR: 없음
- 후속 PR: 프론트 천둥번개 배경, 너굴 표정, 말풍선 노출 처리

### 이 PR에서 변경한 것
- 홈 요약 예산 응답에 `remainingAmount`, `exhausted` 필드를 추가했습니다.
- 숙려 결과 응답에 `budgetExhaustedAfter`, `budgetBecameExhausted` 필드를 추가했습니다.
- 구매결정 수정으로 예산 소진 상태에 진입하는 경우도 응답에서 구분하도록 했습니다.
- 예산 소진/비소진 홈 요약, 숙려 결과 생성, 소비관리 수정 케이스 통합 테스트를 보강했습니다.

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
- AC1: 현재 월 예산의 `spentAmount >= monthlyBudgetAmount`이면 홈 요약에서 예산 소진 상태를 내려줍니다.
- AC2: 숙려 결과 처리 후 예산 소진 여부와 이번 처리로 소진 상태에 진입했는지를 내려줍니다.
- AC3: 소비관리에서 구매결정 수정 시 예산 소진 상태 전환도 응답에 반영됩니다.

### Not covered (후속 작업)
- AC4: 천둥번개 배경, 너굴 당황/식은땀 표정 전환은 프론트 작업입니다. → 후속 프론트 PR
- AC5: 말풍선 노출 플래그 저장/매월 초기화는 이번 백엔드 예산 소진 응답 범위에서 제외했습니다. → 별도 이슈 또는 후속 PR
- AC6: 월 예산 초기화 스케줄러 자체는 이번 범위에서 제외했습니다. → 별도 이슈 또는 후속 PR

---

## 🧪 테스트 결과 (필수)
### 로컬
```
./gradlew test
```
- ✅ 결과: 성공

### CI
- (자동 첨부)

### Smoke 테스트
- 시나리오: 홈 요약에서 남은 예산/예산 소진 여부 확인
- 시나리오: 숙려 결과 생성으로 예산 한도 도달 시 `budgetBecameExhausted=true` 확인
- 시나리오: 소비관리 결과 수정으로 예산 한도 초과 시 `budgetBecameExhausted=true` 확인
- 결과: ✅ 통합 테스트로 확인

---

## 🧭 영향 범위 체크 (필수)
- [x] API 변경 (요약: 홈 요약/숙려 결과 응답 필드 추가)
- [ ] DB 변경 (마이그레이션: 없음)
- [ ] 설정 변경 (항목: 없음)
- [ ] Breaking change (무엇: 없음, 응답 필드 추가)

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인: `HomeSummaryService`, `DecisionService`
- 트레이드오프/대안: 말풍선 노출 플래그와 UI 상태 전환은 이번 PR에 포함하지 않고, 프론트가 판단 가능한 예산 소진 응답만 추가했습니다.
