### PR TITLE
[Docs] NF-40 Swagger 기반 API 명세 문서화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.jsoup:jsoup:1.18.3'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.17'
 	runtimeOnly 'org.flywaydb:flyway-database-postgresql'
 	runtimeOnly 'org.postgresql:postgresql'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/sagongsa/backend/auth/AuthApiController.java
+++ b/src/main/java/com/sagongsa/backend/auth/AuthApiController.java
@@ -1,5 +1,8 @@
 package com.sagongsa.backend.auth;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.Instant;
 import java.util.List;
 import org.springframework.http.HttpStatus;
@@ -17,6 +20,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/auth")
+@Tag(name = "Auth", description = "OAuth login session and JWT refresh APIs")
 public class AuthApiController {
 
 	private final JwtTokenService jwtTokenService;
@@ -26,6 +30,14 @@ public class AuthApiController {
 	}
 
 	@GetMapping("/me")
+	@Operation(
+		summary = "Get authenticated user",
+		description = "Returns the current OAuth or JWT user profile used by the app after login.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "Authenticated user profile"),
+			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication")
+		}
+	)
 	public AuthenticatedUserResponse me(Authentication authentication) {
 		SocialUserProfile profile = extractProfile(authentication);
 		List<String> authorities = authentication.getAuthorities().stream()
@@ -47,6 +59,14 @@ public class AuthApiController {
 	}
 
 	@PostMapping("/token/refresh")
+	@Operation(
+		summary = "Refresh access token",
+		description = "Issues a new access token and refresh token pair from a valid refresh token.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "Token pair refreshed"),
+			@ApiResponse(responseCode = "401", description = "Refresh token is invalid")
+		}
+	)
 	public TokenRefreshResponse refresh(@RequestBody TokenRefreshRequest request) {
 		try {
 			JwtTokenService.TokenPair tokenPair = jwtTokenService.refresh(request.refreshToken());

--- a/src/main/java/com/sagongsa/backend/config/OpenApiConfig.java
+++ b/src/main/java/com/sagongsa/backend/config/OpenApiConfig.java
@@ -1,0 +1,56 @@
+package com.sagongsa.backend.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.servers.Server;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("!prod")
+@OpenAPIDefinition(
+	info = @Info(
+		title = "404 Backend API",
+		version = "1.0.0",
+		description = "Frontend integration API contract for auth, onboarding, item import, wishlist, deliberation, decision, home, notification, and reflection flows.",
+		license = @License(name = "Internal")
+	),
+	servers = {
+		@Server(url = "/", description = "Current host")
+	}
+)
+@SecurityScheme(
+	name = "bearerAuth",
+	type = SecuritySchemeType.HTTP,
+	scheme = "bearer",
+	bearerFormat = "JWT"
+)
+public class OpenApiConfig {
+
+	@Bean
+	GroupedOpenApi frontendApi() {
+		return GroupedOpenApi.builder()
+			.group("frontend-api")
+			.pathsToMatch("/api/**")
+			.build();
+	}
+
+	@Bean
+	OpenApiCustomizer bearerAuthCustomizer() {
+		return openApi -> openApi.getPaths().forEach((path, pathItem) -> {
+			if ("/api/auth/token/refresh".equals(path)) {
+				return;
+			}
+
+			pathItem.readOperations().forEach(operation -> operation.addSecurityItem(
+				new io.swagger.v3.oas.models.security.SecurityRequirement().addList("bearerAuth")
+			));
+		});
+	}
+}

--- a/src/main/java/com/sagongsa/backend/config/SecurityConfig.java
+++ b/src/main/java/com/sagongsa/backend/config/SecurityConfig.java
@@ -73,6 +73,7 @@ public class SecurityConfig {
 					.requestMatchers("/api/auth/me").authenticated();
 
 				if (nonProd) {
+					auth.requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll();
 					auth.requestMatchers("/api/dev/**").permitAll();
 				}
 

--- a/src/main/java/com/sagongsa/backend/decision/DecisionController.java
+++ b/src/main/java/com/sagongsa/backend/decision/DecisionController.java
@@ -1,6 +1,10 @@
 package com.sagongsa.backend.decision;
 
 import com.sagongsa.backend.auth.CurrentUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/decisions")
+@Tag(name = "Decision", description = "Purchase decision result APIs")
 public class DecisionController {
 
 	private final DecisionService decisionService;
@@ -23,8 +28,20 @@ public class DecisionController {
 	}
 
 	@PostMapping
+	@Operation(
+		summary = "Complete purchase decision",
+		description = "Stores GO or STOP decision result, self-check answers, budget impact, mascot reaction, and reminder data.",
+		responses = {
+			@ApiResponse(responseCode = "201", description = "Decision completed"),
+			@ApiResponse(responseCode = "400", description = "Invalid decision payload"),
+			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication"),
+			@ApiResponse(responseCode = "403", description = "Item belongs to another user"),
+			@ApiResponse(responseCode = "404", description = "Item does not exist"),
+			@ApiResponse(responseCode = "409", description = "Decision already exists")
+		}
+	)
 	public ResponseEntity<DecisionResultResponse> complete(
-		@CurrentUserId UUID userId,
+		@Parameter(hidden = true) @CurrentUserId UUID userId,
 		@RequestBody(required = false) DecisionCompleteRequest request
 	) {
 		DecisionResultResponse response = decisionService.complete(userId, request);
@@ -34,16 +51,37 @@ public class DecisionController {
 	}
 
 	@GetMapping("/{decisionId}/result")
+	@Operation(
+		summary = "Get purchase decision result",
+		description = "Returns a previously completed purchase decision result screen payload.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "Decision result returned"),
+			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication"),
+			@ApiResponse(responseCode = "403", description = "Decision belongs to another user"),
+			@ApiResponse(responseCode = "404", description = "Decision does not exist")
+		}
+	)
 	public DecisionResultResponse getResult(
-		@CurrentUserId UUID userId,
+		@Parameter(hidden = true) @CurrentUserId UUID userId,
 		@PathVariable UUID decisionId
 	) {
 		return decisionService.getResult(userId, decisionId);
 	}
 
 	@PatchMapping("/{decisionId}/result")
+	@Operation(
+		summary = "Update purchase decision result",
+		description = "Updates GO or STOP result and self-check answers for an existing decision.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "Decision result updated"),
+			@ApiResponse(responseCode = "400", description = "Invalid decision update payload"),
+			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication"),
+			@ApiResponse(responseCode = "403", description = "Decision belongs to another user"),
+			@ApiResponse(responseCode = "404", description = "Decision does not exist")
+		}
+	)
 	public DecisionResultResponse updateResult(
-		@CurrentUserId UUID userId,
+		@Parameter(hidden = true) @CurrentUserId UUID userId,
 		@PathVariable UUID decisionId,
 		@RequestBody(required = false) DecisionResultUpdateRequest request
 	) {

--- a/src/main/java/com/sagongsa/backend/deliberation/DeliberationController.java
+++ b/src/main/java/com/sagongsa/backend/deliberation/DeliberationController.java
@@ -1,6 +1,10 @@
 package com.sagongsa.backend.deliberation;
 
 import com.sagongsa.backend.auth.CurrentUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -9,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/deliberations")
+@Tag(name = "Deliberation", description = "Purchase deliberation summary API")
 public class DeliberationController {
 
 	private final DeliberationService deliberationService;
@@ -18,8 +23,18 @@ public class DeliberationController {
 	}
 
 	@GetMapping("/items/{itemId}")
+	@Operation(
+		summary = "Get deliberation summary",
+		description = "Returns item, budget projection, similar category spend, and opportunity cost data for purchase deliberation.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "Deliberation summary returned"),
+			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication"),
+			@ApiResponse(responseCode = "403", description = "Item belongs to another user"),
+			@ApiResponse(responseCode = "404", description = "Item does not exist")
+		}
+	)
 	public DeliberationSummaryResponse getSummary(
-		@CurrentUserId UUID userId,
+		@Parameter(hidden = true) @CurrentUserId UUID userId,
 		@PathVariable UUID itemId
 	) {
 		return deliberationService.getSummary(userId, itemId);

--- a/src/main/java/com/sagongsa/backend/home/HomeSummaryController.java
+++ b/src/main/java/com/sagongsa/backend/home/HomeSummaryController.java
@@ -1,6 +1,10 @@
 package com.sagongsa.backend.home;
 
 import com.sagongsa.backend.auth.CurrentUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/home")
+@Tag(name = "Home", description = "Home screen summary API")
 public class HomeSummaryController {
 
 	private final HomeSummaryService homeSummaryService;
@@ -20,7 +25,17 @@ public class HomeSummaryController {
 	}
 
 	@GetMapping("/summary")
-	public HomeSummaryResponse getSummary(@CurrentUserId UUID userId) {
+	@Operation(
+		summary = "Get home summary",
+		description = "Returns user profile, mascot state, monthly budget summary, latest notifications, and rational choice rate for the home screen.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "Home summary returned"),
+			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication"),
+			@ApiResponse(responseCode = "403", description = "User cannot access this summary"),
+			@ApiResponse(responseCode = "404", description = "User account does not exist")
+		}
+	)
+	public HomeSummaryResponse getSummary(@Parameter(hidden = true) @CurrentUserId UUID userId) {
 		return homeSummaryService.getSummary(userId);
 	}
 

--- a/src/main/java/com/sagongsa/backend/itemimport/ItemImportController.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/ItemImportController.java
@@ -3,6 +3,9 @@ package com.sagongsa.backend.itemimport;
 import com.sagongsa.backend.itemimport.item.ShoppingLinkImportRequest;
 import com.sagongsa.backend.itemimport.item.ShoppingLinkImportResponse;
 import com.sagongsa.backend.itemimport.item.ShoppingLinkImportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/items")
+@Tag(name = "Item Import", description = "Shopping link preview API before saving an item to wishlist")
 public class ItemImportController {
 
 	private final ShoppingLinkImportService shoppingLinkImportService;
@@ -19,6 +23,15 @@ public class ItemImportController {
 	}
 
 	@PostMapping("/import-link")
+	@Operation(
+		summary = "Import shopping link",
+		description = "Creates a wishlist save draft from a shared or manually entered shopping link payload.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "Import preview generated"),
+			@ApiResponse(responseCode = "400", description = "Invalid import payload"),
+			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication")
+		}
+	)
 	public ShoppingLinkImportResponse importLink(@RequestBody ShoppingLinkImportRequest request) {
 		return shoppingLinkImportService.importLink(request);
 	}

--- a/src/main/java/com/sagongsa/backend/notification/NotificationController.java
+++ b/src/main/java/com/sagongsa/backend/notification/NotificationController.java
@@ -1,6 +1,10 @@
 package com.sagongsa.backend.notification;
 
 import com.sagongsa.backend.auth.CurrentUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/notifications")
+@Tag(name = "Notification", description = "Notification list and read-state APIs")
 public class NotificationController {
 
 	private final NotificationService notificationService;
@@ -21,16 +26,34 @@ public class NotificationController {
 	}
 
 	@GetMapping
+	@Operation(
+		summary = "List notifications",
+		description = "Returns notifications for the authenticated user. Use unreadOnly=true to filter unread notifications.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "Notifications returned"),
+			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication")
+		}
+	)
 	public List<NotificationResponse> list(
-		@CurrentUserId UUID userId,
+		@Parameter(hidden = true) @CurrentUserId UUID userId,
 		@RequestParam(defaultValue = "false") boolean unreadOnly
 	) {
 		return notificationService.list(userId, unreadOnly);
 	}
 
 	@PatchMapping("/{notificationId}/read")
+	@Operation(
+		summary = "Mark notification as read",
+		description = "Marks one notification as read and returns the updated notification payload.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "Notification marked as read"),
+			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication"),
+			@ApiResponse(responseCode = "403", description = "Notification belongs to another user"),
+			@ApiResponse(responseCode = "404", description = "Notification does not exist")
+		}
+	)
 	public NotificationResponse markAsRead(
-		@CurrentUserId UUID userId,
+		@Parameter(hidden = true) @CurrentUserId UUID userId,
 		@PathVariable UUID notificationId
 	) {
 		return notificationService.markAsRead(userId, notificationId);

--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingController.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingController.java
@@ -1,6 +1,10 @@
 package com.sagongsa.backend.onboarding;
 
 import com.sagongsa.backend.auth.CurrentUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -10,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/onboarding")
+@Tag(name = "Onboarding", description = "Initial profile, mascot, budget, and survey completion API")
 public class OnboardingController {
 
 	private final OnboardingService onboardingService;
@@ -19,8 +24,20 @@ public class OnboardingController {
 	}
 
 	@PostMapping("/complete")
+	@Operation(
+		summary = "Complete onboarding",
+		description = "Stores the user's onboarding profile, mascot name, monthly budget, and survey choice.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "Onboarding completed"),
+			@ApiResponse(responseCode = "400", description = "Invalid onboarding payload"),
+			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication"),
+			@ApiResponse(responseCode = "403", description = "User is not allowed to complete onboarding"),
+			@ApiResponse(responseCode = "404", description = "User account does not exist"),
+			@ApiResponse(responseCode = "409", description = "Onboarding is already complete")
+		}
+	)
 	public ResponseEntity<OnboardingCompleteResponse> complete(
-		@CurrentUserId UUID userId,
+		@Parameter(hidden = true) @CurrentUserId UUID userId,
 		@RequestBody(required = false) OnboardingCompleteRequest request
 	) {
 		return ResponseEntity.ok(onboardingService.complete(userId, request));

--- a/src/main/java/com/sagongsa/backend/reflection/PurchaseReflectionController.java
+++ b/src/main/java/com/sagongsa/backend/reflection/PurchaseReflectionController.java
@@ -1,6 +1,10 @@
 package com.sagongsa.backend.reflection;
 
 import com.sagongsa.backend.auth.CurrentUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/reflections")
+@Tag(name = "Reflection", description = "Post-purchase reflection API")
 public class PurchaseReflectionController {
 
 	private final PurchaseReflectionService purchaseReflectionService;
@@ -20,8 +25,20 @@ public class PurchaseReflectionController {
 	}
 
 	@PostMapping
+	@Operation(
+		summary = "Create purchase reflection",
+		description = "Stores satisfaction and regret feedback for a completed purchase decision.",
+		responses = {
+			@ApiResponse(responseCode = "201", description = "Reflection created"),
+			@ApiResponse(responseCode = "400", description = "Invalid reflection payload"),
+			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication"),
+			@ApiResponse(responseCode = "403", description = "Decision belongs to another user"),
+			@ApiResponse(responseCode = "404", description = "Decision or reminder does not exist"),
+			@ApiResponse(responseCode = "409", description = "Reflection already exists")
+		}
+	)
 	public ResponseEntity<PurchaseReflectionResponse> create(
-		@CurrentUserId UUID userId,
+		@Parameter(hidden = true) @CurrentUserId UUID userId,
 		@RequestBody(required = false) PurchaseReflectionRequest request
 	) {
 		PurchaseReflectionResponse response = purchaseReflectionService.create(userId, request);

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistController.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistController.java
@@ -1,6 +1,10 @@
 package com.sagongsa.backend.wishlist;
 
 import com.sagongsa.backend.auth.CurrentUserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/wishlist/items")
+@Tag(name = "Wishlist", description = "Saved wishlist item create, list, detail, category update, and delete APIs")
 public class WishlistController {
 
 	private final WishlistService wishlistService;
@@ -25,8 +30,18 @@ public class WishlistController {
 	}
 
 	@PostMapping
+	@Operation(
+		summary = "Create wishlist item",
+		description = "Saves an imported or directly entered item into the authenticated user's wishlist.",
+		responses = {
+			@ApiResponse(responseCode = "201", description = "Wishlist item created"),
+			@ApiResponse(responseCode = "400", description = "Invalid wishlist payload"),
+			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication"),
+			@ApiResponse(responseCode = "409", description = "Same normalized URL is already saved")
+		}
+	)
 	public ResponseEntity<WishlistItemResponse> create(
-		@CurrentUserId UUID userId,
+		@Parameter(hidden = true) @CurrentUserId UUID userId,
 		@RequestBody WishlistItemCreateRequest request
 	) {
 		WishlistItemResponse response = wishlistService.create(userId, request);
@@ -34,8 +49,17 @@ public class WishlistController {
 	}
 
 	@GetMapping
+	@Operation(
+		summary = "List wishlist items",
+		description = "Returns the authenticated user's saved wishlist items with optional category filtering and cursor pagination.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "Wishlist items returned"),
+			@ApiResponse(responseCode = "400", description = "Invalid pagination cursor or limit"),
+			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication")
+		}
+	)
 	public WishlistItemPageResponse list(
-		@CurrentUserId UUID userId,
+		@Parameter(hidden = true) @CurrentUserId UUID userId,
 		@RequestParam(required = false) String category,
 		@RequestParam(required = false) Integer limit,
 		@RequestParam(required = false) String cursor
@@ -44,16 +68,37 @@ public class WishlistController {
 	}
 
 	@GetMapping("/{itemId}")
+	@Operation(
+		summary = "Get wishlist item",
+		description = "Returns one saved wishlist item owned by the authenticated user.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "Wishlist item returned"),
+			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication"),
+			@ApiResponse(responseCode = "403", description = "Item belongs to another user"),
+			@ApiResponse(responseCode = "404", description = "Wishlist item does not exist")
+		}
+	)
 	public WishlistItemResponse get(
-		@CurrentUserId UUID userId,
+		@Parameter(hidden = true) @CurrentUserId UUID userId,
 		@PathVariable UUID itemId
 	) {
 		return wishlistService.get(userId, itemId);
 	}
 
 	@PatchMapping("/{itemId}/category")
+	@Operation(
+		summary = "Update wishlist category",
+		description = "Changes an item category and marks the category as user locked.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "Category updated"),
+			@ApiResponse(responseCode = "400", description = "Invalid category"),
+			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication"),
+			@ApiResponse(responseCode = "403", description = "Item belongs to another user"),
+			@ApiResponse(responseCode = "404", description = "Wishlist item does not exist")
+		}
+	)
 	public WishlistItemResponse updateCategory(
-		@CurrentUserId UUID userId,
+		@Parameter(hidden = true) @CurrentUserId UUID userId,
 		@PathVariable UUID itemId,
 		@RequestBody WishlistCategoryUpdateRequest request
 	) {
@@ -61,8 +106,18 @@ public class WishlistController {
 	}
 
 	@DeleteMapping("/{itemId}")
+	@Operation(
+		summary = "Delete wishlist item",
+		description = "Drops a saved wishlist item from the user's active wishlist.",
+		responses = {
+			@ApiResponse(responseCode = "204", description = "Wishlist item deleted"),
+			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication"),
+			@ApiResponse(responseCode = "403", description = "Item belongs to another user"),
+			@ApiResponse(responseCode = "404", description = "Wishlist item does not exist")
+		}
+	)
 	public ResponseEntity<Void> delete(
-		@CurrentUserId UUID userId,
+		@Parameter(hidden = true) @CurrentUserId UUID userId,
 		@PathVariable UUID itemId
 	) {
 		wishlistService.drop(userId, itemId);

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,5 @@
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false


### PR DESCRIPTION
# 📝 Docs PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-40**
- Jira: https://parkjaehong.atlassian.net/browse/NF-40
- GitHub: Closes #72

> PR 제목: `NF-40 Docs: Swagger 기반 API 명세 문서화`
> 브랜치: `docs/NF-40-swagger-openapi-docs`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #72

---

## 🧩 한눈에 요약 (필수)
### 무엇을 문서화/수정했나?
- Springdoc Swagger UI / OpenAPI JSON 생성을 추가했습니다.
- OpenAPI 문서 버전은 작업 키가 아니라 API 계약 버전 기준인 `1.0.0`으로 설정했습니다.
- Swagger/OpenAPI 접근은 non-prod에서만 permitAll로 열고, prod profile에서는 springdoc api-docs/swagger-ui를 비활성화했습니다.
- 프론트 연동 대상 API 컨트롤러에 Swagger 태그, operation summary, 주요 응답 코드를 추가했습니다.
- OpenAPI 문서에 Bearer JWT 인증 스키마와 `frontend-api` 그룹을 추가했습니다.

### 왜 필요한가? (대상 독자 / 문제)
- 대상 독자: 프론트엔드 팀, API 연동/QA 담당자
- 해결하는 문제: 기존 HTML 전달 문서를 수동으로 확인하던 API 계약을 Swagger/OpenAPI 기반으로 조회할 수 있게 합니다.

### 범위(스코프)
- Included:
  - `springdoc-openapi-starter-webmvc-ui` 의존성 추가
  - Swagger/OpenAPI 설정 추가
  - non-prod Swagger 접근 경로 보안 허용
  - prod profile springdoc 비활성화 설정 추가
  - 인증, 온보딩, 쇼핑 링크 import, 위시리스트, 구매 숙려, 구매 결정, 홈 요약, 알림, 회고 API 설명 추가
- Not included:
  - `MypageController`, `SocialFeedController`, `TermsController` Swagger 문서화
  - 서비스 로직 변경
  - DB 스키마 변경
  - API request/response 필드 변경
  - HomeSummaryIntegrationTest 변경
  - 운영 배포 URL/CORS 정책 확정

---

## ✅ Done 체크 (필수)
- [x] Done1: `/swagger-ui.html`과 `/v3/api-docs`를 생성할 수 있도록 Springdoc 설정을 추가했습니다.
- [x] Done2: Swagger 문서 경로를 non-prod에서만 인증 예외로 열도록 조정했습니다.
- [x] Done3: prod profile에서 springdoc api-docs/swagger-ui를 비활성화했습니다.
- [x] Done4: 프론트 전달 대상 컨트롤러에 Swagger 설명을 추가했습니다.

---

## 🔍 검증 (필수)
### Preview / 확인 위치
- 문서 경로:
  - `/swagger-ui.html`
  - `/v3/api-docs`
  - `/v3/api-docs/frontend-api`
- 주요 섹션 링크:
  - Auth
  - Onboarding
  - Item Import
  - Wishlist
  - Deliberation
  - Decision
  - Home
  - Notification
  - Reflection

### 로컬 검증
```bash
./gradlew.bat compileJava
./gradlew.bat bootJar
```
- 결과: ✅ 성공

```bash
./gradlew.bat test
```
- 결과: 미실행

---

## 🧭 영향 범위 (필수)
- [ ] 코드/동작 변경 없음
- [x] 운영 절차(런북) 변경 없음
- [ ] 운영 절차(런북) 변경 있음 (요약: )
- [x] 외부 공개 문서 변경 없음
- [ ] 외부 공개 문서 변경 있음 (요약: )
- [ ] 설정/환경변수 문서 변경 없음
- [x] 설정 변경 있음 (항목: `application-prod.yml` springdoc 비활성화)

추가 영향:
- 라이브러리 추가: `org.springdoc:springdoc-openapi-starter-webmvc-ui`
- Security 설정 변경: Swagger/OpenAPI 문서 경로는 non-prod에서만 permitAll
- prod 설정 변경: `springdoc.api-docs.enabled=false`, `springdoc.swagger-ui.enabled=false`

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 컨트롤러 설명이 실제 API 계약과 어긋나면 프론트 연동 혼선을 만들 수 있습니다.
- Not included에 적은 컨트롤러 문서화는 후속 PR에서 별도로 보강해야 합니다.

### 롤백
- [x] 단순 revert로 가능
- [ ] 별도 안내/공지 필요 (대상: , 내용: )

---

## 📸 증빙 (선택)
- 스크린샷/문서 렌더링 캡처: PR 머지 후 실행 환경에서 확인 예정
- 전/후 비교(가능하면): Swagger/OpenAPI 문서 미제공 → non-prod Swagger UI/OpenAPI JSON 제공

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 섹션/문서:
  - `OpenApiConfig`: 문서 메타데이터, 그룹, Bearer JWT 적용 범위, non-prod profile 제한
  - `SecurityConfig`: Swagger 문서 경로가 non-prod에서만 인증 예외로 열리는지
  - `application-prod.yml`: prod profile에서 springdoc 문서 경로가 비활성화되는지
  - 각 Controller의 `@Operation`: 프론트 전달 API 설명이 실제 동작과 맞는지
- 사실관계/절차/보안 관련 체크포인트:
  - `/api/auth/token/refresh`는 Bearer 인증 요구에서 제외되어야 합니다.
  - 기존 비즈니스 로직과 DB 스키마 변경이 없어야 합니다.