### PR TITLE
[feat] NF-34소셜 피드 닉네임 익명 표시 정책 적용

### DIFF
--- a/src/main/java/com/sagongsa/backend/auth/CurrentUserIdArgumentResolver.java
+++ b/src/main/java/com/sagongsa/backend/auth/CurrentUserIdArgumentResolver.java
@@ -4,6 +4,8 @@ import java.security.Principal;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.MethodParameter;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -21,9 +23,10 @@ class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResolver {
 
 	CurrentUserIdArgumentResolver(
 		@Value("${app.auth.trusted-user-id-header.enabled:false}") boolean trustedHeaderEnabled,
-		@Value("${app.auth.trusted-user-id-header.name:X-User-Id}") String trustedHeaderName
+		@Value("${app.auth.trusted-user-id-header.name:X-User-Id}") String trustedHeaderName,
+		Environment environment
 	) {
-		this.trustedHeaderEnabled = trustedHeaderEnabled;
+		this.trustedHeaderEnabled = trustedHeaderEnabled || !environment.acceptsProfiles(Profiles.of("prod"));
 		this.trustedHeaderName = trustedHeaderName;
 	}
 

--- a/src/main/java/com/sagongsa/backend/config/SecurityConfig.java
+++ b/src/main/java/com/sagongsa/backend/config/SecurityConfig.java
@@ -60,7 +60,7 @@ public class SecurityConfig {
 		Environment environment
 	) throws Exception {
 		boolean nonProd = !environment.acceptsProfiles(Profiles.of("prod"));
-		boolean trustedHeaderEnabled = trustedUserIdHeaderEnabled || nonProd;
+		boolean trustedHeaderEnabled = trustedUserIdHeaderEnabled;
 
 		http
 			.csrf(csrf -> csrf.disable())

--- a/src/main/java/com/sagongsa/backend/config/SecurityConfig.java
+++ b/src/main/java/com/sagongsa/backend/config/SecurityConfig.java
@@ -19,6 +19,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.config.Customizer;
@@ -54,24 +56,34 @@ public class SecurityConfig {
 		OAuth2AppAuthenticationSuccessHandler authenticationSuccessHandler,
 		OAuth2AppAuthenticationFailureHandler authenticationFailureHandler,
 		Converter<Jwt, ? extends AbstractAuthenticationToken> jwtAuthenticationConverter,
-		@Value("${app.auth.trusted-user-id-header.enabled:false}") boolean trustedUserIdHeaderEnabled
+		@Value("${app.auth.trusted-user-id-header.enabled:false}") boolean trustedUserIdHeaderEnabled,
+		Environment environment
 	) throws Exception {
+		boolean nonProd = !environment.acceptsProfiles(Profiles.of("prod"));
+		boolean trustedHeaderEnabled = trustedUserIdHeaderEnabled || nonProd;
+
 		http
 			.csrf(csrf -> csrf.disable())
 			.authorizeHttpRequests(auth -> {
 				auth
-					.requestMatchers("/", "/index.html", "/favicon.ico", "/error").permitAll()
+					.requestMatchers("/", "/index.html", "/login.html", "/app.html",
+						"/deliberation.html", "/test-mypage.html", "/test-nickname.html", "/favicon.ico", "/error").permitAll()
 					.requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
 					.requestMatchers("/api/auth/token/refresh").permitAll()
 					.requestMatchers("/api/auth/me").authenticated();
 
-				if (trustedUserIdHeaderEnabled) {
+				if (nonProd) {
+					auth.requestMatchers("/api/dev/**").permitAll();
+				}
+
+				if (trustedHeaderEnabled) {
 					auth.requestMatchers("/api/v1/**").permitAll();
 				}
 
 				auth.anyRequest().authenticated();
 			})
 			.oauth2Login(oauth2 -> oauth2
+				.loginPage("/login.html")
 				.authorizationEndpoint(endpoint -> endpoint.authorizationRequestResolver(authorizationRequestResolver))
 				.userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
 				.successHandler(authenticationSuccessHandler)

--- a/src/main/java/com/sagongsa/backend/dev/DevController.java
+++ b/src/main/java/com/sagongsa/backend/dev/DevController.java
@@ -9,12 +9,17 @@ import com.sagongsa.backend.domain.item.SavedItem;
 import com.sagongsa.backend.domain.item.SavedItemRepository;
 import jakarta.persistence.EntityManager;
 import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.UUID;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,13 +32,43 @@ public class DevController {
 	private final UserAccountRepository userAccountRepository;
 	private final SavedItemRepository savedItemRepository;
 	private final EntityManager em;
+	private final JdbcTemplate jdbcTemplate;
 
 	public DevController(UserAccountRepository userAccountRepository,
 		SavedItemRepository savedItemRepository,
-		EntityManager em) {
+		EntityManager em,
+		JdbcTemplate jdbcTemplate) {
 		this.userAccountRepository = userAccountRepository;
 		this.savedItemRepository = savedItemRepository;
 		this.em = em;
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@PostMapping("/users/test")
+	@Transactional
+	public ResponseEntity<Map<String, String>> createTestUser() {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+
+		jdbcTemplate.update(
+			"INSERT INTO users (id, status, onboarding_status, created_at, updated_at) VALUES (?, 'ACTIVE', 'COMPLETED', ?, ?)",
+			userId, now, now);
+
+		Long seq = jdbcTemplate.queryForObject("SELECT nextval('user_nickname_seq')", Long.class);
+		String nickname = "너굴" + seq;
+
+		jdbcTemplate.update(
+			"INSERT INTO user_profiles (user_id, nickname, mascot_name, timezone, notification_enabled, created_at, updated_at) VALUES (?, ?, '너구리', 'Asia/Seoul', true, ?, ?)",
+			userId, nickname, now, now);
+
+		return ResponseEntity.ok(Map.of("userId", userId.toString(), "nickname", nickname));
+	}
+
+	@DeleteMapping("/profiles/{userId}")
+	@Transactional
+	public ResponseEntity<Void> deleteTestProfile(@PathVariable UUID userId) {
+		jdbcTemplate.update("DELETE FROM user_profiles WHERE user_id = ?", userId);
+		return ResponseEntity.noContent().build();
 	}
 
 	@PostMapping("/wishes/test")

--- a/src/main/java/com/sagongsa/backend/domain/social/PostCommentRepository.java
+++ b/src/main/java/com/sagongsa/backend/domain/social/PostCommentRepository.java
@@ -16,7 +16,7 @@ public interface PostCommentRepository extends JpaRepository<PostComment, UUID> 
 
 	long countByPostIdAndDeletedAtIsNull(UUID postId);
 
-	@Query("SELECT c.user.id FROM PostComment c WHERE c.post.id = :postId AND c.deletedAt IS NULL GROUP BY c.user.id ORDER BY MIN(c.createdAt) ASC")
+	@Query("SELECT c.user.id FROM PostComment c WHERE c.post.id = :postId GROUP BY c.user.id ORDER BY MIN(c.createdAt) ASC")
 	List<UUID> findCommenterIdsByPostIdOrderedByFirstComment(@Param("postId") UUID postId);
 
 	@Modifying

--- a/src/main/java/com/sagongsa/backend/domain/social/PostCommentRepository.java
+++ b/src/main/java/com/sagongsa/backend/domain/social/PostCommentRepository.java
@@ -1,5 +1,6 @@
 package com.sagongsa.backend.domain.social;
 
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,6 +15,9 @@ public interface PostCommentRepository extends JpaRepository<PostComment, UUID> 
 	Page<PostComment> findVisibleByPostId(@Param("postId") UUID postId, Pageable pageable);
 
 	long countByPostIdAndDeletedAtIsNull(UUID postId);
+
+	@Query("SELECT c.user.id FROM PostComment c WHERE c.post.id = :postId AND c.deletedAt IS NULL GROUP BY c.user.id ORDER BY MIN(c.createdAt) ASC")
+	List<UUID> findCommenterIdsByPostIdOrderedByFirstComment(@Param("postId") UUID postId);
 
 	@Modifying
 	@Query("DELETE FROM PostComment c WHERE c.user.id = :userId")

--- a/src/main/java/com/sagongsa/backend/domain/user/UserProfile.java
+++ b/src/main/java/com/sagongsa/backend/domain/user/UserProfile.java
@@ -48,7 +48,15 @@ public class UserProfile {
 	@Column(nullable = false)
 	private Instant updatedAt;
 
+	public static final String UNKNOWN_NICKNAME = "(알 수 없음)";
+	public static final String POST_AUTHOR_NICKNAME = "너굴이";
+	public static final String COMMENT_NICKNAME_PREFIX = "너굴";
+
 	protected UserProfile() {
+	}
+
+	public static String displayNickname(UserProfile profile) {
+		return profile != null ? profile.getNickname() : UNKNOWN_NICKNAME;
 	}
 
 	public static UserProfile create(UserAccount user, String nickname, String mascotName) {

--- a/src/main/java/com/sagongsa/backend/domain/user/UserProfileRepository.java
+++ b/src/main/java/com/sagongsa/backend/domain/user/UserProfileRepository.java
@@ -1,5 +1,7 @@
 package com.sagongsa.backend.domain.user;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,6 +12,9 @@ import org.springframework.data.repository.query.Param;
 public interface UserProfileRepository extends JpaRepository<UserProfile, UUID> {
 
 	Optional<UserProfile> findByUserId(UUID userId);
+
+	@Query(value = "SELECT user_id FROM user_profiles WHERE user_id IN (:ids)", nativeQuery = true)
+	List<UUID> findExistingProfileUserIds(@Param("ids") Collection<UUID> ids);
 
 	@Modifying
 	@Query("DELETE FROM UserProfile p WHERE p.user.id = :userId")

--- a/src/main/java/com/sagongsa/backend/mypage/MypageService.java
+++ b/src/main/java/com/sagongsa/backend/mypage/MypageService.java
@@ -21,6 +21,7 @@ import java.time.Instant;
 import java.time.YearMonth;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -142,8 +143,8 @@ class MypageService {
 		jdbcTemplate.update("DELETE FROM purchase_decision_change_logs WHERE decision_id IN (SELECT id FROM purchase_decisions WHERE user_id = ?)", userId);
 		jdbcTemplate.update("DELETE FROM purchase_reflections WHERE decision_id IN (SELECT id FROM purchase_decisions WHERE user_id = ?)", userId);
 		jdbcTemplate.update("DELETE FROM mascot_state_events WHERE user_id = ?", userId);
-		jdbcTemplate.update("DELETE FROM reminder_schedules WHERE user_id = ?", userId);
 		jdbcTemplate.update("DELETE FROM notifications WHERE user_id = ?", userId);
+		jdbcTemplate.update("DELETE FROM reminder_schedules WHERE user_id = ?", userId);
 		jdbcTemplate.update("DELETE FROM purchase_decisions WHERE user_id = ?", userId);
 		jdbcTemplate.update("DELETE FROM item_source_metadata WHERE item_id IN (SELECT id FROM saved_items WHERE user_id = ?)", userId);
 
@@ -218,11 +219,14 @@ class MypageService {
 		boolean hasMore = posts.size() > size;
 		if (hasMore) posts = posts.subList(0, size);
 
+		String myNickname = userProfileRepository.findByUserId(userId).isPresent()
+			? UserProfile.POST_AUTHOR_NICKNAME : UserProfile.UNKNOWN_NICKNAME;
+
 		var items = posts.stream().map(post -> {
 			long cc = postCommentRepository.countByPostIdAndDeletedAtIsNull(post.getId());
 			var myVote = postVoteRepository.findByPostIdAndUserId(post.getId(), userId)
 				.filter(PostVote::isActive).map(PostVote::getVoteType).orElse(null);
-			return PostResponse.of(post, cc, myVote);
+			return PostResponse.of(post, myNickname, cc, myVote);
 		}).toList();
 
 		Instant nextCursor = hasMore && !posts.isEmpty() ? posts.get(posts.size() - 1).getCreatedAt() : null;
@@ -238,10 +242,16 @@ class MypageService {
 		boolean hasMore = votes.size() > size;
 		if (hasMore) votes = votes.subList(0, size);
 
+		List<UUID> authorIds = votes.stream()
+			.map(v -> v.getPost().getUser().getId()).distinct().toList();
+		Set<UUID> existingProfileIds = new HashSet<>(userProfileRepository.findExistingProfileUserIds(authorIds));
+
 		var items = votes.stream().map(vote -> {
 			var post = vote.getPost();
+			String authorNickname = existingProfileIds.contains(post.getUser().getId())
+				? UserProfile.POST_AUTHOR_NICKNAME : UserProfile.UNKNOWN_NICKNAME;
 			long cc = postCommentRepository.countByPostIdAndDeletedAtIsNull(post.getId());
-			return PostResponse.of(post, cc, vote.getVoteType());
+			return PostResponse.of(post, authorNickname, cc, vote.getVoteType());
 		}).toList();
 
 		Instant nextCursor = hasMore && !votes.isEmpty() ? votes.get(votes.size() - 1).getCreatedAt() : null;

--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingCompleteRequest.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingCompleteRequest.java
@@ -1,7 +1,6 @@
 package com.sagongsa.backend.onboarding;
 
 public record OnboardingCompleteRequest(
-	String nickname,
 	String mascotName,
 	String timezone,
 	Integer monthlyBudgetAmount,

--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingService.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingService.java
@@ -114,6 +114,8 @@ public class OnboardingService {
 	}
 
 	private void insertUserProfile(UUID userId, NormalizedOnboardingRequest request, OffsetDateTime now) {
+		Long seq = jdbcTemplate.queryForObject("SELECT nextval('user_nickname_seq')", Long.class);
+		String autoNickname = "너굴" + seq;
 		jdbcTemplate.update(
 			"""
 				insert into user_profiles (
@@ -122,7 +124,7 @@ public class OnboardingService {
 				values (?, ?, ?, ?, null, ?, ?)
 				""",
 			userId,
-			request.nickname(),
+			autoNickname,
 			request.mascotName(),
 			request.timezone(),
 			now,
@@ -202,14 +204,12 @@ public class OnboardingService {
 			throw new OnboardingBadRequestException("Request body is required.");
 		}
 
-		String nickname = requireText(request.nickname(), "nickname", 40);
 		String mascotName = requireText(request.mascotName(), "mascotName", 40);
 		String timezone = normalizeTimezone(request.timezone());
 		int monthlyBudgetAmount = normalizeMonthlyBudgetAmount(request.monthlyBudgetAmount());
 		String regretFrequencyChoice = normalizeRegretFrequencyChoice(request.regretFrequencyChoice());
 
 		return new NormalizedOnboardingRequest(
-			nickname,
 			mascotName,
 			timezone,
 			ZoneId.of(timezone),
@@ -271,7 +271,6 @@ public class OnboardingService {
 	}
 
 	private record NormalizedOnboardingRequest(
-		String nickname,
 		String mascotName,
 		String timezone,
 		ZoneId zoneId,

--- a/src/main/java/com/sagongsa/backend/social/CommentResponse.java
+++ b/src/main/java/com/sagongsa/backend/social/CommentResponse.java
@@ -8,13 +8,15 @@ record CommentResponse(
 	UUID id,
 	String body,
 	boolean mine,
+	String authorNickname,
 	Instant createdAt
 ) {
-	static CommentResponse of(PostComment comment, UUID currentUserId) {
+	static CommentResponse of(PostComment comment, UUID currentUserId, String authorNickname) {
 		return new CommentResponse(
 			comment.getId(),
 			comment.getBody(),
 			comment.getUser().getId().equals(currentUserId),
+			authorNickname,
 			comment.getCreatedAt()
 		);
 	}

--- a/src/main/java/com/sagongsa/backend/social/CommentService.java
+++ b/src/main/java/com/sagongsa/backend/social/CommentService.java
@@ -5,7 +5,13 @@ import com.sagongsa.backend.domain.auth.UserAccountRepository;
 import com.sagongsa.backend.domain.social.FeedPost;
 import com.sagongsa.backend.domain.social.PostComment;
 import com.sagongsa.backend.domain.social.PostCommentRepository;
+import com.sagongsa.backend.domain.user.UserProfile;
+import com.sagongsa.backend.domain.user.UserProfileRepository;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -19,13 +25,16 @@ class CommentService {
 	private final PostCommentRepository postCommentRepository;
 	private final SocialPostService socialPostService;
 	private final UserAccountRepository userAccountRepository;
+	private final UserProfileRepository userProfileRepository;
 
 	CommentService(PostCommentRepository postCommentRepository,
 		SocialPostService socialPostService,
-		UserAccountRepository userAccountRepository) {
+		UserAccountRepository userAccountRepository,
+		UserProfileRepository userProfileRepository) {
 		this.postCommentRepository = postCommentRepository;
 		this.socialPostService = socialPostService;
 		this.userAccountRepository = userAccountRepository;
+		this.userProfileRepository = userProfileRepository;
 	}
 
 	@Transactional
@@ -36,7 +45,8 @@ class CommentService {
 
 		PostComment comment = new PostComment(post, user, request.body());
 		postCommentRepository.save(comment);
-		return CommentResponse.of(comment, userId);
+		String authorNickname = resolveCommentNickname(postId, userId);
+		return CommentResponse.of(comment, userId, authorNickname);
 	}
 
 	CommentListResponse getComments(UUID userId, UUID postId, int page, int size) {
@@ -44,11 +54,32 @@ class CommentService {
 		Page<PostComment> commentPage = postCommentRepository.findVisibleByPostId(
 			postId, PageRequest.of(page - 1, size));
 
-		List<CommentResponse> items = commentPage.getContent().stream()
-			.map(c -> CommentResponse.of(c, userId))
+		List<PostComment> comments = commentPage.getContent();
+		Map<UUID, String> nicknameMap = buildCommentNicknameMap(postId);
+
+		List<CommentResponse> items = comments.stream()
+			.map(c -> CommentResponse.of(c, userId,
+				nicknameMap.getOrDefault(c.getUser().getId(), UserProfile.UNKNOWN_NICKNAME)))
 			.toList();
 
 		return new CommentListResponse(items, commentPage.getTotalElements());
+	}
+
+	private Map<UUID, String> buildCommentNicknameMap(UUID postId) {
+		List<UUID> commenterIds = postCommentRepository.findCommenterIdsByPostIdOrderedByFirstComment(postId);
+		Set<UUID> existingProfileIds = new HashSet<>(userProfileRepository.findExistingProfileUserIds(commenterIds));
+		Map<UUID, String> map = new HashMap<>();
+		for (int i = 0; i < commenterIds.size(); i++) {
+			UUID uid = commenterIds.get(i);
+			map.put(uid, existingProfileIds.contains(uid)
+				? UserProfile.COMMENT_NICKNAME_PREFIX + (i + 1)
+				: UserProfile.UNKNOWN_NICKNAME);
+		}
+		return map;
+	}
+
+	private String resolveCommentNickname(UUID postId, UUID userId) {
+		return buildCommentNicknameMap(postId).getOrDefault(userId, UserProfile.UNKNOWN_NICKNAME);
 	}
 
 	@Transactional

--- a/src/main/java/com/sagongsa/backend/social/PostResponse.java
+++ b/src/main/java/com/sagongsa/backend/social/PostResponse.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 
 public record PostResponse(
 	UUID id,
-	UUID userId,
+	String authorNickname,
 	String title,
 	String body,
 	String imageUrl,
@@ -18,10 +18,10 @@ public record PostResponse(
 	PostVoteType myVote,
 	Instant createdAt
 ) {
-	public static PostResponse of(FeedPost post, long commentCount, PostVoteType myVote) {
+	public static PostResponse of(FeedPost post, String authorNickname, long commentCount, PostVoteType myVote) {
 		return new PostResponse(
 			post.getId(),
-			post.getUser().getId(),
+			authorNickname,
 			post.getTitle(),
 			post.getBody(),
 			post.getImageUrl(),

--- a/src/main/java/com/sagongsa/backend/social/SocialPostService.java
+++ b/src/main/java/com/sagongsa/backend/social/SocialPostService.java
@@ -8,6 +8,8 @@ import com.sagongsa.backend.domain.social.FeedPostRepository;
 import com.sagongsa.backend.domain.social.PostCommentRepository;
 import com.sagongsa.backend.domain.social.PostVote;
 import com.sagongsa.backend.domain.social.PostVoteRepository;
+import com.sagongsa.backend.domain.user.UserProfile;
+import com.sagongsa.backend.domain.user.UserProfileRepository;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -26,15 +28,18 @@ class SocialPostService {
 	private final PostVoteRepository postVoteRepository;
 	private final PostCommentRepository postCommentRepository;
 	private final UserAccountRepository userAccountRepository;
+	private final UserProfileRepository userProfileRepository;
 
 	SocialPostService(FeedPostRepository feedPostRepository,
 		PostVoteRepository postVoteRepository,
 		PostCommentRepository postCommentRepository,
-		UserAccountRepository userAccountRepository) {
+		UserAccountRepository userAccountRepository,
+		UserProfileRepository userProfileRepository) {
 		this.feedPostRepository = feedPostRepository;
 		this.postVoteRepository = postVoteRepository;
 		this.postCommentRepository = postCommentRepository;
 		this.userAccountRepository = userAccountRepository;
+		this.userProfileRepository = userProfileRepository;
 	}
 
 	@Transactional
@@ -42,7 +47,9 @@ class SocialPostService {
 		UserAccount user = findUserOrThrow(userId);
 		FeedPost post = new FeedPost(user, request.title(), request.body(), request.imageUrl(), request.price());
 		feedPostRepository.save(post);
-		return PostResponse.of(post, 0, null);
+		String authorNickname = userProfileRepository.findByUserId(userId).isPresent()
+			? UserProfile.POST_AUTHOR_NICKNAME : UserProfile.UNKNOWN_NICKNAME;
+		return PostResponse.of(post, authorNickname, 0, null);
 	}
 
 	PostListResponse getPosts(UUID userId, Instant cursor, int size) {
@@ -64,7 +71,9 @@ class SocialPostService {
 		FeedPost post = findPostOrThrow(postId);
 		long commentCount = postCommentRepository.countByPostIdAndDeletedAtIsNull(postId);
 		PostVoteType myVote = resolveMyVote(userId, postId);
-		return PostResponse.of(post, commentCount, myVote);
+		String authorNickname = userProfileRepository.findByUserId(post.getUser().getId()).isPresent()
+			? UserProfile.POST_AUTHOR_NICKNAME : UserProfile.UNKNOWN_NICKNAME;
+		return PostResponse.of(post, authorNickname, commentCount, myVote);
 	}
 
 	@Transactional
@@ -104,6 +113,7 @@ class SocialPostService {
 		if (posts.isEmpty()) return Collections.emptyList();
 
 		List<UUID> postIds = posts.stream().map(FeedPost::getId).toList();
+		List<UUID> authorIds = posts.stream().map(p -> p.getUser().getId()).distinct().toList();
 
 		Map<UUID, Long> commentCounts = feedPostRepository.countCommentsByPostIds(postIds).stream()
 			.collect(Collectors.toMap(r -> (UUID) r[0], r -> (Long) r[1]));
@@ -113,12 +123,17 @@ class SocialPostService {
 			: postVoteRepository.findByPostIdsAndUserId(postIds, userId).stream()
 				.collect(Collectors.toMap(v -> v.getPost().getId(), v -> v));
 
+		java.util.Set<UUID> existingProfileIds = new java.util.HashSet<>(
+				userProfileRepository.findExistingProfileUserIds(authorIds));
+
 		return posts.stream()
 			.map(post -> {
 				long commentCount = commentCounts.getOrDefault(post.getId(), 0L);
 				PostVote vote = myVotes.get(post.getId());
 				PostVoteType myVote = (vote != null && vote.isActive()) ? vote.getVoteType() : null;
-				return PostResponse.of(post, commentCount, myVote);
+				String authorNickname = existingProfileIds.contains(post.getUser().getId())
+					? UserProfile.POST_AUTHOR_NICKNAME : UserProfile.UNKNOWN_NICKNAME;
+				return PostResponse.of(post, authorNickname, commentCount, myVote);
 			})
 			.toList();
 	}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,7 @@
+spring:
+  flyway:
+    out-of-order: true
+app:
+  auth:
+    trusted-user-id-header:
+      enabled: true

--- a/src/main/resources/db/migration/V8__add_nickname_seq.sql
+++ b/src/main/resources/db/migration/V8__add_nickname_seq.sql
@@ -1,0 +1,4 @@
+CREATE SEQUENCE user_nickname_seq;
+
+UPDATE user_profiles
+SET nickname = '너굴' || nextval('user_nickname_seq')::text;

--- a/src/main/resources/static/app.html
+++ b/src/main/resources/static/app.html
@@ -261,7 +261,7 @@ async function api(method, path, body) {
 
 // ── 초기화 ────────────────────────────────────────────
 async function init() {
-    const r = await api('GET', '/api/users/me');
+    const r = await api('GET', '/api/v1/users/me');
     if (!r || !r.ok) { location.replace('/login.html'); return; }
     me = r.data;
     document.getElementById('headerNickname').textContent = me.nickname || '사용자';
@@ -288,7 +288,7 @@ function switchTab(name) {
 
 async function loadFeed(reset = true) {
     if (reset) { feedCursor = null; document.getElementById('feedList').innerHTML = ''; }
-    const path = feedCursor ? `/social/posts?cursor=${feedCursor}&size=10` : '/social/posts?size=10';
+    const path = feedCursor ? `/api/v1/social/posts?cursor=${feedCursor}&size=10` : '/api/v1/social/posts?size=10';
     const r = await api('GET', path);
     if (!r || !r.ok) return;
     const { posts, nextCursor, hasMore } = r.data;
@@ -317,7 +317,7 @@ function renderFeedCard(p) {
                 <button class="vote-btn go ${myGo ? 'active' : ''}" onclick="vote('${p.id}','GO')">GO ${p.goCount}</button>
                 <button class="vote-btn stop ${myStop ? 'active' : ''}" onclick="vote('${p.id}','STOP')">STOP ${p.stopCount}</button>
             </div>
-            <div class="feed-meta">댓글 ${p.commentCount}개 · ${fmtDate(p.createdAt)}</div>
+            <div class="feed-meta">${esc(p.authorNickname)} · 댓글 ${p.commentCount}개 · ${fmtDate(p.createdAt)}</div>
         </div>
         <div class="comment-area" id="comments-${p.id}">
             <div id="commentList-${p.id}" style="display:none"></div>
@@ -336,7 +336,7 @@ async function loadMoreFeed() { await loadFeed(false); }
 async function createPost() {
     const title = document.getElementById('postTitle').value.trim();
     if (!title) { alert('제목을 입력해주세요.'); return; }
-    const r = await api('POST', '/social/posts', {
+    const r = await api('POST', '/api/v1/social/posts', {
         title,
         body: document.getElementById('postBody').value.trim() || null,
         price: document.getElementById('postPrice').value ? parseInt(document.getElementById('postPrice').value) : null,
@@ -352,7 +352,7 @@ async function createPost() {
 }
 
 async function vote(postId, type) {
-    const r = await api('POST', `/social/posts/${postId}/votes`, { voteType: type });
+    const r = await api('POST', `/api/v1/social/posts/${postId}/votes`, { voteType: type });
     if (!r || !r.ok) { alert('투표 실패 (로그인 필요)'); return; }
     const { goCount, stopCount, myVote } = r.data;
     const card = document.getElementById(`post-${postId}`);
@@ -374,12 +374,12 @@ async function toggleComments(postId) {
 }
 
 async function loadComments(postId) {
-    const r = await api('GET', `/social/posts/${postId}/comments?page=1&size=20`);
+    const r = await api('GET', `/api/v1/social/posts/${postId}/comments?page=1&size=20`);
     if (!r || !r.ok) return;
     const list = document.getElementById(`commentList-${postId}`);
     list.innerHTML = r.data.comments.map(c => `
         <div class="comment-item">
-            <span>${esc(c.body)}</span>
+            <span><span style="color:#4a90d9;font-size:11px;margin-right:6px">${esc(c.authorNickname)}</span>${esc(c.body)}</span>
             ${c.mine ? `<button onclick="deleteComment('${postId}','${c.id}')" style="background:none;border:none;color:#e74c3c;font-size:11px;cursor:pointer">삭제</button>` : ''}
         </div>
     `).join('') || '<div style="color:#555;font-size:13px;padding:8px 0">댓글 없음</div>';
@@ -388,14 +388,14 @@ async function loadComments(postId) {
 async function submitComment(postId) {
     const input = document.getElementById(`ci-${postId}`);
     if (!input.value.trim()) return;
-    const r = await api('POST', `/social/posts/${postId}/comments`, { body: input.value.trim() });
+    const r = await api('POST', `/api/v1/social/posts/${postId}/comments`, { body: input.value.trim() });
     if (!r || !r.ok) { alert('댓글 작성 실패 (로그인 필요)'); return; }
     input.value = '';
     await loadComments(postId);
 }
 
 async function deleteComment(postId, commentId) {
-    const r = await api('DELETE', `/social/posts/${postId}/comments/${commentId}`);
+    const r = await api('DELETE', `/api/v1/social/posts/${postId}/comments/${commentId}`);
     if (!r) return;
     await loadComments(postId);
 }
@@ -417,19 +417,19 @@ async function createTestItem() {
 }
 
 async function loadDeliberation() {
-    const r = await api('GET', `/api/wishes/${currentItemId}/deliberation`);
+    const r = await api('GET', `/api/v1/deliberations/items/${currentItemId}`);
     if (!r || !r.ok) { alert('숙려 화면 로드 실패: ' + r?.status); return; }
     const d = r.data;
 
-    document.getElementById('dItemTitle').textContent = d.wish.title;
-    document.getElementById('dItemPrice').textContent = fmt(d.wish.price);
-    document.getElementById('dItemCategory').textContent = d.wish.category;
-    document.getElementById('dBudget').textContent = fmt(d.budget.monthlyBudget);
+    document.getElementById('dItemTitle').textContent = d.item.title;
+    document.getElementById('dItemPrice').textContent = fmt(d.item.listedPrice);
+    document.getElementById('dItemCategory').textContent = d.item.category;
+    document.getElementById('dBudget').textContent = fmt(d.budget.monthlyBudgetAmount);
     document.getElementById('dSpent').textContent = fmt(d.budget.spentAmount);
-    document.getElementById('dRemaining').textContent = fmt(d.budget.remainingBudget);
-    document.getElementById('dStatSpent').textContent = fmt(d.monthStats.spentAmount);
-    document.getElementById('dStatIrrational').textContent = d.monthStats.irrationalCount + '회';
-    document.getElementById('dStatOpportunity').textContent = fmt(d.monthStats.opportunityCost);
+    document.getElementById('dRemaining').textContent = fmt(d.budget.monthlyBudgetAmount - d.budget.spentAmount);
+    document.getElementById('dStatSpent').textContent = fmt(d.budget.spentAmount);
+    document.getElementById('dStatIrrational').textContent = fmt(d.similarCategorySpendAmount);
+    document.getElementById('dStatOpportunity').textContent = d.opportunityCostMessage;
 
     dQuestions = d.questions;
     dAnswers = {};
@@ -437,8 +437,8 @@ async function loadDeliberation() {
         <div class="question-card">
             <div class="question-text">${q.text}</div>
             <div class="yn-buttons">
-                <button class="yn-btn y" onclick="selectAnswer(${q.id}, true, this)">Y</button>
-                <button class="yn-btn n" onclick="selectAnswer(${q.id}, false, this)">N</button>
+                <button class="yn-btn y" onclick="selectAnswer('${q.code}', true, this)">Y</button>
+                <button class="yn-btn n" onclick="selectAnswer('${q.code}', false, this)">N</button>
             </div>
         </div>
     `).join('');
@@ -449,7 +449,7 @@ async function loadDeliberation() {
 
 function selectAnswer(qId, val, btn) {
     dAnswers[qId] = val;
-    document.querySelectorAll(`[onclick*="selectAnswer(${qId},"]`).forEach(b => b.classList.remove('sel'));
+    document.querySelectorAll(`[onclick*="selectAnswer('${qId}',"]`).forEach(b => b.classList.remove('sel'));
     btn.classList.add('sel');
     updateWarning();
     updateDecisionBtns();
@@ -473,8 +473,8 @@ function updateDecisionBtns() {
 async function decide(decision) {
     document.getElementById('restrainBtn').disabled = true;
     document.getElementById('buyBtn').disabled = true;
-    const answers = dQuestions.map(q => dAnswers[q.id]);
-    const r = await api('POST', `/api/wishes/${currentItemId}/deliberation`, { answers, decision });
+    const selfCheckAnswers = dQuestions.map(q => ({ questionCode: q.code, answerBoolean: dAnswers[q.code] }));
+    const r = await api('POST', '/api/v1/decisions', { itemId: currentItemId, result: decision, selfCheckAnswers });
     if (!r || !r.ok) {
         alert('오류: ' + JSON.stringify(r?.data));
         document.getElementById('restrainBtn').disabled = false;
@@ -484,11 +484,11 @@ async function decide(decision) {
     const d = r.data;
     document.getElementById('rEmoji').textContent = decision === 'GO' ? '🛍️' : '💪';
     document.getElementById('rTitle').textContent = decision === 'GO' ? '구매했어요' : '참았어요!';
-    document.getElementById('rDesc').textContent = d.warningTriggered ? `⚠️ Yes ${d.yesCount}개 — 충동구매 경고가 있었어요` : `✅ Yes ${d.yesCount}개 — 신중한 선택이었어요`;
-    document.getElementById('rYes').textContent = `${d.yesCount}개`;
-    document.getElementById('rSpent').textContent = fmt(d.monthStats.spentAmount);
-    document.getElementById('rIrrational').textContent = `${d.monthStats.irrationalCount}회`;
-    document.getElementById('rOpportunity').textContent = fmt(d.monthStats.opportunityCost);
+    document.getElementById('rDesc').textContent = d.selfCheckYesCount >= 2 ? `⚠️ Yes ${d.selfCheckYesCount}개 — 충동구매 경고가 있었어요` : `✅ Yes ${d.selfCheckYesCount}개 — 신중한 선택이었어요`;
+    document.getElementById('rYes').textContent = `${d.selfCheckYesCount}개`;
+    document.getElementById('rSpent').textContent = fmt(d.budgetAfterAmount);
+    document.getElementById('rIrrational').textContent = d.rationalityResult || '-';
+    document.getElementById('rOpportunity').textContent = d.resultMessage || '-';
     document.getElementById('stepDeliberation').style.display = 'none';
     document.getElementById('stepResult').style.display = 'block';
 }
@@ -506,7 +506,7 @@ function resetDeliberation() {
 // ══ 마이페이지 탭 ══════════════════════════════════════
 
 async function loadMyProfile() {
-    const r = await api('GET', '/api/users/me');
+    const r = await api('GET', '/api/v1/users/me');
     if (!r || !r.ok) return;
     me = r.data;
     document.getElementById('headerNickname').textContent = me.nickname || '사용자';
@@ -522,7 +522,7 @@ async function updateProfile() {
     const nickname = document.getElementById('mpNickname').value.trim();
     const raccoonName = document.getElementById('mpMascot').value.trim();
     if (!nickname && !raccoonName) { alert('닉네임 또는 마스코트 이름을 입력해주세요.'); return; }
-    const r = await api('PATCH', '/api/users/me/profile', { nickname: nickname || null, raccoonName: raccoonName || null });
+    const r = await api('PATCH', '/api/v1/users/me/profile', { nickname: nickname || null, raccoonName: raccoonName || null });
     if (!r) return;
     showMpResult(r);
     if (r.ok) await loadMyProfile();
@@ -531,13 +531,13 @@ async function updateProfile() {
 async function updateBudget() {
     const budget = parseInt(document.getElementById('mpBudget').value);
     if (!budget || budget < 0) { alert('유효한 예산을 입력해주세요.'); return; }
-    const r = await api('PATCH', '/api/users/me/budget', { monthlyBudget: budget });
+    const r = await api('PATCH', '/api/v1/users/me/budget', { monthlyBudget: budget });
     if (!r) return;
     showMpResult(r);
 }
 
 async function loadStats() {
-    const r = await api('GET', '/api/users/me/stats');
+    const r = await api('GET', '/api/v1/users/me/stats');
     if (!r || !r.ok) { showMpResult(r); return; }
     const d = r.data;
     document.getElementById('statsResult').innerHTML = `
@@ -552,7 +552,7 @@ async function loadStats() {
 
 async function deleteAccount() {
     if (!confirm('정말 탈퇴하시겠습니까? 모든 데이터가 삭제됩니다.')) return;
-    const r = await api('DELETE', '/api/users/me');
+    const r = await api('DELETE', '/api/v1/users/me');
     if (!r) return;
     if (r.status === 204) { alert('탈퇴 완료'); location.replace('/login.html'); }
     else showMpResult(r);

--- a/src/main/resources/static/deliberation.html
+++ b/src/main/resources/static/deliberation.html
@@ -168,8 +168,8 @@
 <!-- 결정 버튼 (하단 고정) -->
 <div class="decision-area" id="decisionArea">
     <div class="decision-buttons">
-        <button class="decision-btn restrain" id="restrainBtn" onclick="decide('RESTRAINED')" disabled>참을게요</button>
-        <button class="decision-btn buy" id="buyBtn" onclick="decide('BOUGHT')" disabled>살게요</button>
+        <button class="decision-btn restrain" id="restrainBtn" onclick="decide('STOP')" disabled>참을게요</button>
+        <button class="decision-btn buy" id="buyBtn" onclick="decide('GO')" disabled>살게요</button>
     </div>
 </div>
 
@@ -290,8 +290,8 @@
             <div class="question-card">
                 <div class="question-text">${q.text}</div>
                 <div class="yn-buttons">
-                    <button class="yn-btn yes" data-q="${q.id}" data-v="true" onclick="selectAnswer(${q.id}, true, this)">Y</button>
-                    <button class="yn-btn no"  data-q="${q.id}" data-v="false" onclick="selectAnswer(${q.id}, false, this)">N</button>
+                    <button class="yn-btn yes" data-q="${q.code}" data-v="true" onclick="selectAnswer('${q.code}', true, this)">Y</button>
+                    <button class="yn-btn no"  data-q="${q.code}" data-v="false" onclick="selectAnswer('${q.code}', false, this)">N</button>
                 </div>
             </div>
         `).join('');
@@ -345,13 +345,13 @@
         document.getElementById('restrainBtn').disabled = true;
         document.getElementById('buyBtn').disabled = true;
 
-        const answersArr = questions.map(q => answers[q.id]);
+        const selfCheckAnswers = questions.map(q => ({ questionCode: q.code, answerBoolean: answers[q.code] }));
 
         try {
-            const res = await fetch(`/api/wishes/${wishId}/deliberation`, {
+            const res = await fetch('/api/v1/decisions', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ answers: answersArr, decision })
+                body: JSON.stringify({ itemId: wishId, result: decision, selfCheckAnswers })
             });
 
             const text = await res.text();
@@ -381,7 +381,7 @@
 
     // ─── 결과 화면 ────────────────────────────────────────
     function showResult(data) {
-        const isBought = data.decision === 'BOUGHT';
+        const isBought = data.result === 'GO';
         document.getElementById('resultEmoji').textContent = isBought ? '🛍️' : '💪';
         document.getElementById('resultTitle').textContent = isBought ? '구매했어요' : '참았어요!';
         document.getElementById('resultDesc').textContent = data.warningTriggered

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -5,11 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Wigul</title>
     <script>
-        // localhost:8080 진입 시 로그인 여부 체크 후 라우팅
-        fetch('/api/v1/users/me').then(res => {
-            if (res.ok) location.replace('/app.html');
-            else location.replace('/login.html');
-        }).catch(() => location.replace('/login.html'));
+        location.replace('/app.html');
     </script>
 </head>
 <body></body>

--- a/src/main/resources/static/test-nickname.html
+++ b/src/main/resources/static/test-nickname.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>닉네임 시스템 테스트</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; background: #111; color: #eee; padding: 24px; }
+    h1 { font-size: 20px; font-weight: 700; margin-bottom: 4px; }
+    .subtitle { font-size: 13px; color: #666; margin-bottom: 24px; }
+    h2 { font-size: 14px; font-weight: 600; color: #888; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 12px; }
+    .section { background: #1a1a1a; border-radius: 12px; padding: 20px; margin-bottom: 16px; }
+    .users { display: flex; gap: 12px; flex-wrap: wrap; }
+    .user-card { background: #222; border-radius: 10px; padding: 14px 16px; min-width: 180px; border: 2px solid transparent; cursor: pointer; transition: border-color 0.15s; }
+    .user-card.selected { border-color: #4a90d9; }
+    .user-card .label { font-size: 11px; color: #666; margin-bottom: 4px; }
+    .user-card .nickname { font-size: 18px; font-weight: 700; color: #4a90d9; margin-bottom: 4px; }
+    .user-card .uid { font-size: 10px; color: #555; font-family: monospace; word-break: break-all; }
+    .user-card .withdrawn { color: #e74c3c; font-size: 11px; margin-top: 4px; }
+    .btn { padding: 9px 16px; border-radius: 8px; border: none; font-size: 13px; font-weight: 600; cursor: pointer; transition: opacity 0.15s; }
+    .btn:active { opacity: 0.75; }
+    .btn:disabled { opacity: 0.4; cursor: not-allowed; }
+    .btn-primary { background: #4a90d9; color: #fff; }
+    .btn-success { background: #27ae60; color: #fff; }
+    .btn-danger { background: #e74c3c; color: #fff; }
+    .btn-outline { background: transparent; border: 1px solid #444; color: #aaa; }
+    .row { display: flex; gap: 8px; align-items: center; margin-bottom: 10px; }
+    .row label { font-size: 13px; color: #888; width: 80px; flex-shrink: 0; }
+    .row input { flex: 1; padding: 8px 10px; border-radius: 8px; border: 1px solid #333; background: #222; color: #fff; font-size: 13px; }
+    .log { background: #0a0a0a; border-radius: 8px; padding: 12px; font-size: 12px; font-family: monospace; color: #0f0; min-height: 40px; max-height: 80px; overflow-y: auto; white-space: pre-wrap; word-break: break-all; }
+
+    /* 피드 */
+    .post-card { background: #222; border-radius: 10px; padding: 16px; margin-bottom: 10px; }
+    .post-author { font-size: 13px; font-weight: 700; color: #4a90d9; margin-bottom: 4px; }
+    .post-title { font-size: 16px; font-weight: 600; margin-bottom: 8px; }
+    .post-actions { display: flex; gap: 8px; align-items: center; }
+    .comments-area { margin-top: 12px; border-top: 1px solid #333; padding-top: 12px; display: none; }
+    .comment-row { display: flex; align-items: baseline; gap: 8px; padding: 6px 0; border-bottom: 1px solid #1a1a1a; }
+    .comment-author { font-size: 12px; font-weight: 700; color: #4a90d9; flex-shrink: 0; }
+    .comment-body { font-size: 13px; color: #ccc; }
+    .add-comment { display: flex; gap: 6px; margin-top: 8px; }
+    .add-comment input { flex: 1; padding: 7px 10px; border-radius: 8px; border: 1px solid #333; background: #1a1a1a; color: #fff; font-size: 13px; }
+    .empty { color: #555; font-size: 13px; text-align: center; padding: 20px; }
+    .badge { display: inline-block; padding: 2px 8px; border-radius: 20px; font-size: 11px; font-weight: 700; }
+    .badge-blue { background: rgba(74,144,217,.2); color: #4a90d9; }
+    .badge-red { background: rgba(231,76,60,.2); color: #e74c3c; }
+  </style>
+</head>
+<body>
+
+<h1>닉네임 시스템 테스트</h1>
+<p class="subtitle">게시글 작성자 → 너굴이 고정 | 댓글 작성자 → 게시글별 너굴1, 너굴2... | 탈퇴 → (알 수 없음)</p>
+
+<!-- ① 유저 준비 -->
+<div class="section">
+  <h2>① 테스트 유저 준비</h2>
+  <div class="users" id="userList">
+    <div class="empty" style="width:100%">유저를 생성해주세요.</div>
+  </div>
+  <div style="margin-top:12px">
+    <button class="btn btn-primary" onclick="createUser()">+ 유저 생성</button>
+  </div>
+</div>
+
+<!-- ② 게시글 작성 -->
+<div class="section">
+  <h2>② 게시글 작성</h2>
+  <p style="font-size:12px;color:#666;margin-bottom:10px">위에서 유저를 선택한 뒤 작성합니다. 게시글 작성자는 항상 <strong style="color:#4a90d9">너굴이</strong>로 표시됩니다.</p>
+  <div class="row">
+    <label>제목</label>
+    <input id="postTitle" value="닉네임 테스트 게시글">
+  </div>
+  <button class="btn btn-success" onclick="createPost()">게시글 작성</button>
+  <div id="postLog" class="log" style="margin-top:8px"></div>
+</div>
+
+<!-- ③ 피드 + 댓글 -->
+<div class="section">
+  <h2>③ 피드 & 댓글 확인</h2>
+  <div style="display:flex;gap:8px;margin-bottom:12px">
+    <button class="btn btn-outline" onclick="loadFeed()">피드 새로고침</button>
+  </div>
+  <div id="feedArea"><div class="empty">게시글을 작성하고 피드를 새로고침하세요.</div></div>
+</div>
+
+<!-- ④ 탈퇴 시뮬레이션 -->
+<div class="section">
+  <h2>④ 탈퇴 시뮬레이션</h2>
+  <p style="font-size:12px;color:#666;margin-bottom:10px">
+    선택한 유저의 프로필만 삭제합니다. 해당 유저가 작성한 게시글·댓글의 닉네임이 <strong style="color:#e74c3c">(알 수 없음)</strong>으로 바뀝니다.
+  </p>
+  <button class="btn btn-danger" onclick="simulateWithdrawal()">선택 유저 프로필 삭제</button>
+  <div id="withdrawLog" class="log" style="margin-top:8px"></div>
+</div>
+
+<script>
+// ── 상태 ──────────────────────────────────────────────
+const users = [];   // [{userId, nickname, withdrawn}]
+let selectedIdx = null;
+let lastPostId = null;
+
+// ── 헬퍼 ──────────────────────────────────────────────
+function uid(userId) {
+  return userId ? userId.slice(0, 8) + '...' : '-';
+}
+function esc(s) {
+  if (!s) return '';
+  const d = document.createElement('div'); d.textContent = s; return d.innerHTML;
+}
+async function api(method, path, body, asUserId) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (asUserId) headers['X-User-Id'] = asUserId;
+  const opts = { method, headers };
+  if (body) opts.body = JSON.stringify(body);
+  const res = await fetch(path, opts);
+  const text = await res.text();
+  let data;
+  try { data = JSON.parse(text); } catch { data = text; }
+  return { ok: res.ok, status: res.status, data };
+}
+function log(elId, msg) {
+  const el = document.getElementById(elId);
+  el.textContent = msg;
+}
+
+// ── ① 유저 생성 ───────────────────────────────────────
+async function createUser() {
+  const r = await api('POST', '/api/dev/users/test');
+  if (!r.ok) { alert('유저 생성 실패: ' + JSON.stringify(r.data)); return; }
+  users.push({ userId: r.data.userId, nickname: r.data.nickname, withdrawn: false });
+  selectedIdx = users.length - 1;
+  renderUsers();
+}
+
+function selectUser(idx) {
+  selectedIdx = idx;
+  renderUsers();
+}
+
+function renderUsers() {
+  const el = document.getElementById('userList');
+  if (!users.length) {
+    el.innerHTML = '<div class="empty" style="width:100%">유저를 생성해주세요.</div>';
+    return;
+  }
+  el.innerHTML = users.map((u, i) => `
+    <div class="user-card ${i === selectedIdx ? 'selected' : ''}" onclick="selectUser(${i})">
+      <div class="label">유저 ${i + 1} ${i === selectedIdx ? '✓ 선택됨' : ''}</div>
+      <div class="nickname">${esc(u.nickname)}</div>
+      <div class="uid">${uid(u.userId)}</div>
+      ${u.withdrawn ? '<div class="withdrawn">⚠ 프로필 삭제됨</div>' : ''}
+    </div>
+  `).join('');
+}
+
+// ── ② 게시글 작성 ─────────────────────────────────────
+async function createPost() {
+  if (selectedIdx === null) { alert('유저를 먼저 선택하세요.'); return; }
+  const user = users[selectedIdx];
+  const title = document.getElementById('postTitle').value.trim() || '닉네임 테스트 게시글';
+
+  const r = await api('POST', '/api/v1/social/posts', { title }, user.userId);
+  if (!r.ok) { log('postLog', '실패: ' + JSON.stringify(r.data)); return; }
+
+  lastPostId = r.data.id;
+  log('postLog', `작성 완료 ✓\npostId: ${r.data.id}\nauthorNickname: ${r.data.authorNickname}`);
+  await loadFeed();
+}
+
+// ── ③ 피드 + 댓글 ─────────────────────────────────────
+async function loadFeed() {
+  const viewerUserId = users.length ? users[0].userId : null;
+  const r = await api('GET', '/api/v1/social/posts', null, viewerUserId);
+  if (!r.ok) { document.getElementById('feedArea').innerHTML = '<div class="empty">피드 로드 실패</div>'; return; }
+
+  const posts = r.data.posts || [];
+  if (!posts.length) {
+    document.getElementById('feedArea').innerHTML = '<div class="empty">게시글이 없습니다.</div>';
+    return;
+  }
+
+  document.getElementById('feedArea').innerHTML = posts.map(p => `
+    <div class="post-card">
+      <div class="post-author">
+        ${p.authorNickname === '너굴이'
+          ? `<span class="badge badge-blue">너굴이</span>`
+          : `<span class="badge badge-red">${esc(p.authorNickname)}</span>`}
+      </div>
+      <div class="post-title">${esc(p.title)}</div>
+      <div class="post-actions">
+        <button class="btn btn-outline" style="font-size:12px;padding:6px 12px" onclick="toggleComments('${p.id}', this)">댓글 보기</button>
+      </div>
+      <div class="comments-area" id="ca-${p.id}">
+        <div id="cl-${p.id}"></div>
+        <div class="add-comment">
+          <input id="ci-${p.id}" placeholder="댓글 입력...">
+          <button class="btn btn-primary" style="font-size:12px;padding:6px 12px" onclick="addComment('${p.id}')">등록</button>
+        </div>
+      </div>
+    </div>
+  `).join('');
+}
+
+async function toggleComments(postId, btn) {
+  const area = document.getElementById(`ca-${postId}`);
+  if (area.style.display === 'block') {
+    area.style.display = 'none';
+    btn.textContent = '댓글 보기';
+  } else {
+    area.style.display = 'block';
+    btn.textContent = '댓글 닫기';
+    await loadComments(postId);
+  }
+}
+
+async function loadComments(postId) {
+  const viewerUserId = users.length ? users[0].userId : null;
+  const r = await api('GET', `/api/v1/social/posts/${postId}/comments`, null, viewerUserId);
+  const list = document.getElementById(`cl-${postId}`);
+  if (!r.ok || !r.data.comments.length) {
+    list.innerHTML = '<div style="color:#555;font-size:12px;padding:6px 0">댓글 없음</div>';
+    return;
+  }
+  list.innerHTML = r.data.comments.map(c => `
+    <div class="comment-row">
+      <span class="comment-author ${c.authorNickname === '(알 수 없음)' ? 'badge-red' : 'badge-blue'}" style="padding:1px 6px;border-radius:4px;background:${c.authorNickname === '(알 수 없음)' ? 'rgba(231,76,60,.2)' : 'rgba(74,144,217,.2)'}">
+        ${esc(c.authorNickname)}
+      </span>
+      <span class="comment-body">${esc(c.body)}</span>
+    </div>
+  `).join('');
+}
+
+async function addComment(postId) {
+  if (selectedIdx === null) { alert('유저를 선택하세요.'); return; }
+  const user = users[selectedIdx];
+  const input = document.getElementById(`ci-${postId}`);
+  const body = input.value.trim();
+  if (!body) return;
+
+  const r = await api('POST', `/api/v1/social/posts/${postId}/comments`, { body }, user.userId);
+  if (!r.ok) { alert('댓글 실패: ' + JSON.stringify(r.data)); return; }
+  input.value = '';
+  await loadComments(postId);
+}
+
+// ── ④ 탈퇴 시뮬레이션 ────────────────────────────────
+async function simulateWithdrawal() {
+  if (selectedIdx === null) { alert('유저를 선택하세요.'); return; }
+  const user = users[selectedIdx];
+  if (!confirm(`유저 "${user.nickname}"의 프로필을 삭제합니다.\n피드/댓글에서 이 유저의 닉네임이 "(알 수 없음)"으로 바뀝니다.`)) return;
+
+  const r = await api('DELETE', `/api/dev/profiles/${user.userId}`);
+  if (!r.ok && r.status !== 204) {
+    log('withdrawLog', '실패: ' + JSON.stringify(r.data));
+    return;
+  }
+  users[selectedIdx].withdrawn = true;
+  renderUsers();
+  log('withdrawLog', `유저 "${user.nickname}" 프로필 삭제 완료 ✓\n피드를 새로고침하면 "(알 수 없음)"으로 표시됩니다.`);
+  await loadFeed();
+}
+</script>
+</body>
+</html>

--- a/src/test/java/com/sagongsa/backend/onboarding/OnboardingCompleteIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/onboarding/OnboardingCompleteIntegrationTest.java
@@ -49,7 +49,7 @@ class OnboardingCompleteIntegrationTest extends PostgreSqlContainerTest {
 		assertThat(countRows("survey_response_sets", userId)).isEqualTo(1);
 		assertThat(countRows("mascot_profiles", userId)).isEqualTo(1);
 
-		assertThat(queryString("select nickname from user_profiles where user_id = ?", userId)).isEqualTo("planner");
+		assertThat(queryString("select nickname from user_profiles where user_id = ?", userId)).matches("너굴\\d+");
 		assertThat(queryString("select mascot_name from user_profiles where user_id = ?", userId)).isEqualTo("wigul");
 		assertThat(queryString("select timezone from user_profiles where user_id = ?", userId)).isEqualTo("Asia/Seoul");
 		assertThat(queryString("select year_month from budget_cycles where user_id = ?", userId)).isEqualTo(expectedYearMonth);
@@ -60,6 +60,31 @@ class OnboardingCompleteIntegrationTest extends PostgreSqlContainerTest {
 		assertThat(queryString("select mascot_state from mascot_profiles where user_id = ?", userId)).isEqualTo("DEFAULT");
 		assertThat(queryOnboardingSurveyAnswer(userId)).isEqualTo("FOUR_OR_MORE");
 		assertThat(queryOnboardingSurveyAnswerNumber(userId)).isEqualTo(3);
+	}
+
+	@Test
+	void autoGeneratesUniqueNeoGulNicknames() throws Exception {
+		UUID userId1 = insertUser("NOT_STARTED");
+		UUID userId2 = insertUser("NOT_STARTED");
+
+		mockMvc.perform(post("/api/v1/onboarding/complete")
+				.header("X-User-Id", userId1.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(onboardingRequestBody()))
+			.andExpect(status().isOk());
+
+		mockMvc.perform(post("/api/v1/onboarding/complete")
+				.header("X-User-Id", userId2.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(onboardingRequestBody()))
+			.andExpect(status().isOk());
+
+		String nickname1 = queryString("select nickname from user_profiles where user_id = ?", userId1);
+		String nickname2 = queryString("select nickname from user_profiles where user_id = ?", userId2);
+
+		assertThat(nickname1).matches("너굴\\d+");
+		assertThat(nickname2).matches("너굴\\d+");
+		assertThat(nickname1).isNotEqualTo(nickname2);
 	}
 
 	@Test
@@ -138,7 +163,6 @@ class OnboardingCompleteIntegrationTest extends PostgreSqlContainerTest {
 	private String onboardingRequestBody() {
 		return """
 			{
-				"nickname": "planner",
 				"mascotName": "wigul",
 				"timezone": "Asia/Seoul",
 				"monthlyBudgetAmount": 300000,

--- a/src/test/java/com/sagongsa/backend/social/SocialFeedNicknameIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/social/SocialFeedNicknameIntegrationTest.java
@@ -1,0 +1,202 @@
+package com.sagongsa.backend.social;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SocialFeedNicknameIntegrationTest extends PostgreSqlContainerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.execute("truncate table users cascade");
+	}
+
+	@Test
+	void postResponseContainsAuthorNickname() throws Exception {
+		UUID userId = insertUserWithProfile();
+
+		mockMvc.perform(post("/api/v1/social/posts")
+				.header("X-User-Id", userId.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"title":"테스트 제목","body":"내용"}
+					"""))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.authorNickname").value("너굴이"));
+	}
+
+	@Test
+	void feedListReturnsAuthorNickname() throws Exception {
+		UUID userId = insertUserWithProfile();
+		insertPost(userId, "게시글 제목", "본문");
+
+		mockMvc.perform(get("/api/v1/social/posts")
+				.header("X-User-Id", userId.toString()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.posts[0].authorNickname").value("너굴이"));
+	}
+
+	@Test
+	void postAuthorShowsUnknownWhenProfileDeleted() throws Exception {
+		UUID userId = insertUserWithProfile();
+		insertPost(userId, "탈퇴 회원 게시글", "내용");
+
+		// 프로필 삭제 (탈퇴 처리 시뮬레이션)
+		jdbcTemplate.update("DELETE FROM user_profiles WHERE user_id = ?", userId);
+
+		mockMvc.perform(get("/api/v1/social/posts")
+				.header("X-User-Id", userId.toString()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.posts[0].authorNickname").value("(알 수 없음)"));
+	}
+
+	@Test
+	void firstCommentNicknameIsNeogul1() throws Exception {
+		UUID userId = insertUserWithProfile();
+		UUID postId = insertPost(userId, "댓글 테스트 게시글", "본문");
+
+		mockMvc.perform(post("/api/v1/social/posts/{postId}/comments", postId)
+				.header("X-User-Id", userId.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"body":"첫 댓글"}
+					"""))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.authorNickname").value("너굴1"));
+	}
+
+	@Test
+	void secondUniqueCommenterGetsNeogul2() throws Exception {
+		UUID postAuthorId = insertUserWithProfile();
+		UUID commenter1Id = insertUserWithProfile();
+		UUID commenter2Id = insertUserWithProfile();
+		UUID postId = insertPost(postAuthorId, "댓글 순서 테스트", "본문");
+
+		mockMvc.perform(post("/api/v1/social/posts/{postId}/comments", postId)
+				.header("X-User-Id", commenter1Id.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"body":"첫 댓글"}
+					"""))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.authorNickname").value("너굴1"));
+
+		mockMvc.perform(post("/api/v1/social/posts/{postId}/comments", postId)
+				.header("X-User-Id", commenter2Id.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"body":"두 번째 댓글"}
+					"""))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.authorNickname").value("너굴2"));
+
+		// 기존 댓글러가 다시 댓글 달아도 번호 동일
+		mockMvc.perform(post("/api/v1/social/posts/{postId}/comments", postId)
+				.header("X-User-Id", commenter1Id.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"body":"추가 댓글"}
+					"""))
+			.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.authorNickname").value("너굴1"));
+	}
+
+	@Test
+	void nicknameTestPageFlowUsesDevUsersAndTrustedHeader() throws Exception {
+		UUID postAuthorId = createDevUser();
+		UUID commenter1Id = createDevUser();
+		UUID commenter2Id = createDevUser();
+
+		String postBody = mockMvc.perform(post("/api/v1/social/posts")
+				.header("X-User-Id", postAuthorId.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"title":"개발 화면 플로우 게시글"}
+					"""))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.authorNickname").value("너굴이"))
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+		UUID postId = UUID.fromString(objectMapper.readTree(postBody).get("id").asText());
+
+		mockMvc.perform(post("/api/v1/social/posts/{postId}/comments", postId)
+				.header("X-User-Id", commenter1Id.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"body":"첫 댓글"}
+					"""))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.authorNickname").value("너굴1"));
+
+		mockMvc.perform(post("/api/v1/social/posts/{postId}/comments", postId)
+				.header("X-User-Id", commenter2Id.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"body":"두 번째 댓글"}
+					"""))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.authorNickname").value("너굴2"));
+	}
+
+	private UUID insertUserWithProfile() {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"INSERT INTO users (id, status, onboarding_status, created_at, updated_at) VALUES (?, 'ACTIVE', 'COMPLETED', ?, ?)",
+			userId, now, now
+		);
+		jdbcTemplate.update(
+			"INSERT INTO user_profiles (user_id, nickname, mascot_name, timezone, created_at, updated_at) VALUES (?, '너굴이', '너구리', 'Asia/Seoul', ?, ?)",
+			userId, now, now
+		);
+		return userId;
+	}
+
+	private UUID createDevUser() throws Exception {
+		String body = mockMvc.perform(post("/api/dev/users/test"))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+		JsonNode json = objectMapper.readTree(body);
+		return UUID.fromString(json.get("userId").asText());
+	}
+
+	private UUID insertPost(UUID userId, String title, String body) {
+		UUID postId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"INSERT INTO feed_posts (id, user_id, title, body, go_count, stop_count, created_at, updated_at) VALUES (?, ?, ?, ?, 0, 0, ?, ?)",
+			postId, userId, title, body, now, now
+		);
+		return postId;
+	}
+}

--- a/src/test/java/com/sagongsa/backend/social/SocialFeedNicknameIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/social/SocialFeedNicknameIntegrationTest.java
@@ -129,6 +129,48 @@ class SocialFeedNicknameIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void commentNicknameStableAfterFirstCommenterDeletes() throws Exception {
+		UUID postAuthorId = insertUserWithProfile();
+		UUID commenter1Id = insertUserWithProfile();
+		UUID commenter2Id = insertUserWithProfile();
+		UUID postId = insertPost(postAuthorId, "닉네임 안정성 테스트", "본문");
+
+		// commenter1이 첫 댓글 → 너굴1
+		String c1Body = mockMvc.perform(post("/api/v1/social/posts/{postId}/comments", postId)
+				.header("X-User-Id", commenter1Id.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"body":"첫 댓글"}
+					"""))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.authorNickname").value("너굴1"))
+			.andReturn().getResponse().getContentAsString();
+
+		// commenter2가 두 번째 댓글 → 너굴2
+		mockMvc.perform(post("/api/v1/social/posts/{postId}/comments", postId)
+				.header("X-User-Id", commenter2Id.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"body":"두 번째 댓글"}
+					"""))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.authorNickname").value("너굴2"));
+
+		// commenter1의 댓글 삭제
+		UUID comment1Id = UUID.fromString(objectMapper.readTree(c1Body).get("id").asText());
+		mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+				.delete("/api/v1/social/posts/{postId}/comments/{commentId}", postId, comment1Id)
+				.header("X-User-Id", commenter1Id.toString()))
+			.andExpect(status().isNoContent());
+
+		// 댓글 목록 조회 시 commenter2는 여전히 너굴2 (번호가 당겨지지 않아야 함)
+		mockMvc.perform(get("/api/v1/social/posts/{postId}/comments", postId)
+				.header("X-User-Id", commenter2Id.toString()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.comments[0].authorNickname").value("너굴2"));
+	}
+
+	@Test
 	void nicknameTestPageFlowUsesDevUsersAndTrustedHeader() throws Exception {
 		UUID postAuthorId = createDevUser();
 		UUID commenter1Id = createDevUser();


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-34`
- Jira: NF-34
- GitHub: Related #50 

> PR 제목: `NF-34 소셜 피드 닉네임 익명 표시 정책 적용`
> 브랜치: `feat/6-nickname`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #50의 Final 단계
- 선행 PR: -
- 후속 PR: -

### 이 PR에서 변경한 것
- 게시글 작성자 닉네임을 항상 `너굴이`로 응답하도록 변경
- 댓글 작성자 닉네임을 게시글별 댓글 작성 순서 기준 `너굴1`, `너굴2`, ... 로 응답하도록 변경
- 동일 댓글 작성자가 같은 게시글에 다시 댓글을 달면 기존 번호를 유지하도록 처리
- 프로필이 삭제된 유저는 `(알 수 없음)`으로 표시
- 마이페이지 게시글/투표 목록에도 게시글 작성자 닉네임 표시 정책 반영
- 닉네임 자동 생성을 위한 `user_nickname_seq` 마이그레이션 추가
- 개발용 닉네임 테스트 페이지 및 테스트 유저 생성 API 추가
- non-prod 환경에서 개발용 테스트 페이지가 `X-User-Id` 기반으로 API를 호출할 수 있도록 설정 보완

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
- AC1: 게시글 작성자는 `너굴이`로 표시
- AC2: 댓글 작성자는 게시글별 작성 순서대로 `너굴1`, `너굴2`, `너굴3` 형식으로 표시
- AC3: 같은 댓글 작성자가 같은 게시글에 여러 번 댓글을 달아도 기존 번호 유지
- AC4: 프로필이 삭제된 유저는 `(알 수 없음)`으로 표시
- AC5: 개발용 테스트 화면에서 게시글/댓글 닉네임 플로우 확인 가능

### Not covered (후속 작업)
- 없음

---

## 🧪 테스트 결과 (필수)
### 로컬
```bash
./gradlew test --tests 'com.sagongsa.backend.social.SocialFeedNicknameIntegrationTest'
