### PR TITLE
[bug] NF-39 숙려 화면 UI 누락 항목 보완

### DIFF
--- a/src/main/resources/static/deliberation.html
+++ b/src/main/resources/static/deliberation.html
@@ -597,8 +597,8 @@
 
     // ⑤ 결과 화면 렌더링
     function renderResult(data) {
-        const state      = data.mascotReaction?.state ?? 'SMILE';
-        const mascotMsg  = data.mascotReaction?.message ?? '';
+        const state      = data.mascot?.state ?? 'SMILE';
+        const mascotMsg  = data.mascot?.message ?? '';
         const isBought   = data.result === 'GO';
         const irrational = data.rationalityResult === 'IRRATIONAL';
 

--- a/src/main/resources/static/deliberation.html
+++ b/src/main/resources/static/deliberation.html
@@ -8,202 +8,352 @@
         * { box-sizing: border-box; margin: 0; padding: 0; }
         body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; background: #111; color: #fff; min-height: 100vh; }
 
-        /* 로그인 화면 */
-        .login-screen { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100vh; gap: 16px; }
-        .login-screen h1 { font-size: 24px; margin-bottom: 8px; }
-        .login-screen p { color: #888; font-size: 14px; margin-bottom: 16px; }
-        .login-btn { padding: 12px 32px; border-radius: 24px; border: none; font-size: 16px; font-weight: 600; cursor: pointer; }
-        .kakao { background: #FEE500; color: #000; }
-        .google { background: #fff; color: #333; }
-        .naver { background: #03C75A; color: #fff; }
-
-        /* 셋업 화면 */
-        .setup-screen { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100vh; gap: 16px; padding: 24px; }
-        .setup-screen h2 { font-size: 20px; }
-        .setup-screen p { color: #888; font-size: 14px; text-align: center; }
-        .create-btn { padding: 14px 36px; border-radius: 24px; border: none; background: #4a90d9; color: #fff; font-size: 16px; font-weight: 600; cursor: pointer; }
-        .create-btn:disabled { opacity: 0.5; cursor: not-allowed; }
-
-        /* 숙려 화면 */
-        .deliberation-screen { display: none; max-width: 420px; margin: 0 auto; padding: 24px 20px 80px; }
-
-        /* 상품 카드 */
-        .product-card { background: #1a1a1a; border-radius: 16px; padding: 20px; margin-bottom: 16px; }
-        .product-card img { width: 100%; height: 180px; object-fit: cover; border-radius: 10px; margin-bottom: 12px; display: none; }
-        .product-card img.loaded { display: block; }
-        .product-category { font-size: 12px; color: #888; margin-bottom: 4px; }
-        .product-title { font-size: 20px; font-weight: 700; margin-bottom: 6px; }
-        .product-price { font-size: 22px; font-weight: 700; color: #ffd700; }
-
-        /* 예산 카드 */
-        .budget-card { background: #1a1a1a; border-radius: 16px; padding: 20px; margin-bottom: 16px; }
-        .budget-card h3 { font-size: 14px; color: #888; margin-bottom: 12px; }
-        .budget-row { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
-        .budget-row:last-child { margin-bottom: 0; }
-        .budget-label { font-size: 14px; color: #aaa; }
-        .budget-value { font-size: 16px; font-weight: 600; }
-        .budget-remaining { color: #4a90d9; }
-        .budget-bar { width: 100%; height: 6px; background: #333; border-radius: 3px; margin-top: 12px; }
-        .budget-bar-fill { height: 100%; border-radius: 3px; background: #4a90d9; transition: width 0.5s; }
-
-        /* 구분선 */
-        .section-title { font-size: 13px; font-weight: 600; color: #888; text-transform: uppercase; letter-spacing: 0.5px; margin: 24px 0 12px; }
-
-        /* 질문 카드 */
-        .question-card { background: #1a1a1a; border-radius: 16px; padding: 18px 20px; margin-bottom: 10px; display: flex; justify-content: space-between; align-items: center; gap: 12px; }
-        .question-text { font-size: 15px; line-height: 1.4; flex: 1; }
-        .yn-buttons { display: flex; gap: 6px; flex-shrink: 0; }
-        .yn-btn { width: 44px; height: 36px; border-radius: 8px; border: 1px solid #444; background: transparent; color: #888; font-size: 13px; font-weight: 600; cursor: pointer; transition: all 0.15s; }
-        .yn-btn.yes.selected { background: #e74c3c; border-color: #e74c3c; color: #fff; }
-        .yn-btn.no.selected { background: #27ae60; border-color: #27ae60; color: #fff; }
-
-        /* 경고 배너 */
-        .warning-banner { border-radius: 12px; padding: 14px 16px; margin: 16px 0; font-size: 14px; font-weight: 600; text-align: center; display: none; }
-        .warning-banner.danger { background: rgba(231, 76, 60, 0.15); border: 1px solid #e74c3c; color: #e74c3c; }
-        .warning-banner.safe { background: rgba(39, 174, 96, 0.15); border: 1px solid #27ae60; color: #27ae60; }
-
-        /* 이달 통계 */
-        .stats-card { background: #1a1a1a; border-radius: 16px; padding: 20px; margin-bottom: 16px; }
-        .stats-card h3 { font-size: 14px; color: #888; margin-bottom: 14px; }
-        .stat-row { display: flex; justify-content: space-between; align-items: center; padding: 8px 0; border-bottom: 1px solid #222; }
-        .stat-row:last-child { border-bottom: none; padding-bottom: 0; }
-        .stat-label { font-size: 14px; color: #aaa; }
-        .stat-value { font-size: 16px; font-weight: 700; }
-        .stat-value.red { color: #e74c3c; }
-        .stat-value.yellow { color: #ffd700; }
-        .stat-value.blue { color: #4a90d9; }
-
-        /* 결정 버튼 */
-        .decision-area { position: fixed; bottom: 0; left: 0; right: 0; padding: 16px 20px; background: #111; border-top: 1px solid #222; display: none; }
-        .decision-buttons { display: flex; gap: 10px; max-width: 420px; margin: 0 auto; }
-        .decision-btn { flex: 1; padding: 16px; border-radius: 14px; border: none; font-size: 16px; font-weight: 700; cursor: pointer; transition: all 0.2s; }
-        .decision-btn:disabled { opacity: 0.4; cursor: not-allowed; }
-        .decision-btn.restrain { background: #4a90d9; color: #fff; }
-        .decision-btn.buy { background: #e74c3c; color: #fff; }
-        .decision-btn:not(:disabled):active { transform: scale(0.97); }
-
-        /* 결과 화면 */
-        .result-screen { display: none; flex-direction: column; align-items: center; justify-content: center; min-height: 100vh; padding: 40px 24px; text-align: center; }
-        .result-screen h2 { font-size: 28px; margin-bottom: 8px; }
-        .result-screen p { color: #888; font-size: 14px; margin-bottom: 32px; }
-        .result-stats { background: #1a1a1a; border-radius: 16px; padding: 24px; width: 100%; max-width: 340px; margin-bottom: 24px; }
-        .result-row { display: flex; justify-content: space-between; padding: 10px 0; border-bottom: 1px solid #222; }
-        .result-row:last-child { border-bottom: none; }
-        .reset-btn { padding: 12px 32px; border-radius: 24px; border: 1px solid #444; background: transparent; color: #aaa; font-size: 14px; cursor: pointer; }
-
+        /* ── 공통 ── */
         .hidden { display: none !important; }
-        .loading { color: #888; font-size: 14px; text-align: center; padding: 40px; }
+
+        /* ── 진입 화면 (로그인/셋업) ── */
+        .entry-screen {
+            display: flex; flex-direction: column; align-items: center;
+            justify-content: center; height: 100vh; gap: 14px; padding: 32px; text-align: center;
+        }
+        .entry-emoji { font-size: 52px; }
+        .entry-screen h1, .entry-screen h2 { font-size: 22px; font-weight: 700; }
+        .entry-screen p { color: #888; font-size: 14px; line-height: 1.6; }
+        .primary-btn {
+            margin-top: 12px; padding: 14px 40px; border-radius: 28px;
+            border: none; background: #4a90d9; color: #fff;
+            font-size: 16px; font-weight: 700; cursor: pointer; transition: opacity 0.2s;
+        }
+        .primary-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+        .entry-msg { font-size: 12px; color: #666; min-height: 18px; }
+
+        /* ── 스텝 화면 ── */
+        .step-screen { display: flex; flex-direction: column; min-height: 100vh; max-width: 420px; margin: 0 auto; }
+
+        /* ── 스텝 헤더 ── */
+        .step-header {
+            position: sticky; top: 0; z-index: 100;
+            background: #111; border-bottom: 1px solid #1e1e1e;
+            padding: 14px 20px;
+            display: flex; align-items: center; justify-content: space-between;
+        }
+        .step-back { background: none; border: none; color: #666; font-size: 14px; cursor: pointer; padding: 4px; }
+        .step-dots { display: flex; gap: 6px; }
+        .step-dot { width: 8px; height: 8px; border-radius: 50%; background: #333; transition: background 0.3s; }
+        .step-dot.on { background: #4a90d9; }
+        .step-label { font-size: 12px; color: #666; width: 36px; text-align: right; }
+
+        /* ── 스크롤 콘텐츠 영역 ── */
+        .step-body { flex: 1; overflow-y: auto; padding: 20px 20px 110px; }
+
+        /* ── 카드 공통 ── */
+        .card { background: #1a1a1a; border-radius: 16px; padding: 20px; margin-bottom: 14px; }
+        .card-label {
+            font-size: 12px; font-weight: 700; color: #555;
+            text-transform: uppercase; letter-spacing: 0.6px; margin-bottom: 14px;
+        }
+
+        /* ── 상품 카드 ── */
+        .product-img { width: 100%; height: 160px; object-fit: cover; border-radius: 10px; margin-bottom: 12px; display: none; }
+        .product-img.show { display: block; }
+        .product-category { font-size: 12px; color: #666; margin-bottom: 4px; }
+        .product-name { font-size: 20px; font-weight: 700; margin-bottom: 8px; }
+        .product-price { font-size: 26px; font-weight: 700; color: #ffd700; }
+
+        /* ── 예산 카드 ── */
+        .brow { display: flex; justify-content: space-between; align-items: center; padding: 7px 0; }
+        .brow-label { font-size: 14px; color: #888; }
+        .brow-value { font-size: 15px; font-weight: 600; }
+        .brow-value.blue { color: #4a90d9; }
+        .brow-value.orange { color: #f39c12; }
+        .budget-bar { height: 6px; background: #2a2a2a; border-radius: 3px; margin-top: 14px; overflow: hidden; }
+        .budget-bar-fill { height: 100%; background: #4a90d9; border-radius: 3px; transition: width 0.6s ease; }
+        .budget-bar-fill.over { background: #e74c3c; }
+        .budget-pct { display: flex; justify-content: flex-end; margin-top: 5px; font-size: 12px; color: #555; }
+
+        /* ── 소비이력 카드 ── */
+        .srow { display: flex; justify-content: space-between; align-items: center; padding: 9px 0; border-bottom: 1px solid #222; }
+        .srow:last-child { border-bottom: none; }
+        .srow-label { font-size: 14px; color: #888; }
+        .srow-value { font-size: 15px; font-weight: 700; }
+        .srow-value.yellow { color: #ffd700; }
+        .opportunity-pill {
+            margin-top: 12px; padding: 10px 14px; background: #222;
+            border-radius: 10px; font-size: 13px; color: #999; line-height: 1.5;
+        }
+
+        /* ── 질문 아이템 ── */
+        .question-item {
+            background: #1a1a1a; border-radius: 14px; padding: 16px 18px;
+            margin-bottom: 10px; display: flex; justify-content: space-between;
+            align-items: center; gap: 12px;
+        }
+        .question-text { font-size: 15px; line-height: 1.45; flex: 1; }
+        .yn-wrap { display: flex; gap: 6px; flex-shrink: 0; }
+        .yn-btn {
+            width: 46px; height: 38px; border-radius: 9px; border: 1.5px solid #333;
+            background: transparent; color: #666; font-size: 13px; font-weight: 700;
+            cursor: pointer; transition: all 0.15s;
+        }
+        .yn-btn.yes.on { background: #e74c3c; border-color: #e74c3c; color: #fff; }
+        .yn-btn.no.on  { background: #27ae60; border-color: #27ae60; color: #fff; }
+
+        /* ── 경고 배너 ── */
+        .alert {
+            border-radius: 12px; padding: 14px 16px; margin: 12px 0;
+            font-size: 14px; font-weight: 600; text-align: center; line-height: 1.5;
+        }
+        .alert.danger { background: rgba(231,76,60,.12); border: 1px solid #c0392b; color: #e74c3c; }
+        .alert.safe   { background: rgba(39,174,96,.12);  border: 1px solid #1e8449; color: #27ae60; }
+        .alert.err    { background: rgba(231,76,60,.12); border: 1px solid #c0392b; color: #e74c3c; }
+
+        /* ── 요약 카드 ── */
+        .summary-card {
+            background: #17172a; border: 1px solid #2a2a4a;
+            border-radius: 14px; padding: 18px; margin: 12px 0;
+        }
+        .summary-title { font-size: 11px; font-weight: 700; color: #6c6cff; letter-spacing: 0.7px; text-transform: uppercase; margin-bottom: 12px; }
+        .summary-row { display: flex; justify-content: space-between; align-items: center; padding: 7px 0; }
+        .summary-label { font-size: 13px; color: #888; }
+        .summary-val { font-size: 13px; font-weight: 700; }
+        .summary-val.warn { color: #e74c3c; }
+        .modify-hint { margin-top: 14px; font-size: 12px; color: #555; text-align: center; line-height: 1.5; }
+
+        /* ── 하단 고정 버튼 ── */
+        .bottom-bar {
+            position: fixed; bottom: 0; left: 0; right: 0;
+            padding: 14px 20px; background: #111; border-top: 1px solid #1e1e1e;
+        }
+        .bottom-bar-inner { max-width: 420px; margin: 0 auto; display: flex; gap: 10px; }
+        .btn {
+            flex: 1; padding: 16px; border-radius: 14px; border: none;
+            font-size: 16px; font-weight: 700; cursor: pointer; transition: all 0.2s;
+        }
+        .btn:disabled { opacity: 0.3; cursor: not-allowed; }
+        .btn:not(:disabled):active { transform: scale(0.97); }
+        .btn-blue  { background: #4a90d9; color: #fff; }
+        .btn-red   { background: #e74c3c; color: #fff; }
+        .btn-ghost { background: transparent; border: 1px solid #444; color: #aaa; }
+
+        /* ── 결과 화면 ── */
+        #resultScreen {
+            min-height: 100vh; display: flex; flex-direction: column;
+            align-items: center; justify-content: center; padding: 48px 24px;
+            text-align: center; transition: background 0.5s;
+        }
+        .mascot-box { margin-bottom: 20px; }
+        .mascot-main { font-size: 80px; line-height: 1; display: block; }
+        .mascot-badge {
+            display: inline-block; margin-top: 8px; padding: 4px 14px;
+            border-radius: 20px; font-size: 12px; font-weight: 700;
+        }
+        .badge-smile      { background: rgba(255,215,0,.15);  color: #ffd700; }
+        .badge-very-happy { background: rgba(39,174,96,.15);  color: #27ae60; }
+        .badge-sad        { background: rgba(74,144,217,.15); color: #4a90d9; }
+
+        .res-title { font-size: 24px; font-weight: 700; margin-bottom: 8px; }
+        .res-msg   { font-size: 15px; color: #bbb; line-height: 1.6; margin-bottom: 28px; padding: 0 12px; }
+
+        .res-detail {
+            background: #1a1a1a; border-radius: 16px; padding: 20px;
+            width: 100%; max-width: 340px; margin-bottom: 16px;
+        }
+        .rrow { display: flex; justify-content: space-between; padding: 9px 0; border-bottom: 1px solid #222; }
+        .rrow:last-child { border-bottom: none; }
+        .rrow-label { font-size: 13px; color: #888; }
+        .rrow-value { font-size: 14px; font-weight: 700; }
+
+        .reminder-box {
+            background: #15152a; border: 1px solid #303060; border-radius: 14px;
+            padding: 14px 18px; width: 100%; max-width: 340px; margin-bottom: 16px; text-align: left;
+        }
+        .reminder-head { font-size: 12px; color: #7c7cff; font-weight: 700; margin-bottom: 5px; }
+        .reminder-body { font-size: 13px; color: #999; line-height: 1.5; }
+
+        .home-btn { width: 100%; max-width: 340px; }
     </style>
 </head>
 <body>
 
-<!-- 로그인 화면 (개발용: 자동 생성) -->
-<div id="loginScreen" class="login-screen">
+<!-- ① 로그인 화면 -->
+<div id="loginScreen" class="entry-screen">
+    <div class="entry-emoji">🦝</div>
     <h1>구매 숙려 테스트</h1>
     <p>개발용 테스트 유저를 생성합니다</p>
-    <button class="login-btn kakao" onclick="createDevUser()">테스트 유저로 시작</button>
+    <button id="loginBtn" class="primary-btn" onclick="createDevUser()">테스트 유저로 시작</button>
+    <p id="loginMsg" class="entry-msg"></p>
 </div>
 
-<!-- 셋업 화면 -->
-<div id="setupScreen" class="setup-screen hidden">
+<!-- ② 셋업 화면 -->
+<div id="setupScreen" class="entry-screen hidden">
+    <div class="entry-emoji">🛍️</div>
     <h2>구매 숙려 화면 테스트</h2>
     <p>24시간이 경과한 테스트 위시를<br>자동으로 생성합니다</p>
-    <button class="create-btn" id="createBtn" onclick="createTestWish()">테스트 위시 만들기</button>
-    <p id="setupMsg" style="color:#888;font-size:13px;margin-top:8px"></p>
+    <button id="createBtn" class="primary-btn" onclick="createTestWish()">테스트 위시 만들기</button>
+    <p id="setupMsg" class="entry-msg"></p>
 </div>
 
-<!-- 숙려 화면 -->
-<div id="deliberationScreen" class="deliberation-screen hidden">
-
-    <div class="section-title">구매 예정 상품</div>
-    <div class="product-card">
-        <img id="productImg" alt="상품 이미지">
-        <div class="product-category" id="productCategory"></div>
-        <div class="product-title" id="productTitle"></div>
-        <div class="product-price" id="productPrice"></div>
+<!-- ③ 탭 1: 상품 정보 -->
+<div id="productScreen" class="step-screen hidden">
+    <div class="step-header">
+        <span style="width:40px;"></span>
+        <div class="step-dots">
+            <div class="step-dot on"></div>
+            <div class="step-dot"></div>
+        </div>
+        <span class="step-label">1 / 2</span>
     </div>
 
-    <div class="section-title">이번 달 예산</div>
-    <div class="budget-card">
-        <div class="budget-row">
-            <span class="budget-label">이번 달 예산</span>
-            <span class="budget-value" id="budgetMonthly">-</span>
+    <div class="step-body">
+        <!-- 상품 카드 -->
+        <div class="card">
+            <img id="productImg" class="product-img" alt="상품 이미지">
+            <div class="product-category" id="productCategory"></div>
+            <div class="product-name" id="productName"></div>
+            <div class="product-price" id="productPrice"></div>
         </div>
-        <div class="budget-row">
-            <span class="budget-label">사용한 금액</span>
-            <span class="budget-value" id="budgetSpent">-</span>
+
+        <!-- 이번 달 예산 -->
+        <div class="card">
+            <div class="card-label">이번 달 예산</div>
+            <div class="brow">
+                <span class="brow-label">월 예산</span>
+                <span class="brow-value" id="budgetMonthly"></span>
+            </div>
+            <div class="brow">
+                <span class="brow-label">이달 소비</span>
+                <span class="brow-value orange" id="budgetSpent"></span>
+            </div>
+            <div class="brow">
+                <span class="brow-label">남은 예산</span>
+                <span class="brow-value blue" id="budgetRemaining"></span>
+            </div>
+            <div class="budget-bar">
+                <div class="budget-bar-fill" id="budgetBarFill" style="width:0%"></div>
+            </div>
+            <div class="budget-pct" id="budgetPctLabel"></div>
         </div>
-        <div class="budget-row">
-            <span class="budget-label">남은 예산</span>
-            <span class="budget-value budget-remaining" id="budgetRemaining">-</span>
+
+        <!-- 소비 이력 -->
+        <div class="card">
+            <div class="card-label">소비 이력</div>
+            <div class="srow">
+                <span class="srow-label">같은 카테고리 이달 소비</span>
+                <span class="srow-value yellow" id="similarSpend"></span>
+            </div>
+            <div class="opportunity-pill" id="opportunityPill"></div>
         </div>
-        <div class="budget-bar"><div class="budget-bar-fill" id="budgetBarFill" style="width:0%"></div></div>
     </div>
 
-    <div class="section-title">충동구매 점검</div>
-    <div id="questionList"></div>
-
-    <div class="warning-banner" id="warningBanner"></div>
-
-    <div class="section-title">이번 달 소비 현황</div>
-    <div class="stats-card">
-        <div class="stat-row">
-            <span class="stat-label">이번 달 사용 금액</span>
-            <span class="stat-value red" id="statSpent">-</span>
-        </div>
-        <div class="stat-row">
-            <span class="stat-label">같은 카테고리 소비</span>
-            <span class="stat-value yellow" id="statIrrational">-</span>
-        </div>
-        <div class="stat-row">
-            <span class="stat-label">기회비용 메시지</span>
-            <span class="stat-value blue" id="statOpportunity">-</span>
+    <div class="bottom-bar">
+        <div class="bottom-bar-inner">
+            <button class="btn btn-blue" onclick="goToQuestions()">다음</button>
         </div>
     </div>
-
 </div>
 
-<!-- 결정 버튼 (하단 고정) -->
-<div class="decision-area" id="decisionArea">
-    <div class="decision-buttons">
-        <button class="decision-btn restrain" id="restrainBtn" onclick="decide('STOP')" disabled>참을게요</button>
-        <button class="decision-btn buy" id="buyBtn" onclick="decide('GO')" disabled>살게요</button>
+<!-- ④ 탭 2: 자가점검 -->
+<div id="questionScreen" class="step-screen hidden">
+    <div class="step-header">
+        <button class="step-back" onclick="goToProduct()">← 뒤로</button>
+        <div class="step-dots">
+            <div class="step-dot"></div>
+            <div class="step-dot on"></div>
+        </div>
+        <span class="step-label">2 / 2</span>
+    </div>
+
+    <div class="step-body">
+        <!-- 상품 리마인더 -->
+        <div style="display:flex;justify-content:space-between;align-items:center;background:#1a1a1a;border-radius:12px;padding:12px 16px;margin-bottom:16px;">
+            <span id="qName" style="font-size:14px;color:#ccc;"></span>
+            <span id="qPrice" style="font-size:14px;font-weight:700;color:#ffd700;"></span>
+        </div>
+
+        <!-- 질문 목록 -->
+        <div id="questionList"></div>
+
+        <!-- 경고 배너 -->
+        <div class="alert danger hidden" id="warningBanner"></div>
+
+        <!-- 요약 카드 -->
+        <div class="summary-card hidden" id="summaryCard">
+            <div class="summary-title">지금까지 확인한 내용</div>
+            <div class="summary-row">
+                <span class="summary-label">이 상품 구매 시 예산 사용률</span>
+                <span class="summary-val" id="sumBudgetPct"></span>
+            </div>
+            <div class="summary-row">
+                <span class="summary-label">충동구매 신호 (Yes 답변)</span>
+                <span class="summary-val" id="sumYesCount"></span>
+            </div>
+            <div class="summary-row" id="sumOppRow">
+                <span class="summary-label">기회비용</span>
+                <span class="summary-val" style="font-size:12px;max-width:55%;text-align:right;" id="sumOpp"></span>
+            </div>
+            <div class="modify-hint">나중에 마음이 바뀌면<br>소비 관리에서 수정할 수 있어요</div>
+        </div>
+
+        <!-- 에러 -->
+        <div class="alert err hidden" id="errorBanner"></div>
+    </div>
+
+    <div class="bottom-bar">
+        <div class="bottom-bar-inner">
+            <button class="btn btn-blue" id="stopBtn" onclick="decide('STOP')" disabled>참을게요</button>
+            <button class="btn btn-red"  id="goBtn"   onclick="decide('GO')"   disabled>살게요</button>
+        </div>
     </div>
 </div>
 
-<!-- 결과 화면 -->
-<div id="resultScreen" class="result-screen hidden">
-    <h2 id="resultEmoji"></h2>
-    <h2 id="resultTitle"></h2>
-    <p id="resultDesc"></p>
-    <div class="result-stats">
-        <div class="result-row">
-            <span style="color:#aaa;font-size:14px">Yes 응답 수</span>
-            <span style="font-weight:700" id="resYesCount"></span>
+<!-- ⑤ 결과 화면 -->
+<div id="resultScreen" class="hidden">
+    <div class="mascot-box">
+        <span class="mascot-main" id="resMascotEmoji"></span>
+        <span class="mascot-badge" id="resMascotBadge"></span>
+    </div>
+
+    <div class="res-title" id="resTitle"></div>
+    <div class="res-msg"   id="resMsg"></div>
+
+    <div class="res-detail">
+        <div class="rrow">
+            <span class="rrow-label">결정</span>
+            <span class="rrow-value" id="resDecision"></span>
         </div>
-        <div class="result-row">
-            <span style="color:#aaa;font-size:14px">결정 후 이달 소비</span>
-            <span style="font-weight:700;color:#e74c3c" id="resSpent"></span>
+        <div class="rrow">
+            <span class="rrow-label">Yes 응답</span>
+            <span class="rrow-value" id="resYesCount"></span>
         </div>
-        <div class="result-row">
-            <span style="color:#aaa;font-size:14px">합리성 판정</span>
-            <span style="font-weight:700;color:#ffd700" id="resIrrational"></span>
+        <div class="rrow">
+            <span class="rrow-label">합리성 판정</span>
+            <span class="rrow-value" id="resRationality"></span>
         </div>
-        <div class="result-row">
-            <span style="color:#aaa;font-size:14px">같은 카테고리 소비</span>
-            <span style="font-weight:700;color:#4a90d9" id="resOpportunity"></span>
+        <div class="rrow">
+            <span class="rrow-label">결정 후 이달 소비</span>
+            <span class="rrow-value" id="resSpent"></span>
         </div>
     </div>
-    <button class="reset-btn" onclick="location.reload()">다시 테스트</button>
+
+    <!-- 7일 후 만족도 체크 (GO일 때) -->
+    <div class="reminder-box hidden" id="reminderBox">
+        <div class="reminder-head">📅 7일 후 만족도 체크</div>
+        <div class="reminder-body" id="reminderBody"></div>
+    </div>
+
+    <div class="home-btn">
+        <button class="btn btn-ghost" style="width:100%" onclick="location.reload()">홈으로 돌아가기</button>
+    </div>
 </div>
 
 <script>
-    let wishId = null;
-    let devUserId = null;
-    let questions = [];
-    let answers = {};
+    let devUserId       = null;
+    let wishId          = null;
+    let deliberationData = null;
+    let questions       = [];
+    let answers         = {};
 
-    const fmt = n => n == null ? '미설정' : n.toLocaleString() + '원';
+    const fmt = n => (n == null) ? '미설정' : Number(n).toLocaleString() + '원';
 
     function authHeaders() {
         const h = { 'Content-Type': 'application/json' };
@@ -211,153 +361,213 @@
         return h;
     }
 
-    // ─── 개발용 유저 생성 ─────────────────────────────────
+    function show(id) {
+        ['loginScreen','setupScreen','productScreen','questionScreen','resultScreen'].forEach(s => {
+            document.getElementById(s).classList.add('hidden');
+        });
+        document.getElementById(id).classList.remove('hidden');
+        window.scrollTo(0, 0);
+    }
+
+    // ① 테스트 유저 생성
     async function createDevUser() {
-        const btn = document.querySelector('#loginScreen .login-btn');
-        btn.disabled = true;
-        btn.textContent = '생성 중...';
+        const btn = document.getElementById('loginBtn');
+        const msg = document.getElementById('loginMsg');
+        btn.disabled = true; btn.textContent = '생성 중...';
         try {
             const res = await fetch('/api/dev/users/test', { method: 'POST' });
-            if (!res.ok) { btn.disabled = false; btn.textContent = '테스트 유저로 시작'; return; }
+            if (!res.ok) {
+                msg.textContent = '유저 생성 실패: ' + res.status + ' — 서버 재시작 필요할 수 있음';
+                btn.disabled = false; btn.textContent = '테스트 유저로 시작';
+                return;
+            }
             const data = await res.json();
             devUserId = data.userId;
             show('setupScreen');
         } catch (e) {
-            btn.disabled = false;
-            btn.textContent = '테스트 유저로 시작';
+            msg.textContent = '오류: ' + e.message;
+            btn.disabled = false; btn.textContent = '테스트 유저로 시작';
         }
     }
 
-    // ─── 초기화 ──────────────────────────────────────────
-    async function init() {
-        show('loginScreen');
-    }
-
-    // ─── 테스트 위시 생성 ─────────────────────────────────
+    // ② 테스트 위시 생성
     async function createTestWish() {
         const btn = document.getElementById('createBtn');
         const msg = document.getElementById('setupMsg');
-        btn.disabled = true;
-        btn.textContent = '생성 중...';
-
-        const res = await fetch('/api/dev/wishes/test', {
-            method: 'POST',
-            headers: authHeaders()
-        });
-        if (!res.ok) {
-            msg.textContent = '오류: ' + (await res.text());
-            btn.disabled = false;
-            btn.textContent = '테스트 위시 만들기';
-            return;
+        btn.disabled = true; btn.textContent = '생성 중...';
+        try {
+            const res = await fetch('/api/dev/wishes/test', {
+                method: 'POST', headers: authHeaders()
+            });
+            if (!res.ok) {
+                const body = await res.text().catch(() => '');
+                msg.textContent = `위시 생성 실패: ${res.status} ${body}`;
+                btn.disabled = false; btn.textContent = '테스트 위시 만들기';
+                return;
+            }
+            const data = await res.json();
+            wishId = data.itemId;
+            msg.textContent = 'itemId: ' + wishId;
+            await loadDeliberation();
+        } catch (e) {
+            msg.textContent = '오류: ' + e.message;
+            btn.disabled = false; btn.textContent = '테스트 위시 만들기';
         }
-        const data = await res.json();
-        wishId = data.itemId;
-        msg.textContent = `itemId: ${wishId}`;
-
-        await loadDeliberation();
     }
 
-    // ─── 숙려 화면 로드 ───────────────────────────────────
+    // ③ 숙려 데이터 로드
     async function loadDeliberation() {
-        const res = await fetch(`/api/v1/deliberations/items/${wishId}`, {
-            headers: authHeaders()
-        });
-        if (!res.ok) {
-            const body = await res.text().catch(() => '');
-            alert(`숙려 화면 로드 실패: ${res.status}\nX-User-Id: ${devUserId}\n${body}`);
-            return;
+        try {
+            const res = await fetch(`/api/v1/deliberations/items/${wishId}`, {
+                headers: authHeaders()
+            });
+            if (!res.ok) {
+                const body = await res.text().catch(() => '');
+                alert(`숙려 화면 로드 실패: ${res.status}\nX-User-Id: ${devUserId}\n${body}`);
+                return;
+            }
+            deliberationData = await res.json();
+            renderProductScreen();
+            show('productScreen');
+        } catch (e) {
+            alert('숙려 데이터 로드 오류: ' + e.message);
         }
-        const data = await res.json();
+    }
+
+    // ③ 상품 화면 렌더링
+    function renderProductScreen() {
+        const d = deliberationData;
 
         // 상품 정보
-        document.getElementById('productCategory').textContent = data.item.category;
-        document.getElementById('productTitle').textContent = data.item.title;
-        document.getElementById('productPrice').textContent = fmt(data.item.listedPrice);
-        if (data.item.imageUrl) {
+        document.getElementById('productCategory').textContent = d.item.category ?? '';
+        document.getElementById('productName').textContent     = d.item.title;
+        document.getElementById('productPrice').textContent    = fmt(d.item.listedPrice);
+        if (d.item.imageUrl) {
             const img = document.getElementById('productImg');
-            img.src = data.item.imageUrl;
-            img.onload = () => img.classList.add('loaded');
+            img.src = d.item.imageUrl;
+            img.onload = () => img.classList.add('show');
         }
 
         // 예산 정보
-        const monthly = data.budget.monthlyBudgetAmount;
-        const spent = data.budget.spentAmount;
-        document.getElementById('budgetMonthly').textContent = fmt(monthly);
-        document.getElementById('budgetSpent').textContent = fmt(spent);
-        document.getElementById('budgetRemaining').textContent = monthly ? fmt(monthly - spent) : '미설정';
-        if (monthly) {
-            const pct = Math.min(100, (spent / monthly) * 100);
-            document.getElementById('budgetBarFill').style.width = pct + '%';
+        const monthly  = d.budget.monthlyBudgetAmount;
+        const spent    = d.budget.spentAmount;
+        const remaining = monthly ? monthly - spent : null;
+        const usedPct  = monthly ? Math.min(100, (spent / monthly) * 100) : 0;
+
+        document.getElementById('budgetMonthly').textContent   = monthly ? fmt(monthly) : '미설정';
+        document.getElementById('budgetSpent').textContent     = fmt(spent);
+        document.getElementById('budgetRemaining').textContent = remaining != null ? fmt(remaining) : '미설정';
+        document.getElementById('budgetPctLabel').textContent  = monthly ? `현재 ${usedPct.toFixed(1)}% 사용` : '';
+
+        const bar = document.getElementById('budgetBarFill');
+        bar.style.width = usedPct + '%';
+        if (usedPct >= 80) bar.classList.add('over');
+
+        // 소비 이력
+        document.getElementById('similarSpend').textContent = fmt(d.similarCategorySpendAmount);
+        const opp = document.getElementById('opportunityPill');
+        if (d.opportunityCostMessage) {
+            opp.textContent = '💡 ' + d.opportunityCostMessage;
+        } else {
+            opp.style.display = 'none';
         }
+    }
 
-        // 통계 (deliberation 응답 기준)
-        document.getElementById('statSpent').textContent = fmt(spent);
-        document.getElementById('statIrrational').textContent = fmt(data.similarCategorySpendAmount);
-        document.getElementById('statOpportunity').textContent = data.opportunityCostMessage ?? '-';
+    // ④ 질문 화면으로 전환
+    function goToQuestions() {
+        questions = deliberationData.questions;
+        answers   = {};
 
-        // 질문 렌더링
-        questions = data.questions;
-        const list = document.getElementById('questionList');
-        list.innerHTML = questions.map(q => `
-            <div class="question-card">
+        document.getElementById('qName').textContent  = deliberationData.item.title;
+        document.getElementById('qPrice').textContent = fmt(deliberationData.item.listedPrice);
+
+        document.getElementById('questionList').innerHTML = questions.map(q => `
+            <div class="question-item">
                 <div class="question-text">${q.text}</div>
-                <div class="yn-buttons">
-                    <button class="yn-btn yes" data-q="${q.code}" data-v="true" onclick="selectAnswer('${q.code}', true, this)">Y</button>
-                    <button class="yn-btn no"  data-q="${q.code}" data-v="false" onclick="selectAnswer('${q.code}', false, this)">N</button>
+                <div class="yn-wrap">
+                    <button class="yn-btn yes" data-q="${q.code}" onclick="pick('${q.code}', true, this)">Y</button>
+                    <button class="yn-btn no"  data-q="${q.code}" onclick="pick('${q.code}', false, this)">N</button>
                 </div>
             </div>
         `).join('');
 
-        show('deliberationScreen');
-        document.getElementById('decisionArea').style.display = 'block';
+        document.getElementById('warningBanner').classList.add('hidden');
+        document.getElementById('summaryCard').classList.add('hidden');
+        document.getElementById('errorBanner').classList.add('hidden');
+        document.getElementById('stopBtn').disabled = true;
+        document.getElementById('goBtn').disabled   = true;
+
+        show('questionScreen');
     }
 
-    // ─── 답변 선택 ────────────────────────────────────────
-    function selectAnswer(qId, value, btn) {
-        answers[qId] = value;
+    function goToProduct() { show('productScreen'); }
 
-        // 같은 질문 버튼 스타일 리셋
-        document.querySelectorAll(`[data-q="${qId}"]`).forEach(b => {
-            b.classList.remove('selected');
-        });
-        btn.classList.add('selected');
-
-        updateWarning();
-        updateDecisionBtns();
+    // ④ 답변 선택
+    function pick(code, value, btn) {
+        answers[code] = value;
+        document.querySelectorAll(`[data-q="${code}"]`).forEach(b => b.classList.remove('on'));
+        btn.classList.add('on');
+        updateQuestionUI();
     }
 
-    function updateWarning() {
-        const yesCount = Object.values(answers).filter(v => v === true).length;
-        const answeredCount = Object.keys(answers).length;
-        const banner = document.getElementById('warningBanner');
+    function updateQuestionUI() {
+        const allDone   = Object.keys(answers).length === questions.length;
+        const yesCount  = Object.values(answers).filter(Boolean).length;
+        const irrational = yesCount >= 2;
 
-        if (answeredCount < questions.length) {
-            banner.style.display = 'none';
+        const warning = document.getElementById('warningBanner');
+        const summary = document.getElementById('summaryCard');
+
+        if (!allDone) {
+            warning.classList.add('hidden');
+            summary.classList.add('hidden');
+            document.getElementById('stopBtn').disabled = true;
+            document.getElementById('goBtn').disabled   = true;
             return;
         }
 
-        banner.style.display = 'block';
-        if (yesCount >= 2) {
-            banner.className = 'warning-banner danger';
-            banner.textContent = `⚠️ Yes ${yesCount}개 — 충동구매일 가능성이 높아요!`;
+        // 경고 배너
+        warning.classList.remove('hidden');
+        if (irrational) {
+            warning.className = 'alert danger';
+            warning.textContent = `⚠️ Yes ${yesCount}개 — 이거 충동구매인데 괜찮을까요?`;
         } else {
-            banner.className = 'warning-banner safe';
-            banner.textContent = `✅ Yes ${yesCount}개 — 신중한 구매예요.`;
+            warning.className = 'alert safe';
+            warning.textContent = `✅ Yes ${yesCount}개 — 신중한 소비예요.`;
         }
+
+        // 요약 카드
+        const d = deliberationData;
+        const projRate = parseFloat(d.budget.projectedUsageRate ?? 0); // 이미 0~100 퍼센트 값
+        document.getElementById('sumBudgetPct').textContent = projRate.toFixed(1) + '%';
+        document.getElementById('sumBudgetPct').className  = 'summary-val' + (projRate >= 100 ? ' warn' : '');
+
+        document.getElementById('sumYesCount').textContent = `${yesCount}개 / 4개`;
+        document.getElementById('sumYesCount').className   = 'summary-val' + (irrational ? ' warn' : '');
+
+        const oppRow = document.getElementById('sumOppRow');
+        if (d.opportunityCostMessage) {
+            document.getElementById('sumOpp').textContent = d.opportunityCostMessage;
+            oppRow.style.display = '';
+        } else {
+            oppRow.style.display = 'none';
+        }
+
+        summary.classList.remove('hidden');
+
+        document.getElementById('stopBtn').disabled = false;
+        document.getElementById('goBtn').disabled   = false;
     }
 
-    function updateDecisionBtns() {
-        const allAnswered = Object.keys(answers).length === questions.length;
-        document.getElementById('restrainBtn').disabled = !allAnswered;
-        document.getElementById('buyBtn').disabled = !allAnswered;
-    }
-
-    // ─── 결정 제출 ────────────────────────────────────────
+    // ⑤ 결정 제출
     async function decide(decision) {
-        document.getElementById('restrainBtn').disabled = true;
-        document.getElementById('buyBtn').disabled = true;
+        document.getElementById('stopBtn').disabled = true;
+        document.getElementById('goBtn').disabled   = true;
 
-        const selfCheckAnswers = questions.map(q => ({ questionCode: q.code, answerBoolean: answers[q.code] }));
+        const selfCheckAnswers = questions.map(q => ({
+            questionCode: q.code,
+            answerBoolean: answers[q.code]
+        }));
 
         try {
             const res = await fetch('/api/v1/decisions', {
@@ -365,73 +575,78 @@
                 headers: authHeaders(),
                 body: JSON.stringify({ itemId: wishId, result: decision, selfCheckAnswers })
             });
-
-            const text = await res.text();
-            console.log('[decide] status:', res.status, 'body:', text);
-
             if (!res.ok) {
-                showError(`서버 오류 ${res.status}: ${text}`);
+                const body = await res.text().catch(() => '');
+                showError(`서버 오류 ${res.status}: ${body}`);
                 return;
             }
-
-            const data = JSON.parse(text);
-            showResult(data);
+            const data = await res.json();
+            renderResult(data);
         } catch (e) {
-            console.error('[decide] 예외:', e);
             showError('네트워크 오류: ' + e.message);
         }
     }
 
     function showError(msg) {
-        document.getElementById('restrainBtn').disabled = false;
-        document.getElementById('buyBtn').disabled = false;
-        const banner = document.getElementById('warningBanner');
-        banner.style.display = 'block';
-        banner.className = 'warning-banner danger';
-        banner.textContent = '❌ ' + msg;
+        document.getElementById('stopBtn').disabled = false;
+        document.getElementById('goBtn').disabled   = false;
+        const el = document.getElementById('errorBanner');
+        el.textContent = '❌ ' + msg;
+        el.classList.remove('hidden');
     }
 
-    // ─── 결과 화면 ────────────────────────────────────────
-    function showResult(data) {
-        const isBought = data.result === 'GO';
-        document.getElementById('resultEmoji').textContent = isBought ? '🛍️' : '💪';
-        document.getElementById('resultTitle').textContent = isBought ? '구매했어요' : '참았어요!';
-        const isIrrational = data.rationalityResult === 'IRRATIONAL';
-        document.getElementById('resultDesc').textContent = isIrrational
-            ? `⚠️ Yes ${data.selfCheckYesCount}개 — 충동구매 경고가 있었어요`
-            : `✅ Yes ${data.selfCheckYesCount}개 — 신중한 선택이었어요`;
+    // ⑤ 결과 화면 렌더링
+    function renderResult(data) {
+        const state      = data.mascotReaction?.state ?? 'SMILE';
+        const mascotMsg  = data.mascotReaction?.message ?? '';
+        const isBought   = data.result === 'GO';
+        const irrational = data.rationalityResult === 'IRRATIONAL';
 
-        document.getElementById('resYesCount').textContent = `${data.selfCheckYesCount}개`;
-        document.getElementById('resSpent').textContent = fmt(data.budgetAfterAmount);
-        document.getElementById('resIrrational').textContent = isIrrational ? '비합리적' : '합리적';
-        document.getElementById('resOpportunity').textContent = fmt(data.similarCategorySpendAmount);
+        // 마스코트 상태별 설정
+        const MASCOT = {
+            SMILE:      { emoji: '🦝☀️', badge: '미소',    badgeClass: 'badge-smile',      bg: 'linear-gradient(180deg,#111 0%,#1a1800 100%)' },
+            VERY_HAPPY: { emoji: '🦝🎉', badge: '기쁨',    badgeClass: 'badge-very-happy',  bg: 'linear-gradient(180deg,#111 0%,#0a1f10 100%)' },
+            SAD:        { emoji: '🦝🌧️', badge: '슬픔',    badgeClass: 'badge-sad',         bg: 'linear-gradient(180deg,#111 0%,#0a1220 100%)' },
+        };
+        const m = MASCOT[state] ?? MASCOT.SMILE;
 
-        document.getElementById('decisionArea').style.display = 'none';
+        document.getElementById('resMascotEmoji').textContent = m.emoji;
+        const badge = document.getElementById('resMascotBadge');
+        badge.textContent  = m.badge;
+        badge.className    = 'mascot-badge ' + m.badgeClass;
+
+        document.getElementById('resultScreen').style.background = m.bg;
+
+        // 결정 제목
+        document.getElementById('resTitle').textContent = isBought ? '살게요! 🛍️' : '참을게요! 💪';
+
+        // 너구리 멘트
+        document.getElementById('resMsg').textContent = mascotMsg;
+
+        // 상세 정보
+        document.getElementById('resDecision').textContent   = isBought ? '구매' : '절제';
+        document.getElementById('resYesCount').textContent   = data.selfCheckYesCount + '개';
+        document.getElementById('resRationality').textContent = irrational ? '비합리적' : '합리적';
+        document.getElementById('resSpent').textContent      = fmt(data.budgetAfterAmount);
+
+        // 7일 후 만족도 (GO일 때만)
+        const reminderBox = document.getElementById('reminderBox');
+        if (data.reminder) {
+            const when = data.reminder.scheduledFor
+                ? new Date(data.reminder.scheduledFor).toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' })
+                : '7일 후';
+            document.getElementById('reminderBody').textContent =
+                `${when}에 구매 만족도를 확인할게요!\n" 벌써 일주일 지났구리! 위시 돌아보기 클릭 "`;
+            reminderBox.classList.remove('hidden');
+        } else {
+            reminderBox.classList.add('hidden');
+        }
+
         show('resultScreen');
     }
 
-    // ─── 화면 전환 ────────────────────────────────────────
-    const SCREEN_DISPLAY = {
-        loginScreen: 'flex',
-        setupScreen: 'flex',
-        deliberationScreen: 'block',
-        resultScreen: 'flex'
-    };
-
-    function show(id) {
-        Object.keys(SCREEN_DISPLAY).forEach(s => {
-            const el = document.getElementById(s);
-            if (s === id) {
-                el.classList.remove('hidden');
-                el.style.display = SCREEN_DISPLAY[s];
-            } else {
-                el.classList.add('hidden');
-                el.style.display = 'none';
-            }
-        });
-    }
-
-    init();
+    // 시작
+    show('loginScreen');
 </script>
 </body>
 </html>


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크
- Tracking Key: NF-39
- Jira: NF-39

> PR 제목: `NF-39 숙려 화면 UI 누락 항목 보완`  
> 브랜치: `test/deliberation-complete-ui`

---

### 🔒 Close Issue
- GitHub: Closes #68 

---

## 🧩 한눈에 요약

### 어떤 버그였나?
- 숙려 화면에서 백엔드 API가 필요한 데이터를 정상 반환하고 있었지만, HTML/UI에서 일부 스펙 항목이 반영되지 않았습니다.
- 탭 전환 버튼, 자가점검 요약, 결과 화면 분기, 7일 후 만족도 알림, 홈 이동 버튼 등이 화면에 누락되거나 단순 처리되어 있었습니다.

### 왜 발생했나? Root Cause
- 백엔드 응답 데이터와 화면 스펙은 준비되어 있었지만, `deliberation.html`에서 해당 값을 사용하는 UI 렌더링 로직이 완성되지 않았습니다.
- 결과 화면의 경우 `mascotReaction.state`, `mascotReaction.message`, 사용자 선택값을 기준으로 한 분기 처리가 부족했습니다.
- GO 선택 시 반환되는 `reminder` 데이터도 화면에서 활용되지 않았습니다.

### 어떻게 고쳤나?
- 탭 1에서 상품 정보, 예산 카드, 소비이력, 기회비용 멘트, 다음 버튼 흐름을 완성했습니다.
- 탭 2에서 4가지 자가점검 질문, 전체 답변 후 경고 배너, 예산 사용률, 비합리 답변 수, 기회비용 요약을 표시하도록 수정했습니다.
- 결과 화면에서 합리/비합리 판단과 GO/STOP 선택에 따라 너구리 상태와 API 멘트가 다르게 표시되도록 분기 처리했습니다.
- GO 선택 시 7일 후 만족도 알림 정보를 표시하도록 보완했습니다.
- 기존 “다시 테스트” 버튼을 “홈으로 돌아가기” 버튼으로 정리했습니다.

---

## 🧯 재현 & 검증

### 재현 방법
- Steps:
  1. `feat/9-feed-product-section` 또는 `test/deliberation-complete-ui` 브랜치로 서버를 실행합니다.
  2. 브라우저에서 `http://localhost:8080/deliberation.html`에 접속합니다.
  3. 탭 1 상품 정보 화면을 확인합니다.
  4. 다음 버튼을 눌러 탭 2 자가점검 화면으로 이동합니다.
  5. 4가지 질문에 모두 답변합니다.
  6. `살게요` 또는 `참을게요` 버튼을 선택합니다.
  7. 결과 화면의 너구리 상태, 멘트, 알림 표시 여부를 확인합니다.

- 기대 결과:
  - 탭 1에서 상품 정보, 예산, 소비이력, 기회비용, 다음 버튼이 정상 표시됩니다.
  - 탭 2에서 4가지 질문과 답변 완료 후 요약 영역이 정상 표시됩니다.
  - 결과 화면이 합리/비합리 판단과 GO/STOP 선택에 따라 다르게 표시됩니다.
  - GO 선택 시 7일 후 만족도 알림 정보가 표시됩니다.
  - 홈으로 돌아가기 버튼이 표시됩니다.

- 실제 결과:
  - 수정 후 기대 결과대로 동작합니다.

### 재발 방지
- [ ] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [x] 문서 보강

---

## ✅ Acceptance Criteria

- [x] AC1: 탭 1에서 상품 사진, 이름, 카테고리, 가격, 예산, 소비이력, 기회비용 멘트가 표시된다.
- [x] AC2: 탭 1에서 다음 버튼을 통해 탭 2 자가점검 화면으로 이동할 수 있다.
- [x] AC3: 탭 2에서 4가지 질문에 모두 답변한 뒤 경고 배너와 요약 정보가 표시된다.
- [x] AC4: 예산 사용률, 비합리 답변 수, 기회비용 멘트가 요약 영역에 표시된다.
- [x] AC5: “소비 관리에서 수정 가능” 안내 문구가 표시된다.
- [x] AC6: 결과 화면이 합리/비합리 판단과 GO/STOP 선택에 따라 분기된다.
- [x] AC7: GO 선택 시 7일 후 만족도 알림 정보가 표시된다.
- [x] AC8: 결과 화면에서 홈으로 돌아가기 버튼이 표시된다.

---

## 🧪 테스트 / 검증

### 로컬
- Command:
  ```bash
  git checkout test/deliberation-complete-ui
  ./gradlew bootRun
  ```

- 접속:
  ```text
  http://localhost:8080/deliberation.html
  ```

- Result:
  - 숙려 화면 탭 1, 탭 2, 결과 화면 흐름을 수동 검증했습니다.

### CI
- 링크/결과: 자동 첨부 시 생략

### Smoke / 수동 검증
- 시나리오:
  - 상품 정보 화면 진입
  - 다음 버튼 클릭
  - 자가점검 4문항 응답
  - 합리 + GO 결과 확인
  - 비합리 + GO 결과 확인
  - 합리 + STOP 결과 확인
  - 비합리 + STOP 결과 확인
  - GO 선택 시 7일 후 만족도 알림 표시 확인
  - 홈으로 돌아가기 버튼 확인

- 결과:
  - 주요 숙려 화면 흐름이 정상 동작합니다.

### 테스트 공백
- 자동화 테스트는 추가하지 않았습니다.
- 이번 PR은 `deliberation.html` 중심의 UI 보완 작업이며, API 스펙 및 DB 변경 없이 화면 렌더링/분기 동작을 수동 검증했습니다.

---

## 🧭 영향 범위

- [x] API 스펙 변경 없음
- [ ] API 스펙 변경 있음
- [x] DB 스키마 변경 없음
- [ ] DB 스키마 변경 있음
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음
- [x] 캐시/큐/외부 연동 영향 없음
- [ ] 캐시/큐/외부 연동 영향 있음

---

## 💥 Breaking / Compatibility

- [x] Breaking change 없음
- [ ] Breaking change 있음

---

## 🚀 배포/릴리즈

### Feature Flag
- [x] 사용 안함
- [ ] 사용함

### 모니터링/알림
- 확인할 대시보드/지표:
  - 별도 없음

- 에러/로그 키워드:
  - 숙려 화면 진입 시 서버 로그
  - 브라우저 콘솔 에러
  - API 응답 누락 여부

---

## ⚠️ 리스크 & 롤백

### 리스크
- 결과 화면 분기 로직이 사용자 선택값과 API 응답값에 의존하므로, 응답 필드명이 변경되면 화면 표시가 깨질 수 있습니다.
- 현재는 HTML 기반 수동 검증 중심이므로, 추후 화면 흐름 변경 시 회귀 테스트가 부족할 수 있습니다.

### 롤백
- [ ] 플래그/설정으로 우회 가능
- [x] 배포 롤백 가능
- [ ] 데이터 롤백/역마이그레이션 필요

---

## 📸 증빙

- 스크린샷/로그/메트릭 링크:
  - 필요 시 첨부

- 전/후 비교:
  - Before: 백엔드 응답 데이터는 존재했지만 UI 일부 항목이 누락됨
  - After: 탭 1, 탭 2, 결과 화면, 7일 후 알림, 홈 버튼까지 숙려 화면 전체 흐름 반영

---

## 💬 리뷰 가이드

- 꼭 봐야 하는 파일/로직:
  - `deliberation.html` 제외하고 보시면 됩니다. 단순 html 파일입니다(보기 좋은용으로 AI 사용하였습니다)
  - 탭 1 → 탭 2 전환 로직
  - 자가점검 답변 완료 후 요약 렌더링 로직
  - GO/STOP 선택 결과 화면 분기 로직
  - `mascotReaction.state`, `mascotReaction.message` 표시 로직
  - `reminder` 표시 로직

- 트레이드오프/대안:
  - 별도 프론트 프레임워크 없이 HTML/JS 기반으로 빠르게 숙려 화면 전체 흐름을 검증할 수 있도록 구현했습니다.
  - 화면 구조가 커질 경우 추후 컴포넌트 분리 또는 프론트엔드 구조화가 필요할 수 있습니다.

- 성능/보안/호환성 영향:
  - API 스펙, DB 스키마, 인증/인가, 외부 연동 변경은 없습니다.
  - 기존 백엔드 응답 데이터를 화면에 반영하는 UI 수정입니다.