### PR TITLE
[Test] NF-42 WishlistService 단위 테스트 보강

### DIFF
--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistServiceTest.java
@@ -1,0 +1,334 @@
+package com.sagongsa.backend.wishlist;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@SpringBootTest
+class WishlistServiceTest extends PostgreSqlContainerTest {
+
+	@Autowired
+	private WishlistService wishlistService;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void cleanDatabase() {
+		jdbcTemplate.execute("truncate table users cascade");
+	}
+
+	// ── TC1: URL 정규화 및 추적 파라미터 제거 ──────────────────────────────
+
+	@Test
+	void stripsUtmAndAdTrackingParametersOnCreate() {
+		UUID userId = createActiveUser();
+
+		WishlistItemResponse response = wishlistService.create(userId, shareRequest(
+			"https://shop.example.com/product?id=100&utm_source=kakao&utm_medium=cpc&fbclid=abc123",
+			"무선 이어폰"
+		));
+
+		assertThat(response.normalizedUrl()).isEqualTo("https://shop.example.com/product?id=100");
+		assertThat(response.status()).isEqualTo("SAVED");
+	}
+
+	@Test
+	void preservesNonTrackingQueryParametersOnCreate() {
+		UUID userId = createActiveUser();
+
+		WishlistItemResponse response = wishlistService.create(userId, shareRequest(
+			"https://shop.example.com/search?q=sneakers&sort=price&utm_source=ig",
+			"스니커즈"
+		));
+
+		assertThat(response.normalizedUrl()).isEqualTo("https://shop.example.com/search?q=sneakers&sort=price");
+	}
+
+	@Test
+	void acceptsDirectInputWithUrl() {
+		UUID userId = createActiveUser();
+
+		WishlistItemResponse response = wishlistService.create(userId, new WishlistItemCreateRequest(
+			"DIRECT_INPUT", "https://shop.example.com/item", null, "직접 입력 상품", null,
+			29000, "KRW", "FASHION", null, false,
+			null, null, null, null, null
+		));
+
+		assertThat(response.normalizedUrl()).isEqualTo("https://shop.example.com/item");
+		assertThat(response.status()).isEqualTo("SAVED");
+	}
+
+	@Test
+	void rejectsDirectInputWithoutUrl() {
+		UUID userId = createActiveUser();
+
+		assertThatThrownBy(() -> wishlistService.create(userId, new WishlistItemCreateRequest(
+			"DIRECT_INPUT", null, null, "직접 입력 상품", null,
+			29000, "KRW", "FASHION", null, false,
+			null, null, null, null, null
+		)))
+			.isInstanceOf(BadRequestException.class);
+	}
+
+	@Test
+	void rejectsNonHttpScheme() {
+		UUID userId = createActiveUser();
+
+		assertThatThrownBy(() -> wishlistService.create(userId, shareRequest("ftp://files.example.com/item", "상품")))
+			.isInstanceOf(BadRequestException.class);
+	}
+
+	// ── TC2: 생성 입력값 검증 ───────────────────────────────────────────────
+
+	@Test
+	void rejectsBlankTitle() {
+		UUID userId = createActiveUser();
+
+		assertThatThrownBy(() -> wishlistService.create(userId, new WishlistItemCreateRequest(
+			"SHARE", "https://shop.example.com/product", null, "   ", null,
+			null, null, "DIGITAL", null, false,
+			null, null, null, null, null
+		)))
+			.isInstanceOf(BadRequestException.class);
+	}
+
+	@Test
+	void rejectsNegativeListedPrice() {
+		UUID userId = createActiveUser();
+
+		assertThatThrownBy(() -> wishlistService.create(userId, new WishlistItemCreateRequest(
+			"SHARE", "https://shop.example.com/product", null, "상품", null,
+			-1, null, "DIGITAL", null, false,
+			null, null, null, null, null
+		)))
+			.isInstanceOf(BadRequestException.class);
+	}
+
+	@Test
+	void rejectsCurrencyCodeNotThreeCharacters() {
+		UUID userId = createActiveUser();
+
+		assertThatThrownBy(() -> wishlistService.create(userId, new WishlistItemCreateRequest(
+			"SHARE", "https://shop.example.com/product", null, "상품", null,
+			10000, "KR", "DIGITAL", null, false,
+			null, null, null, null, null
+		)))
+			.isInstanceOf(BadRequestException.class);
+	}
+
+	@Test
+	void rejectsCategoryConfidenceAbove100() {
+		UUID userId = createActiveUser();
+
+		assertThatThrownBy(() -> wishlistService.create(userId, new WishlistItemCreateRequest(
+			"SHARE", "https://shop.example.com/product", null, "상품", null,
+			null, null, "DIGITAL", BigDecimal.valueOf(100.01), false,
+			null, null, null, null, null
+		)))
+			.isInstanceOf(BadRequestException.class);
+	}
+
+	@Test
+	void rejectsUnknownCategory() {
+		UUID userId = createActiveUser();
+
+		assertThatThrownBy(() -> wishlistService.create(userId, new WishlistItemCreateRequest(
+			"SHARE", "https://shop.example.com/product", null, "상품", null,
+			null, null, "INVALID_CATEGORY", null, false,
+			null, null, null, null, null
+		)))
+			.isInstanceOf(BadRequestException.class);
+	}
+
+	@Test
+	void throwsDuplicateWhenSameNormalizedUrlAlreadySaved() {
+		UUID userId = createActiveUser();
+		wishlistService.create(userId, shareRequest("https://shop.example.com/product?id=1", "첫 번째"));
+
+		assertThatThrownBy(() -> wishlistService.create(userId,
+			shareRequest("https://shop.example.com/product?id=1&utm_source=kakao", "두 번째")))
+			.isInstanceOf(DuplicateSavedItemException.class);
+	}
+
+	// ── TC3: 접근 제어 ──────────────────────────────────────────────────────
+
+	@Test
+	void throwsNotFoundWhenUserDoesNotExist() {
+		assertThatThrownBy(() -> wishlistService.create(UUID.randomUUID(),
+			shareRequest("https://shop.example.com/product", "상품")))
+			.isInstanceOf(WishlistItemNotFoundException.class);
+	}
+
+	@Test
+	void throwsForbiddenWhenOnboardingNotCompleted() {
+		UUID userId = createUserWithOnboardingStatus("NOT_STARTED");
+
+		assertThatThrownBy(() -> wishlistService.create(userId,
+			shareRequest("https://shop.example.com/product", "상품")))
+			.isInstanceOf(WishlistForbiddenException.class);
+	}
+
+	// ── TC4: 목록 조회 및 카테고리 필터 ────────────────────────────────────
+
+	@Test
+	void returnsEmptyListWhenNoItemsSaved() {
+		UUID userId = createActiveUser();
+
+		List<WishlistItemResponse> items = wishlistService.list(userId, null);
+
+		assertThat(items).isEmpty();
+	}
+
+	@Test
+	void returnsAllSavedItemsInDescendingOrder() {
+		UUID userId = createActiveUser();
+		wishlistService.create(userId, shareRequest("https://shop.example.com/a", "상품 A"));
+		wishlistService.create(userId, shareRequest("https://shop.example.com/b", "상품 B"));
+
+		List<WishlistItemResponse> items = wishlistService.list(userId, null);
+
+		assertThat(items).hasSize(2);
+		assertThat(items.get(0).title()).isEqualTo("상품 B");
+		assertThat(items.get(1).title()).isEqualTo("상품 A");
+	}
+
+	@Test
+	void filtersByCategory() {
+		UUID userId = createActiveUser();
+		wishlistService.create(userId, shareRequest("https://shop.example.com/a", "디지털 상품"));
+		wishlistService.create(userId, new WishlistItemCreateRequest(
+			"SHARE", "https://shop.example.com/b", null, "패션 상품", null,
+			null, null, "FASHION", null, false,
+			null, null, null, null, null
+		));
+
+		List<WishlistItemResponse> items = wishlistService.list(userId, "DIGITAL");
+
+		assertThat(items).hasSize(1);
+		assertThat(items.getFirst().category()).isEqualTo("DIGITAL");
+	}
+
+	@Test
+	void rejectsInvalidCategoryOnList() {
+		UUID userId = createActiveUser();
+
+		assertThatThrownBy(() -> wishlistService.list(userId, "INVALID_CATEGORY"))
+			.isInstanceOf(BadRequestException.class);
+	}
+
+	@Test
+	void doesNotReturnDroppedItemsInList() {
+		UUID userId = createActiveUser();
+		WishlistItemResponse created = wishlistService.create(userId,
+			shareRequest("https://shop.example.com/a", "상품"));
+		wishlistService.drop(userId, created.id());
+
+		List<WishlistItemResponse> items = wishlistService.list(userId, null);
+
+		assertThat(items).isEmpty();
+	}
+
+	// ── TC5: 단건 조회 / 삭제 ─────────────────────────────────────────────
+
+	@Test
+	void throwsNotFoundWhenGettingNonExistentItem() {
+		UUID userId = createActiveUser();
+
+		assertThatThrownBy(() -> wishlistService.get(userId, UUID.randomUUID()))
+			.isInstanceOf(WishlistItemNotFoundException.class);
+	}
+
+	@Test
+	void throwsNotFoundWhenGettingDroppedItem() {
+		UUID userId = createActiveUser();
+		WishlistItemResponse created = wishlistService.create(userId,
+			shareRequest("https://shop.example.com/product", "상품"));
+
+		wishlistService.drop(userId, created.id());
+
+		assertThatThrownBy(() -> wishlistService.get(userId, created.id()))
+			.isInstanceOf(WishlistItemNotFoundException.class);
+	}
+
+	@Test
+	void throwsNotFoundWhenDroppingNonExistentItem() {
+		UUID userId = createActiveUser();
+
+		assertThatThrownBy(() -> wishlistService.drop(userId, UUID.randomUUID()))
+			.isInstanceOf(WishlistItemNotFoundException.class);
+	}
+
+	// ── TC6: 카테고리 수정 ──────────────────────────────────────────────────
+
+	@Test
+	void updatesCategoryAndLocksIt() {
+		UUID userId = createActiveUser();
+		WishlistItemResponse created = wishlistService.create(userId,
+			shareRequest("https://shop.example.com/product", "상품"));
+
+		WishlistItemResponse updated = wishlistService.updateCategory(
+			userId, created.id(), new WishlistCategoryUpdateRequest("FASHION")
+		);
+
+		assertThat(updated.category()).isEqualTo("FASHION");
+		assertThat(updated.categoryLockedByUser()).isTrue();
+	}
+
+	@Test
+	void rejectsInvalidCategoryOnUpdate() {
+		UUID userId = createActiveUser();
+		WishlistItemResponse created = wishlistService.create(userId,
+			shareRequest("https://shop.example.com/product", "상품"));
+
+		assertThatThrownBy(() -> wishlistService.updateCategory(
+			userId, created.id(), new WishlistCategoryUpdateRequest("INVALID")
+		))
+			.isInstanceOf(BadRequestException.class);
+	}
+
+	@Test
+	void throwsNotFoundWhenUpdatingNonExistentItem() {
+		UUID userId = createActiveUser();
+
+		assertThatThrownBy(() -> wishlistService.updateCategory(
+			userId, UUID.randomUUID(), new WishlistCategoryUpdateRequest("FASHION")
+		))
+			.isInstanceOf(WishlistItemNotFoundException.class);
+	}
+
+	// ── 헬퍼 ───────────────────────────────────────────────────────────────
+
+	private UUID createActiveUser() {
+		return createUserWithOnboardingStatus("COMPLETED");
+	}
+
+	private UUID createUserWithOnboardingStatus(String onboardingStatus) {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"insert into users (id, status, onboarding_status, created_at, updated_at) values (?, 'ACTIVE', ?, ?, ?)",
+			userId, onboardingStatus, now, now
+		);
+		return userId;
+	}
+
+	private WishlistItemCreateRequest shareRequest(String url, String title) {
+		return new WishlistItemCreateRequest(
+			"SHARE", url, null, title, null,
+			null, null, "DIGITAL", null, false,
+			null, null, null, null, null
+		);
+	}
+}

--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistServiceTest.java
@@ -7,7 +7,6 @@ import com.sagongsa.backend.support.PostgreSqlContainerTest;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,15 +70,18 @@ class WishlistServiceTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
-	void rejectsDirectInputWithoutUrl() {
+	void acceptsDirectInputWithoutUrl() {
 		UUID userId = createActiveUser();
 
-		assertThatThrownBy(() -> wishlistService.create(userId, new WishlistItemCreateRequest(
+		WishlistItemResponse response = wishlistService.create(userId, new WishlistItemCreateRequest(
 			"DIRECT_INPUT", null, null, "직접 입력 상품", null,
 			29000, "KRW", "FASHION", null, false,
 			null, null, null, null, null
-		)))
-			.isInstanceOf(BadRequestException.class);
+		));
+
+		assertThat(response.originalUrl()).isNull();
+		assertThat(response.normalizedUrl()).isNull();
+		assertThat(response.status()).isEqualTo("SAVED");
 	}
 
 	@Test
@@ -186,9 +188,9 @@ class WishlistServiceTest extends PostgreSqlContainerTest {
 	void returnsEmptyListWhenNoItemsSaved() {
 		UUID userId = createActiveUser();
 
-		List<WishlistItemResponse> items = wishlistService.list(userId, null);
+		WishlistItemPageResponse response = wishlistService.list(userId, null, null, null);
 
-		assertThat(items).isEmpty();
+		assertThat(response.items()).isEmpty();
 	}
 
 	@Test
@@ -197,11 +199,11 @@ class WishlistServiceTest extends PostgreSqlContainerTest {
 		wishlistService.create(userId, shareRequest("https://shop.example.com/a", "상품 A"));
 		wishlistService.create(userId, shareRequest("https://shop.example.com/b", "상품 B"));
 
-		List<WishlistItemResponse> items = wishlistService.list(userId, null);
+		WishlistItemPageResponse response = wishlistService.list(userId, null, null, null);
 
-		assertThat(items).hasSize(2);
-		assertThat(items.get(0).title()).isEqualTo("상품 B");
-		assertThat(items.get(1).title()).isEqualTo("상품 A");
+		assertThat(response.items()).hasSize(2);
+		assertThat(response.items().get(0).title()).isEqualTo("상품 B");
+		assertThat(response.items().get(1).title()).isEqualTo("상품 A");
 	}
 
 	@Test
@@ -214,17 +216,17 @@ class WishlistServiceTest extends PostgreSqlContainerTest {
 			null, null, null, null, null
 		));
 
-		List<WishlistItemResponse> items = wishlistService.list(userId, "DIGITAL");
+		WishlistItemPageResponse response = wishlistService.list(userId, "DIGITAL", null, null);
 
-		assertThat(items).hasSize(1);
-		assertThat(items.getFirst().category()).isEqualTo("DIGITAL");
+		assertThat(response.items()).hasSize(1);
+		assertThat(response.items().getFirst().category()).isEqualTo("DIGITAL");
 	}
 
 	@Test
 	void rejectsInvalidCategoryOnList() {
 		UUID userId = createActiveUser();
 
-		assertThatThrownBy(() -> wishlistService.list(userId, "INVALID_CATEGORY"))
+		assertThatThrownBy(() -> wishlistService.list(userId, "INVALID_CATEGORY", null, null))
 			.isInstanceOf(BadRequestException.class);
 	}
 
@@ -235,9 +237,9 @@ class WishlistServiceTest extends PostgreSqlContainerTest {
 			shareRequest("https://shop.example.com/a", "상품"));
 		wishlistService.drop(userId, created.id());
 
-		List<WishlistItemResponse> items = wishlistService.list(userId, null);
+		WishlistItemPageResponse response = wishlistService.list(userId, null, null, null);
 
-		assertThat(items).isEmpty();
+		assertThat(response.items()).isEmpty();
 	}
 
 	// ── TC5: 단건 조회 / 삭제 ─────────────────────────────────────────────


### PR DESCRIPTION
# 🧪 Test PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: 없음 (내부 품질 개선)
- GitHub: Related #77
- GitHub: Closes #77

> PR 제목: `#77 Test: WishlistService 단위 테스트 보강`
> 브랜치: `test/77-unit-wishlist-service`

---

## 🧾 이 PR의 테스트 범위 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #77의 1/1 단계 (Single PR)
- 선행 PR: 없음

### 변경/추가 테스트 상세
- [x] 신규 테스트 추가
  - Unit: 24개 (TC1~TC6, `WishlistServiceTest.java`)
  - Integration: 0개
  - E2E: 0개
- [ ] 기존 테스트 수정
- [ ] 테스트 삭제
- [ ] 테스트 데이터/픽스처 변경

### 대상 모듈/시나리오
1. `com.sagongsa.backend.wishlist.WishlistService`
2. `@SpringBootTest` + `PostgreSqlContainerTest` 패턴 — MockMvc 없이 서비스 직접 주입

---

## ✅ 이 PR이 커버하는 TC (필수)
### Covers (이 PR에서 구현)
- TC1 (URL 정규화 / 추적 파라미터 제거): utm_* · fbclid 등 제거 검증, 비추적 파라미터 보존, DIRECT_INPUT URL 필수 여부, http/https 이외 scheme 거부 — **5개**
- TC2 (생성 입력값 검증): title 빈값, listedPrice 음수, currencyCode 3자리 미만, categoryConfidence 범위 초과, 유효하지 않은 category, 중복 normalized_url — **6개**
- TC3 (접근 제어): 존재하지 않는 userId, 온보딩 미완료 유저 — **2개**
- TC4 (목록 조회 / 카테고리 필터): 빈 목록, 최신순 정렬, category 필터, 유효하지 않은 category 거부, DROPPED 아이템 제외 — **5개**
- TC5 (단건 조회 / 삭제): 없는 아이템 get, DROPPED 아이템 get, 없는 아이템 drop — **3개**
- TC6 (카테고리 수정): 변경 후 `category_locked_by_user=true`, 유효하지 않은 category 거부, 없는 아이템 — **3개**

### Not covered (후속 작업)
- TC4 (커서 페이지네이션: limit 검증, 다음 페이지 커서): develop 브랜치 `WishlistService.list()`에 페이지네이션 미구현 → 해당 기능 머지 후 별도 보강
- TC1 (userInfo 포함 URL 거부): develop `parseHttpUrl`에 userInfo 검증 미포함 → 기능 브랜치 머지 후 추가

---

## ✅ 테스트 실행 결과 (필수)
### 로컬
```
./gradlew test
```
- ✅ 24개 통과 (PostgreSqlContainerTest 컨테이너 공유, 각 테스트 전 `truncate table users cascade`)

### CI
- (자동 첨부)

---

## 🌐 영향 범위 체크 (필수)
- [ ] 런타임 코드 변경 (없음 — 테스트 파일만 추가)
- [ ] DB/마이그레이션 변경 (없음)
- [ ] CI 파이프라인 변경 (없음)
- [ ] 플래키 테스트 (없음 — `truncate` 격리로 상태 공유 없음)

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 테스트/로직: `throwsDuplicateWhenSameNormalizedUrlAlreadySaved` — UTM 포함 URL과 동일 normalized_url이 이미 저장된 경우 `DuplicateSavedItemException` 발생 경로
- 트레이드오프: 페이지네이션 TC는 develop 미구현으로 현재 커버 불가 — `list()` 시그니처가 바뀌면 이 테스트도 수정 필요