### PR TITLE
[feat] 마이페이지 월별 소비기록 조회 및 결정 수정

### DIFF
--- a/src/main/java/com/sagongsa/backend/config/SecurityConfig.java
+++ b/src/main/java/com/sagongsa/backend/config/SecurityConfig.java
@@ -67,7 +67,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> {
 				auth
 					.requestMatchers("/", "/index.html", "/login.html", "/app.html",
-						"/deliberation.html", "/test-mypage.html", "/test-nickname.html", "/favicon.ico", "/error").permitAll()
+						"/deliberation.html", "/test-mypage.html", "/test-nickname.html", "/test-consumption.html", "/favicon.ico", "/error").permitAll()
 					.requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
 					.requestMatchers("/api/auth/token/refresh").permitAll()
 					.requestMatchers("/api/auth/me").authenticated();

--- a/src/main/java/com/sagongsa/backend/dev/DevController.java
+++ b/src/main/java/com/sagongsa/backend/dev/DevController.java
@@ -10,6 +10,8 @@ import com.sagongsa.backend.domain.item.SavedItemRepository;
 import jakarta.persistence.EntityManager;
 import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
@@ -21,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -69,6 +72,65 @@ public class DevController {
 	public ResponseEntity<Void> deleteTestProfile(@PathVariable UUID userId) {
 		jdbcTemplate.update("DELETE FROM user_profiles WHERE user_id = ?", userId);
 		return ResponseEntity.noContent().build();
+	}
+
+	record TestDecisionRequest(String title, Integer price, String result) {}
+
+	@PostMapping("/decisions/test")
+	@Transactional
+	public ResponseEntity<Map<String, String>> createTestDecision(
+		@CurrentUserId UUID userId,
+		@RequestBody TestDecisionRequest request) {
+
+		String title = request.title() != null ? request.title() : "테스트 상품";
+		int price = request.price() != null ? request.price() : 0;
+		String result = request.result() != null ? request.result().toUpperCase() : "GO";
+
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		String yearMonth = YearMonth.now(ZoneId.of("Asia/Seoul")).toString();
+
+		// 예산 사이클 없으면 생성
+		UUID budgetCycleId = jdbcTemplate.query(
+			"SELECT id FROM budget_cycles WHERE user_id = ? AND year_month = ?",
+			(rs, i) -> rs.getObject("id", UUID.class),
+			userId, yearMonth
+		).stream().findFirst().orElseGet(() -> {
+			UUID id = UUID.randomUUID();
+			jdbcTemplate.update(
+				"INSERT INTO budget_cycles (id, user_id, year_month, monthly_budget_amount, spent_amount, warning_threshold_rate, created_at, updated_at) VALUES (?, ?, ?, 500000, 0, 80.00, ?, ?)",
+				id, userId, yearMonth, now, now
+			);
+			return id;
+		});
+
+		// 상품 삽입
+		UUID itemId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"INSERT INTO saved_items (id, user_id, input_source, title, listed_price, currency_code, category, category_locked_by_user, status, created_at, updated_at) VALUES (?, ?, 'DIRECT_INPUT', ?, ?, 'KRW', 'DIGITAL', false, ?, ?, ?)",
+			itemId, userId, title, price, result, now, now
+		);
+
+		// 결정 삽입
+		UUID decisionId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"INSERT INTO purchase_decisions (id, user_id, item_id, budget_cycle_id, result, final_price, rationality_result, self_check_yes_count, is_changed, change_count, decided_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, 'RATIONAL', 0, false, 0, ?, ?, ?)",
+			decisionId, userId, itemId, budgetCycleId, result, price, now, now, now
+		);
+
+		// GO면 예산 소비 반영
+		if ("GO".equals(result)) {
+			jdbcTemplate.update(
+				"UPDATE budget_cycles SET spent_amount = spent_amount + ?, updated_at = ? WHERE id = ?",
+				price, now, budgetCycleId
+			);
+		}
+
+		return ResponseEntity.ok(Map.of(
+			"decisionId", decisionId.toString(),
+			"itemId", itemId.toString(),
+			"result", result,
+			"month", yearMonth
+		));
 	}
 
 	@PostMapping("/wishes/test")

--- a/src/main/java/com/sagongsa/backend/mypage/ChangeDecisionRequest.java
+++ b/src/main/java/com/sagongsa/backend/mypage/ChangeDecisionRequest.java
@@ -1,0 +1,3 @@
+package com.sagongsa.backend.mypage;
+
+public record ChangeDecisionRequest(String result) {}

--- a/src/main/java/com/sagongsa/backend/mypage/ConsumptionBadRequestException.java
+++ b/src/main/java/com/sagongsa/backend/mypage/ConsumptionBadRequestException.java
@@ -1,0 +1,7 @@
+package com.sagongsa.backend.mypage;
+
+class ConsumptionBadRequestException extends RuntimeException {
+	ConsumptionBadRequestException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/mypage/ConsumptionController.java
+++ b/src/main/java/com/sagongsa/backend/mypage/ConsumptionController.java
@@ -1,0 +1,38 @@
+package com.sagongsa.backend.mypage;
+
+import com.sagongsa.backend.auth.CurrentUserId;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/my/consumption")
+public class ConsumptionController {
+
+	private final ConsumptionService consumptionService;
+
+	public ConsumptionController(ConsumptionService consumptionService) {
+		this.consumptionService = consumptionService;
+	}
+
+	@GetMapping
+	public ResponseEntity<ConsumptionListResponse> getMonthlyConsumption(
+		@CurrentUserId UUID userId,
+		@RequestParam String month) {
+		return ResponseEntity.ok(consumptionService.getMonthlyConsumption(userId, month));
+	}
+
+	@PatchMapping("/{id}")
+	public ResponseEntity<ConsumptionRecord> changeDecisionResult(
+		@CurrentUserId UUID userId,
+		@PathVariable UUID id,
+		@RequestBody ChangeDecisionRequest request) {
+		return ResponseEntity.ok(consumptionService.changeDecisionResult(userId, id, request.result()));
+	}
+}

--- a/src/main/java/com/sagongsa/backend/mypage/ConsumptionExceptionHandler.java
+++ b/src/main/java/com/sagongsa/backend/mypage/ConsumptionExceptionHandler.java
@@ -1,5 +1,8 @@
 package com.sagongsa.backend.mypage;
 
+import com.sagongsa.backend.decision.DecisionBadRequestException;
+import com.sagongsa.backend.decision.DecisionForbiddenException;
+import com.sagongsa.backend.decision.DecisionNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -10,15 +13,21 @@ class ConsumptionExceptionHandler {
 
 	record ErrorBody(String code, String message) {}
 
-	@ExceptionHandler(ConsumptionNotFoundException.class)
+	@ExceptionHandler({ConsumptionNotFoundException.class, DecisionNotFoundException.class})
 	@ResponseStatus(HttpStatus.NOT_FOUND)
-	ErrorBody handleNotFound(ConsumptionNotFoundException ex) {
+	ErrorBody handleNotFound(RuntimeException ex) {
 		return new ErrorBody("NOT_FOUND", ex.getMessage());
 	}
 
-	@ExceptionHandler(ConsumptionBadRequestException.class)
+	@ExceptionHandler({ConsumptionBadRequestException.class, DecisionBadRequestException.class})
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	ErrorBody handleBadRequest(ConsumptionBadRequestException ex) {
+	ErrorBody handleBadRequest(RuntimeException ex) {
 		return new ErrorBody("BAD_REQUEST", ex.getMessage());
+	}
+
+	@ExceptionHandler(DecisionForbiddenException.class)
+	@ResponseStatus(HttpStatus.FORBIDDEN)
+	ErrorBody handleForbidden(DecisionForbiddenException ex) {
+		return new ErrorBody("FORBIDDEN", ex.getMessage());
 	}
 }

--- a/src/main/java/com/sagongsa/backend/mypage/ConsumptionExceptionHandler.java
+++ b/src/main/java/com/sagongsa/backend/mypage/ConsumptionExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.sagongsa.backend.mypage;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(assignableTypes = ConsumptionController.class)
+class ConsumptionExceptionHandler {
+
+	record ErrorBody(String code, String message) {}
+
+	@ExceptionHandler(ConsumptionNotFoundException.class)
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	ErrorBody handleNotFound(ConsumptionNotFoundException ex) {
+		return new ErrorBody("NOT_FOUND", ex.getMessage());
+	}
+
+	@ExceptionHandler(ConsumptionBadRequestException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	ErrorBody handleBadRequest(ConsumptionBadRequestException ex) {
+		return new ErrorBody("BAD_REQUEST", ex.getMessage());
+	}
+}

--- a/src/main/java/com/sagongsa/backend/mypage/ConsumptionListResponse.java
+++ b/src/main/java/com/sagongsa/backend/mypage/ConsumptionListResponse.java
@@ -1,0 +1,8 @@
+package com.sagongsa.backend.mypage;
+
+import java.util.List;
+
+public record ConsumptionListResponse(
+	String month,
+	List<ConsumptionRecord> items
+) {}

--- a/src/main/java/com/sagongsa/backend/mypage/ConsumptionNotFoundException.java
+++ b/src/main/java/com/sagongsa/backend/mypage/ConsumptionNotFoundException.java
@@ -1,0 +1,7 @@
+package com.sagongsa.backend.mypage;
+
+class ConsumptionNotFoundException extends RuntimeException {
+	ConsumptionNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/mypage/ConsumptionRecord.java
+++ b/src/main/java/com/sagongsa/backend/mypage/ConsumptionRecord.java
@@ -1,0 +1,14 @@
+package com.sagongsa.backend.mypage;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record ConsumptionRecord(
+	UUID id,
+	String itemTitle,
+	Integer price,
+	String result,
+	Instant decidedAt,
+	boolean isChanged,
+	int changeCount
+) {}

--- a/src/main/java/com/sagongsa/backend/mypage/ConsumptionService.java
+++ b/src/main/java/com/sagongsa/backend/mypage/ConsumptionService.java
@@ -1,0 +1,190 @@
+package com.sagongsa.backend.mypage;
+
+import com.sagongsa.backend.domain.enums.PurchaseDecisionResult;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.UUID;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+class ConsumptionService {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	ConsumptionService(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	ConsumptionListResponse getMonthlyConsumption(UUID userId, String month) {
+		validateMonth(month);
+		List<ConsumptionRecord> records = jdbcTemplate.query(
+			"""
+			SELECT pd.id, si.title AS item_title, pd.final_price AS price,
+			       pd.result, pd.decided_at, pd.is_changed, pd.change_count
+			FROM purchase_decisions pd
+			JOIN saved_items si ON si.id = pd.item_id
+			JOIN budget_cycles bc ON bc.id = pd.budget_cycle_id
+			WHERE pd.user_id = ?
+			  AND bc.year_month = ?
+			ORDER BY pd.decided_at DESC
+			""",
+			this::mapConsumptionRecord,
+			userId,
+			month
+		);
+		return new ConsumptionListResponse(month, records);
+	}
+
+	@Transactional
+	ConsumptionRecord changeDecisionResult(UUID userId, UUID decisionId, String newResultStr) {
+		PurchaseDecisionResult newResult = parseResult(newResultStr);
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+
+		DecisionForChange decision = lockDecision(userId, decisionId);
+		PurchaseDecisionResult previousResult = PurchaseDecisionResult.valueOf(decision.result());
+
+		int previousGoAmount = previousResult == PurchaseDecisionResult.GO
+			? Objects.requireNonNullElse(decision.finalPrice(), 0) : 0;
+		int newGoAmount = newResult == PurchaseDecisionResult.GO
+			? Objects.requireNonNullElse(decision.finalPrice(), 0) : 0;
+		int delta = newGoAmount - previousGoAmount;
+
+		jdbcTemplate.update(
+			"""
+			UPDATE purchase_decisions
+			SET result = ?, is_changed = true, change_count = change_count + 1,
+			    changed_at = ?, updated_at = ?
+			WHERE id = ?
+			""",
+			newResult.name(), now, now, decisionId
+		);
+
+		jdbcTemplate.update(
+			"UPDATE saved_items SET status = ?, updated_at = ? WHERE id = ?",
+			newResult.name(), now, decision.itemId()
+		);
+
+		if (decision.budgetCycleId() != null && delta != 0) {
+			jdbcTemplate.update(
+				"""
+				UPDATE budget_cycles
+				SET spent_amount = GREATEST(spent_amount + ?, 0), updated_at = ?
+				WHERE id = ?
+				""",
+				delta, now, decision.budgetCycleId()
+			);
+		}
+
+		return new ConsumptionRecord(
+			decisionId,
+			decision.itemTitle(),
+			decision.finalPrice(),
+			newResult.name(),
+			decision.decidedAt(),
+			true,
+			decision.changeCount() + 1
+		);
+	}
+
+	private DecisionForChange lockDecision(UUID userId, UUID decisionId) {
+		try {
+			return jdbcTemplate.queryForObject(
+				"""
+				SELECT pd.id, pd.item_id, pd.budget_cycle_id, pd.result,
+				       pd.final_price, pd.change_count, pd.decided_at,
+				       si.title AS item_title
+				FROM purchase_decisions pd
+				JOIN saved_items si ON si.id = pd.item_id
+				WHERE pd.user_id = ?
+				  AND pd.id = ?
+				FOR UPDATE OF pd
+				""",
+				this::mapDecisionForChange,
+				userId,
+				decisionId
+			);
+		} catch (EmptyResultDataAccessException e) {
+			throw new ConsumptionNotFoundException("소비 기록을 찾을 수 없습니다.");
+		}
+	}
+
+	private PurchaseDecisionResult parseResult(String raw) {
+		if (raw == null || raw.isBlank()) {
+			throw new ConsumptionBadRequestException("result는 필수입니다.");
+		}
+		try {
+			return PurchaseDecisionResult.valueOf(raw.trim().toUpperCase(Locale.ROOT));
+		} catch (IllegalArgumentException e) {
+			throw new ConsumptionBadRequestException("result는 GO 또는 STOP이어야 합니다.");
+		}
+	}
+
+	private void validateMonth(String month) {
+		if (month == null || month.isBlank()) {
+			throw new ConsumptionBadRequestException("month는 필수입니다.");
+		}
+		try {
+			YearMonth.parse(month);
+		} catch (Exception e) {
+			throw new ConsumptionBadRequestException("month는 YYYY-MM 형식이어야 합니다.");
+		}
+	}
+
+	private ConsumptionRecord mapConsumptionRecord(ResultSet rs, int rowNum) throws SQLException {
+		return new ConsumptionRecord(
+			rs.getObject("id", UUID.class),
+			rs.getString("item_title"),
+			nullableInt(rs, "price"),
+			rs.getString("result"),
+			toInstant(rs, "decided_at"),
+			rs.getBoolean("is_changed"),
+			rs.getInt("change_count")
+		);
+	}
+
+	private DecisionForChange mapDecisionForChange(ResultSet rs, int rowNum) throws SQLException {
+		return new DecisionForChange(
+			rs.getObject("id", UUID.class),
+			rs.getObject("item_id", UUID.class),
+			rs.getObject("budget_cycle_id", UUID.class),
+			rs.getString("result"),
+			nullableInt(rs, "final_price"),
+			rs.getInt("change_count"),
+			toInstant(rs, "decided_at"),
+			rs.getString("item_title")
+		);
+	}
+
+	private Integer nullableInt(ResultSet rs, String column) throws SQLException {
+		int value = rs.getInt(column);
+		return rs.wasNull() ? null : value;
+	}
+
+	private Instant toInstant(ResultSet rs, String column) throws SQLException {
+		Timestamp ts = rs.getTimestamp(column);
+		return ts == null ? null : ts.toInstant();
+	}
+
+	private record DecisionForChange(
+		UUID id,
+		UUID itemId,
+		UUID budgetCycleId,
+		String result,
+		Integer finalPrice,
+		int changeCount,
+		Instant decidedAt,
+		String itemTitle
+	) {}
+}

--- a/src/main/java/com/sagongsa/backend/mypage/ConsumptionService.java
+++ b/src/main/java/com/sagongsa/backend/mypage/ConsumptionService.java
@@ -1,18 +1,15 @@
 package com.sagongsa.backend.mypage;
 
-import com.sagongsa.backend.domain.enums.PurchaseDecisionResult;
+import com.sagongsa.backend.decision.DecisionResultResponse;
+import com.sagongsa.backend.decision.DecisionResultUpdateRequest;
+import com.sagongsa.backend.decision.DecisionService;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.time.OffsetDateTime;
 import java.time.YearMonth;
-import java.time.ZoneOffset;
 import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
 import java.util.UUID;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,9 +19,11 @@ import org.springframework.transaction.annotation.Transactional;
 class ConsumptionService {
 
 	private final JdbcTemplate jdbcTemplate;
+	private final DecisionService decisionService;
 
-	ConsumptionService(JdbcTemplate jdbcTemplate) {
+	ConsumptionService(JdbcTemplate jdbcTemplate, DecisionService decisionService) {
 		this.jdbcTemplate = jdbcTemplate;
+		this.decisionService = decisionService;
 	}
 
 	ConsumptionListResponse getMonthlyConsumption(UUID userId, String month) {
@@ -49,86 +48,27 @@ class ConsumptionService {
 
 	@Transactional
 	ConsumptionRecord changeDecisionResult(UUID userId, UUID decisionId, String newResultStr) {
-		PurchaseDecisionResult newResult = parseResult(newResultStr);
-		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-
-		DecisionForChange decision = lockDecision(userId, decisionId);
-		PurchaseDecisionResult previousResult = PurchaseDecisionResult.valueOf(decision.result());
-
-		int previousGoAmount = previousResult == PurchaseDecisionResult.GO
-			? Objects.requireNonNullElse(decision.finalPrice(), 0) : 0;
-		int newGoAmount = newResult == PurchaseDecisionResult.GO
-			? Objects.requireNonNullElse(decision.finalPrice(), 0) : 0;
-		int delta = newGoAmount - previousGoAmount;
-
-		jdbcTemplate.update(
-			"""
-			UPDATE purchase_decisions
-			SET result = ?, is_changed = true, change_count = change_count + 1,
-			    changed_at = ?, updated_at = ?
-			WHERE id = ?
-			""",
-			newResult.name(), now, now, decisionId
+		DecisionResultResponse response = decisionService.updateResult(
+			userId,
+			decisionId,
+			new DecisionResultUpdateRequest(newResultStr, null, null, null)
 		);
 
-		jdbcTemplate.update(
-			"UPDATE saved_items SET status = ?, updated_at = ? WHERE id = ?",
-			newResult.name(), now, decision.itemId()
+		int changeCount = jdbcTemplate.queryForObject(
+			"SELECT change_count FROM purchase_decisions WHERE id = ?",
+			Integer.class,
+			decisionId
 		);
-
-		if (decision.budgetCycleId() != null && delta != 0) {
-			jdbcTemplate.update(
-				"""
-				UPDATE budget_cycles
-				SET spent_amount = GREATEST(spent_amount + ?, 0), updated_at = ?
-				WHERE id = ?
-				""",
-				delta, now, decision.budgetCycleId()
-			);
-		}
 
 		return new ConsumptionRecord(
 			decisionId,
-			decision.itemTitle(),
-			decision.finalPrice(),
-			newResult.name(),
-			decision.decidedAt(),
+			response.itemTitle(),
+			response.finalPrice(),
+			response.result(),
+			response.decidedAt(),
 			true,
-			decision.changeCount() + 1
+			changeCount
 		);
-	}
-
-	private DecisionForChange lockDecision(UUID userId, UUID decisionId) {
-		try {
-			return jdbcTemplate.queryForObject(
-				"""
-				SELECT pd.id, pd.item_id, pd.budget_cycle_id, pd.result,
-				       pd.final_price, pd.change_count, pd.decided_at,
-				       si.title AS item_title
-				FROM purchase_decisions pd
-				JOIN saved_items si ON si.id = pd.item_id
-				WHERE pd.user_id = ?
-				  AND pd.id = ?
-				FOR UPDATE OF pd
-				""",
-				this::mapDecisionForChange,
-				userId,
-				decisionId
-			);
-		} catch (EmptyResultDataAccessException e) {
-			throw new ConsumptionNotFoundException("소비 기록을 찾을 수 없습니다.");
-		}
-	}
-
-	private PurchaseDecisionResult parseResult(String raw) {
-		if (raw == null || raw.isBlank()) {
-			throw new ConsumptionBadRequestException("result는 필수입니다.");
-		}
-		try {
-			return PurchaseDecisionResult.valueOf(raw.trim().toUpperCase(Locale.ROOT));
-		} catch (IllegalArgumentException e) {
-			throw new ConsumptionBadRequestException("result는 GO 또는 STOP이어야 합니다.");
-		}
 	}
 
 	private void validateMonth(String month) {
@@ -154,19 +94,6 @@ class ConsumptionService {
 		);
 	}
 
-	private DecisionForChange mapDecisionForChange(ResultSet rs, int rowNum) throws SQLException {
-		return new DecisionForChange(
-			rs.getObject("id", UUID.class),
-			rs.getObject("item_id", UUID.class),
-			rs.getObject("budget_cycle_id", UUID.class),
-			rs.getString("result"),
-			nullableInt(rs, "final_price"),
-			rs.getInt("change_count"),
-			toInstant(rs, "decided_at"),
-			rs.getString("item_title")
-		);
-	}
-
 	private Integer nullableInt(ResultSet rs, String column) throws SQLException {
 		int value = rs.getInt(column);
 		return rs.wasNull() ? null : value;
@@ -176,15 +103,4 @@ class ConsumptionService {
 		Timestamp ts = rs.getTimestamp(column);
 		return ts == null ? null : ts.toInstant();
 	}
-
-	private record DecisionForChange(
-		UUID id,
-		UUID itemId,
-		UUID budgetCycleId,
-		String result,
-		Integer finalPrice,
-		int changeCount,
-		Instant decidedAt,
-		String itemTitle
-	) {}
 }

--- a/src/main/resources/static/test-consumption.html
+++ b/src/main/resources/static/test-consumption.html
@@ -1,0 +1,282 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>월별 소비기록 테스트</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; background: #111; color: #eee; padding: 24px; }
+    h1 { font-size: 20px; font-weight: 700; margin-bottom: 4px; }
+    .subtitle { font-size: 13px; color: #666; margin-bottom: 24px; }
+    h2 { font-size: 13px; font-weight: 600; color: #888; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 12px; }
+    .section { background: #1a1a1a; border-radius: 12px; padding: 20px; margin-bottom: 16px; }
+    .btn { padding: 8px 16px; border-radius: 8px; border: none; font-size: 13px; font-weight: 600; cursor: pointer; }
+    .btn:active { opacity: 0.75; }
+    .btn:disabled { opacity: 0.4; cursor: not-allowed; }
+    .btn-primary { background: #4a90d9; color: #fff; }
+    .btn-success { background: #27ae60; color: #fff; }
+    .btn-danger { background: #e74c3c; color: #fff; }
+    .btn-outline { background: transparent; border: 1px solid #444; color: #aaa; }
+    .btn-sm { padding: 5px 10px; font-size: 12px; }
+    .row { display: flex; gap: 8px; align-items: center; margin-bottom: 10px; }
+    .row label { font-size: 13px; color: #888; width: 80px; flex-shrink: 0; }
+    .row input, .row select { flex: 1; padding: 8px 10px; border-radius: 8px; border: 1px solid #333; background: #222; color: #fff; font-size: 13px; }
+    .log { background: #0a0a0a; border-radius: 8px; padding: 10px 12px; font-size: 12px; font-family: monospace; color: #0f0; min-height: 32px; max-height: 64px; overflow-y: auto; white-space: pre-wrap; word-break: break-all; margin-top: 8px; }
+    .log.err { color: #e74c3c; }
+
+    /* 유저 카드 */
+    .users { display: flex; gap: 10px; flex-wrap: wrap; }
+    .user-card { background: #222; border-radius: 10px; padding: 12px 14px; min-width: 160px; border: 2px solid transparent; cursor: pointer; }
+    .user-card.selected { border-color: #4a90d9; }
+    .user-card .nick { font-size: 16px; font-weight: 700; color: #4a90d9; }
+    .user-card .uid { font-size: 10px; color: #555; font-family: monospace; }
+
+    /* 결정 목록 */
+    .decision-card { background: #222; border-radius: 10px; padding: 14px 16px; margin-bottom: 10px; display: flex; align-items: center; gap: 12px; }
+    .decision-info { flex: 1; }
+    .decision-title { font-size: 15px; font-weight: 600; margin-bottom: 4px; }
+    .decision-meta { font-size: 12px; color: #888; }
+    .badge { display: inline-block; padding: 2px 10px; border-radius: 20px; font-size: 12px; font-weight: 700; }
+    .badge-go { background: rgba(39,174,96,.2); color: #27ae60; }
+    .badge-stop { background: rgba(231,76,60,.2); color: #e74c3c; }
+    .changed-tag { font-size: 11px; color: #f39c12; margin-left: 6px; }
+    .empty { color: #555; font-size: 13px; text-align: center; padding: 20px; }
+
+    /* 월 네비 */
+    .month-nav { display: flex; gap: 8px; align-items: center; margin-bottom: 14px; }
+    .month-nav input { padding: 7px 10px; border-radius: 8px; border: 1px solid #333; background: #222; color: #fff; font-size: 13px; width: 120px; }
+    .month-nav span { font-size: 16px; font-weight: 700; color: #eee; }
+  </style>
+</head>
+<body>
+
+<h1>월별 소비기록 테스트</h1>
+<p class="subtitle">GET /my/consumption?month=YYYY-MM · PATCH /my/consumption/{id}</p>
+
+<!-- ① 유저 -->
+<div class="section">
+  <h2>① 테스트 유저</h2>
+  <div class="users" id="userList">
+    <div class="empty" style="width:100%">유저를 생성해주세요.</div>
+  </div>
+  <div style="margin-top:12px">
+    <button class="btn btn-primary" onclick="createUser()">+ 유저 생성</button>
+  </div>
+</div>
+
+<!-- ② 결정 데이터 만들기 -->
+<div class="section">
+  <h2>② 테스트 결정 데이터 생성</h2>
+  <p style="font-size:12px;color:#666;margin-bottom:10px">
+    선택한 유저로 숙려 → 결정 플로우를 거치거나, 아래에서 빠르게 직접 삽입합니다.
+  </p>
+  <div class="row">
+    <label>상품명</label>
+    <input id="itemTitle" value="에어팟 프로">
+  </div>
+  <div class="row">
+    <label>가격</label>
+    <input id="itemPrice" type="number" value="350000">
+  </div>
+  <div class="row">
+    <label>결정</label>
+    <select id="itemResult">
+      <option value="GO">GO (구매)</option>
+      <option value="STOP">STOP (참음)</option>
+    </select>
+  </div>
+  <button class="btn btn-success" onclick="insertDecision()">결정 데이터 삽입</button>
+  <div id="insertLog" class="log"></div>
+</div>
+
+<!-- ③ 소비기록 조회 -->
+<div class="section">
+  <h2>③ 월별 소비기록 조회</h2>
+  <div class="month-nav">
+    <input type="month" id="monthPicker" oninput="syncMonthInput()">
+    <button class="btn btn-outline btn-sm" onclick="prevMonth()">◀</button>
+    <span id="monthLabel">-</span>
+    <button class="btn btn-outline btn-sm" onclick="nextMonth()">▶</button>
+    <button class="btn btn-primary btn-sm" onclick="loadConsumption()">조회</button>
+  </div>
+  <div id="consumptionArea"><div class="empty">조회 버튼을 눌러주세요.</div></div>
+</div>
+
+<script>
+const users = [];
+let selectedIdx = null;
+let currentMonth = toYearMonth(new Date());
+
+// ── 초기화 ────────────────────────────────────────────
+initMonthPicker();
+
+function toYearMonth(d) {
+  return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0');
+}
+function initMonthPicker() {
+  document.getElementById('monthPicker').value = currentMonth;
+  document.getElementById('monthLabel').textContent = currentMonth;
+}
+function syncMonthInput() {
+  const v = document.getElementById('monthPicker').value;
+  if (v) { currentMonth = v; document.getElementById('monthLabel').textContent = v; }
+}
+function prevMonth() {
+  const [y, m] = currentMonth.split('-').map(Number);
+  const d = new Date(y, m - 2, 1);
+  currentMonth = toYearMonth(d);
+  document.getElementById('monthPicker').value = currentMonth;
+  document.getElementById('monthLabel').textContent = currentMonth;
+  loadConsumption();
+}
+function nextMonth() {
+  const [y, m] = currentMonth.split('-').map(Number);
+  const d = new Date(y, m, 1);
+  currentMonth = toYearMonth(d);
+  document.getElementById('monthPicker').value = currentMonth;
+  document.getElementById('monthLabel').textContent = currentMonth;
+  loadConsumption();
+}
+
+// ── 공통 ──────────────────────────────────────────────
+function esc(s) {
+  if (!s) return '';
+  const d = document.createElement('div'); d.textContent = s; return d.innerHTML;
+}
+async function api(method, path, body, userId) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (userId) headers['X-User-Id'] = userId;
+  const opts = { method, headers };
+  if (body) opts.body = JSON.stringify(body);
+  const res = await fetch(path, opts);
+  const text = await res.text();
+  let data; try { data = JSON.parse(text); } catch { data = text; }
+  return { ok: res.ok, status: res.status, data };
+}
+function log(id, msg, isErr) {
+  const el = document.getElementById(id);
+  el.textContent = msg;
+  el.className = 'log' + (isErr ? ' err' : '');
+}
+
+// ── ① 유저 ──────────────────────────────────────────
+async function createUser() {
+  const r = await api('POST', '/api/dev/users/test');
+  if (!r.ok) { alert('유저 생성 실패: ' + JSON.stringify(r.data)); return; }
+  users.push({ userId: r.data.userId, nickname: r.data.nickname });
+  selectedIdx = users.length - 1;
+  renderUsers();
+}
+function selectUser(i) { selectedIdx = i; renderUsers(); }
+function renderUsers() {
+  const el = document.getElementById('userList');
+  if (!users.length) { el.innerHTML = '<div class="empty" style="width:100%">유저를 생성해주세요.</div>'; return; }
+  el.innerHTML = users.map((u, i) => `
+    <div class="user-card ${i === selectedIdx ? 'selected' : ''}" onclick="selectUser(${i})">
+      <div class="nick">${esc(u.nickname)}</div>
+      <div class="uid">${u.userId.slice(0, 8)}...</div>
+    </div>
+  `).join('');
+}
+
+// ── ② 데이터 삽입 ────────────────────────────────────
+async function insertDecision() {
+  if (selectedIdx === null) { alert('유저를 선택하세요.'); return; }
+  const userId = users[selectedIdx].userId;
+  const title = document.getElementById('itemTitle').value.trim() || '테스트 상품';
+  const price = parseInt(document.getElementById('itemPrice').value) || 0;
+  const result = document.getElementById('itemResult').value;
+
+  // 1) 상품 저장
+  const ir = await api('POST', '/api/v1/items', {
+    title, listedPrice: price, category: 'DIGITAL', inputSource: 'DIRECT_INPUT'
+  }, userId);
+  if (!ir.ok) {
+    // 상품 API가 없을 수 있으니 dev insert endpoint 시도
+    log('insertLog', '상품 API 실패 — /api/dev/decisions/test 를 통해 삽입합니다.', true);
+    await insertDecisionDev(userId, title, price, result);
+    return;
+  }
+  const itemId = ir.data.id;
+
+  // 2) 결정
+  const dr = await api('POST', '/api/v1/decisions', {
+    itemId,
+    result,
+    finalPrice: price,
+    selfCheckAnswers: [
+      { questionCode: 'NEED', answerBoolean: false },
+      { questionCode: 'BUDGET', answerBoolean: false },
+      { questionCode: 'ALTERNATIVE', answerBoolean: false },
+      { questionCode: 'DELAY', answerBoolean: false }
+    ]
+  }, userId);
+  if (!dr.ok) { log('insertLog', '결정 실패: ' + JSON.stringify(dr.data), true); return; }
+  log('insertLog', `삽입 완료 ✓  decisionId: ${dr.data.id}\nresult: ${dr.data.result}  finalPrice: ${dr.data.finalPrice}`);
+  await loadConsumption();
+}
+
+async function insertDecisionDev(userId, title, price, result) {
+  const r = await api('POST', '/api/dev/decisions/test', { title, price, result }, userId);
+  if (!r.ok) { log('insertLog', '삽입 실패: ' + JSON.stringify(r.data), true); return; }
+  log('insertLog', `삽입 완료 ✓\ndecisionId: ${r.data.decisionId}\nresult: ${r.data.result}  month: ${r.data.month}`);
+  await loadConsumption();
+}
+
+// ── ③ 소비기록 조회 ───────────────────────────────────
+async function loadConsumption() {
+  if (selectedIdx === null) { alert('유저를 선택하세요.'); return; }
+  const userId = users[selectedIdx].userId;
+  const r = await api('GET', `/api/v1/my/consumption?month=${currentMonth}`, null, userId);
+  if (!r.ok) {
+    document.getElementById('consumptionArea').innerHTML =
+      `<div class="empty" style="color:#e74c3c">오류: ${JSON.stringify(r.data)}</div>`;
+    return;
+  }
+
+  const items = r.data.items || [];
+  if (!items.length) {
+    document.getElementById('consumptionArea').innerHTML =
+      `<div class="empty">${currentMonth} 에 소비기록이 없습니다.</div>`;
+    return;
+  }
+
+  document.getElementById('consumptionArea').innerHTML = items.map(item => `
+    <div class="decision-card" id="dc-${item.id}">
+      <div class="decision-info">
+        <div class="decision-title">
+          ${esc(item.itemTitle)}
+          ${item.isChanged ? '<span class="changed-tag">✏ 변경됨 ×' + item.changeCount + '</span>' : ''}
+        </div>
+        <div class="decision-meta">
+          ${item.price != null ? item.price.toLocaleString() + '원' : '가격 없음'}
+          &nbsp;·&nbsp; ${new Date(item.decidedAt).toLocaleDateString('ko-KR')}
+        </div>
+      </div>
+      <span class="badge ${item.result === 'GO' ? 'badge-go' : 'badge-stop'}" id="badge-${item.id}">
+        ${item.result === 'GO' ? '구매' : '참음'}
+      </span>
+      <button class="btn btn-outline btn-sm" onclick="toggleResult('${item.id}', '${item.result}')">
+        ${item.result === 'GO' ? '→ 참음으로 변경' : '→ 구매로 변경'}
+      </button>
+    </div>
+  `).join('');
+}
+
+async function toggleResult(decisionId, currentResult) {
+  if (selectedIdx === null) return;
+  const userId = users[selectedIdx].userId;
+  const newResult = currentResult === 'GO' ? 'STOP' : 'GO';
+
+  const r = await api('PATCH', `/api/v1/my/consumption/${decisionId}`, { result: newResult }, userId);
+  if (!r.ok) {
+    alert('변경 실패: ' + JSON.stringify(r.data));
+    return;
+  }
+
+  // 낙관적 업데이트 후 전체 새로고침
+  await loadConsumption();
+}
+</script>
+</body>
+</html>

--- a/src/test/java/com/sagongsa/backend/mypage/ConsumptionApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/mypage/ConsumptionApiIntegrationTest.java
@@ -1,0 +1,226 @@
+package com.sagongsa.backend.mypage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ConsumptionApiIntegrationTest extends PostgreSqlContainerTest {
+
+	private static final String USER_ID_HEADER = "X-User-Id";
+	private static final String BASE_PATH = "/api/v1/my/consumption";
+	private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.execute("truncate table users cascade");
+	}
+
+	@Test
+	void getMonthlyConsumption_returnsDecisionsForMonth() throws Exception {
+		UUID userId = createUser();
+		String month = YearMonth.now(SEOUL).toString();
+		UUID budgetCycleId = insertBudgetCycle(userId, month, 500_000, 35_000);
+		UUID decisionId = insertGoDecision(userId, budgetCycleId, "에어팟 프로", 35_000);
+
+		mockMvc.perform(get(BASE_PATH)
+				.header(USER_ID_HEADER, userId)
+				.param("month", month))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.month").value(month))
+			.andExpect(jsonPath("$.items").isArray())
+			.andExpect(jsonPath("$.items[0].id").value(decisionId.toString()))
+			.andExpect(jsonPath("$.items[0].itemTitle").value("에어팟 프로"))
+			.andExpect(jsonPath("$.items[0].price").value(35_000))
+			.andExpect(jsonPath("$.items[0].result").value("GO"))
+			.andExpect(jsonPath("$.items[0].isChanged").value(false));
+	}
+
+	@Test
+	void getMonthlyConsumption_returnsEmptyListWhenNoDecisions() throws Exception {
+		UUID userId = createUser();
+		String month = YearMonth.now(SEOUL).toString();
+
+		mockMvc.perform(get(BASE_PATH)
+				.header(USER_ID_HEADER, userId)
+				.param("month", month))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.month").value(month))
+			.andExpect(jsonPath("$.items").isEmpty());
+	}
+
+	@Test
+	void getMonthlyConsumption_rejectsBadMonthFormat() throws Exception {
+		UUID userId = createUser();
+
+		mockMvc.perform(get(BASE_PATH)
+				.header(USER_ID_HEADER, userId)
+				.param("month", "2026/05"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("BAD_REQUEST"));
+	}
+
+	@Test
+	void changeDecision_goToStop_syncsBudgetAndStatus() throws Exception {
+		UUID userId = createUser();
+		String month = YearMonth.now(SEOUL).toString();
+		UUID budgetCycleId = insertBudgetCycle(userId, month, 500_000, 35_000);
+		UUID decisionId = insertGoDecision(userId, budgetCycleId, "운동화", 35_000);
+
+		mockMvc.perform(patch(BASE_PATH + "/{id}", decisionId)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"result": "STOP"}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id").value(decisionId.toString()))
+			.andExpect(jsonPath("$.result").value("STOP"))
+			.andExpect(jsonPath("$.isChanged").value(true))
+			.andExpect(jsonPath("$.changeCount").value(1));
+
+		assertThat(queryString("SELECT result FROM purchase_decisions WHERE id = ?", decisionId)).isEqualTo("STOP");
+		assertThat(queryString("SELECT status FROM saved_items si JOIN purchase_decisions pd ON si.id = pd.item_id WHERE pd.id = ?", decisionId)).isEqualTo("STOP");
+		assertThat(queryInteger("SELECT spent_amount FROM budget_cycles WHERE id = ?", budgetCycleId)).isEqualTo(0);
+	}
+
+	@Test
+	void changeDecision_stopToGo_syncsBudgetAndStatus() throws Exception {
+		UUID userId = createUser();
+		String month = YearMonth.now(SEOUL).toString();
+		UUID budgetCycleId = insertBudgetCycle(userId, month, 500_000, 0);
+		UUID decisionId = insertStopDecision(userId, budgetCycleId, "책상", 120_000);
+
+		mockMvc.perform(patch(BASE_PATH + "/{id}", decisionId)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"result": "GO"}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.result").value("GO"))
+			.andExpect(jsonPath("$.isChanged").value(true));
+
+		assertThat(queryString("SELECT result FROM purchase_decisions WHERE id = ?", decisionId)).isEqualTo("GO");
+		assertThat(queryInteger("SELECT spent_amount FROM budget_cycles WHERE id = ?", budgetCycleId)).isEqualTo(120_000);
+	}
+
+	@Test
+	void changeDecision_notFound_returns404() throws Exception {
+		UUID userId = createUser();
+
+		mockMvc.perform(patch(BASE_PATH + "/{id}", UUID.randomUUID())
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"result": "STOP"}
+					"""))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("NOT_FOUND"));
+	}
+
+	@Test
+	void changeDecision_invalidResult_returns400() throws Exception {
+		UUID userId = createUser();
+		String month = YearMonth.now(SEOUL).toString();
+		UUID budgetCycleId = insertBudgetCycle(userId, month, 500_000, 10_000);
+		UUID decisionId = insertGoDecision(userId, budgetCycleId, "키보드", 10_000);
+
+		mockMvc.perform(patch(BASE_PATH + "/{id}", decisionId)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"result": "MAYBE"}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("BAD_REQUEST"));
+	}
+
+	private UUID createUser() {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"INSERT INTO users (id, status, onboarding_status, created_at, updated_at) VALUES (?, 'ACTIVE', 'COMPLETED', ?, ?)",
+			userId, now, now
+		);
+		jdbcTemplate.update(
+			"INSERT INTO user_profiles (user_id, nickname, mascot_name, timezone, created_at, updated_at) VALUES (?, '너굴1', '너구리', 'Asia/Seoul', ?, ?)",
+			userId, now, now
+		);
+		return userId;
+	}
+
+	private UUID insertBudgetCycle(UUID userId, String yearMonth, int monthlyBudget, int spentAmount) {
+		UUID id = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"INSERT INTO budget_cycles (id, user_id, year_month, monthly_budget_amount, spent_amount, warning_threshold_rate, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 80.00, ?, ?)",
+			id, userId, yearMonth, monthlyBudget, spentAmount, now, now
+		);
+		return id;
+	}
+
+	private UUID insertGoDecision(UUID userId, UUID budgetCycleId, String itemTitle, int price) {
+		UUID itemId = insertSavedItem(userId, itemTitle, price, "GO");
+		UUID decisionId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"INSERT INTO purchase_decisions (id, user_id, item_id, budget_cycle_id, result, final_price, rationality_result, self_check_yes_count, is_changed, change_count, decided_at, created_at, updated_at) VALUES (?, ?, ?, ?, 'GO', ?, 'RATIONAL', 0, false, 0, ?, ?, ?)",
+			decisionId, userId, itemId, budgetCycleId, price, now, now, now
+		);
+		return decisionId;
+	}
+
+	private UUID insertStopDecision(UUID userId, UUID budgetCycleId, String itemTitle, int price) {
+		UUID itemId = insertSavedItem(userId, itemTitle, price, "STOP");
+		UUID decisionId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"INSERT INTO purchase_decisions (id, user_id, item_id, budget_cycle_id, result, final_price, rationality_result, self_check_yes_count, is_changed, change_count, decided_at, created_at, updated_at) VALUES (?, ?, ?, ?, 'STOP', ?, 'RATIONAL', 0, false, 0, ?, ?, ?)",
+			decisionId, userId, itemId, budgetCycleId, price, now, now, now
+		);
+		return decisionId;
+	}
+
+	private UUID insertSavedItem(UUID userId, String title, int price, String status) {
+		UUID itemId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"INSERT INTO saved_items (id, user_id, input_source, title, listed_price, currency_code, category, category_locked_by_user, status, created_at, updated_at) VALUES (?, ?, 'DIRECT_INPUT', ?, ?, 'KRW', 'DIGITAL', false, ?, ?, ?)",
+			itemId, userId, title, price, status, now, now
+		);
+		return itemId;
+	}
+
+	private String queryString(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(sql, String.class, args);
+	}
+
+	private Integer queryInteger(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(sql, Integer.class, args);
+	}
+}


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-50`
- Jira: NF-34
- GitHub: Related #50
- GitHub: Closes #50

> PR 제목: `NF-50 마이페이지 월별 소비기록 조회 및 결정 수정`
> 브랜치: `feat/7-monthly-consumption`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #50 1/1 단계
- 선행 PR: `feat/6-nickname` 머지 필요
- 후속 PR: 없음

### 이 PR에서 변경한 것
- `GET /my/consumption?month=YYYY-MM` 월별 소비기록 조회 API 추가
- `month=YYYY-MM` 쿼리 파라미터 처리
- 소비기록 응답에 상품명, 가격, 결정 상태 포함
- `PATCH /my/consumption/{id}` 결정 변경 API 추가
- 결정 변경 시 예산 사용 금액 동기화
- 결정 변경 시 상품 상태값 동기화

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
- AC1: 월별 소비기록을 `month=YYYY-MM` 기준으로 조회할 수 있다.
- AC2: 소비기록 응답에 상품명, 가격, 결정 상태가 포함된다.
- AC3: 결정 상태를 `PATCH /my/consumption/{id}`로 변경할 수 있다.
- AC4: 결정 변경 시 예산 사용 금액이 함께 동기화된다.
- AC5: 결정 변경 시 상품 상태값이 함께 동기화된다.
- AC6: 다른 사용자의 소비기록은 조회하거나 수정할 수 없다.

### Not covered (후속 작업)
- 없음

---

## 🧪 테스트 결과 (필수)
### 로컬
```bash
./gradlew test
```
- ✅/❌ 결과: 직접 실행 후 기입

### CI
- 자동 첨부 예정

### Smoke 테스트
- 시나리오: 로그인 후 월별 소비기록 조회 → 특정 소비기록 결정 상태 변경 → 목록 재조회 → 상품 상태/예산 사용 금액 반영 확인
- 결과: 직접 확인 필요

---

## 🧭 영향 범위 체크 (필수)
- [x] API 변경 (요약: `GET /my/consumption`, `PATCH /my/consumption/{id}` 신규 추가)
- [ ] DB 변경 (마이그레이션: 없음)
- [ ] 설정 변경 (항목: 없음)
- [ ] Breaking change (무엇: )

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인:
  - `MypageController` — 월별 소비기록 조회/결정 변경 API 엔드포인트
  - `MypageService` — 월별 조회 조건 및 결정 변경 트랜잭션 처리
  - 결정 변경 로직 — `budget_used`/예산 사용 금액과 상품 `status` 동기화
- 트레이드오프/대안:
  - 별도 소비기록 테이블을 추가하지 않고 기존 구매 결정/상품/예산 데이터를 조합해 응답합니다.
  - 결정 변경 시 관련 상태를 한 트랜잭션에서 갱신해 데이터 불일치를 줄입니다.
