### PR TITLE
[bug] #79 OAuth 앱 redirect_uri callback 단계 삭제 방지

### DIFF
--- a/src/main/java/com/sagongsa/backend/auth/AppRedirectUriSupport.java
+++ b/src/main/java/com/sagongsa/backend/auth/AppRedirectUriSupport.java
@@ -29,13 +29,12 @@ public class AppRedirectUriSupport {
 
 	public void captureRedirectUri(HttpServletRequest request) {
 		String redirectUri = request.getParameter(REDIRECT_URI_PARAMETER);
-		HttpSession session = request.getSession(true);
 
 		if (!StringUtils.hasText(redirectUri)) {
-			session.removeAttribute(SESSION_KEY);
 			return;
 		}
 
+		HttpSession session = request.getSession(true);
 		parseAllowedRedirectUri(redirectUri).ifPresentOrElse(
 			uri -> session.setAttribute(SESSION_KEY, uri.toString()),
 			() -> session.removeAttribute(SESSION_KEY)

--- a/src/test/java/com/sagongsa/backend/auth/AppRedirectUriSupportTest.java
+++ b/src/test/java/com/sagongsa/backend/auth/AppRedirectUriSupportTest.java
@@ -8,6 +8,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
 
 class AppRedirectUriSupportTest {
 
@@ -43,6 +44,20 @@ class AppRedirectUriSupportTest {
 	@Test
 	void rejectsLocalhostRedirectBelowAllowedCallbackPath() {
 		assertThat(support.parseAllowedRedirectUri("http://localhost/auth/callback/extra")).isEmpty();
+	}
+
+	@Test
+	void keepsCapturedRedirectUriWhenLaterRequestOmitsParameter() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter(AppRedirectUriSupport.REDIRECT_URI_PARAMETER, "sagongsa404://auth/callback");
+		support.captureRedirectUri(request);
+
+		MockHttpServletRequest callbackRequest = new MockHttpServletRequest();
+		callbackRequest.setSession(request.getSession());
+		support.captureRedirectUri(callbackRequest);
+
+		assertThat(support.consumeRedirectUri(callbackRequest))
+			.contains(URI.create("sagongsa404://auth/callback"));
 	}
 
 	@Test


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: 없음 (GitHub 이슈 #79 기반 버그 수정)
- Jira: 없음
- GitHub: Closes #79

> PR 제목: `[bug] #79 OAuth 앱 redirect_uri callback 단계 삭제 방지`
> 브랜치: `codex/fix-oauth-redirect-uri-capture`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #79

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- 모바일 앱 소셜 로그인 시작 시 `redirect_uri=sagongsa404://auth/callback`를 전달해도, OAuth callback 단계에서 세션에 저장된 앱 redirect URI가 삭제되어 로그인 성공 후 앱 딥링크가 아니라 `/app.html`로 이동했습니다.

### 왜 발생했나? (Root Cause)
- `SecurityConfig`의 custom `OAuth2AuthorizationRequestResolver`가 resolver 호출마다 `AppRedirectUriSupport.captureRedirectUri()`를 실행합니다.
- OAuth callback 요청에는 보통 `redirect_uri` query parameter가 없는데, 기존 `captureRedirectUri()`는 파라미터가 없을 때도 세션의 `app.oauth2.redirect_uri` 값을 제거했습니다.
- 그 결과 success handler의 `consumeRedirectUri()`가 빈 값을 반환하고 기본 성공 URL `/`로 fallback했습니다.

### 어떻게 고쳤나?
- `redirect_uri` parameter가 없는 요청은 기존 세션 값을 건드리지 않고 바로 반환하도록 수정했습니다.
- 유효하지 않은 `redirect_uri`가 명시적으로 전달된 경우에는 기존처럼 저장값을 제거합니다.
- OAuth callback 단계에서 parameter가 빠져도 최초 저장된 앱 callback URI가 유지되는 회귀 테스트를 추가했습니다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법(가능하면)
- Steps:
  1. 모바일 앱 OAuth 시작 URL에 `redirect_uri=sagongsa404://auth/callback`를 붙입니다.
  2. OAuth 인증 완료 후 callback 요청이 처리되도록 합니다.
  3. callback 요청에는 `redirect_uri` parameter가 없는 상태를 확인합니다.
- 기대 결과: 최초 저장된 `sagongsa404://auth/callback`로 로그인 성공 redirect가 이어집니다.
- 실제 결과: 기존 구현에서는 세션 값이 삭제되어 `/` fallback 후 `/app.html`로 이동했습니다.

### 재발 방지(있다면)
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [ ] 런북/문서 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] AC1: `redirect_uri` parameter가 없는 후속 요청은 기존 세션 값을 삭제하지 않습니다.
- [x] AC2: callback 단계에서도 최초 저장된 `sagongsa404://auth/callback`이 유지됩니다.
- [x] AC3: 유효하지 않은 `redirect_uri`가 명시적으로 전달되면 기존처럼 저장값을 제거합니다.

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew.bat test --tests "com.sagongsa.backend.auth.AppRedirectUriSupportTest"`
- Result: `BUILD SUCCESSFUL in 21s`

### CI
- 링크/결과: PR에서 GitHub Actions 자동 첨부 확인 예정

### Smoke / 수동 검증
- 시나리오: 같은 HTTP session에서 최초 OAuth 요청에는 앱 callback `redirect_uri`를 저장하고, callback 요청에는 parameter를 생략한 뒤 `consumeRedirectUri()` 결과 확인
- 결과: 회귀 테스트 `keepsCapturedRedirectUriWhenLaterRequestOmitsParameter`로 검증

### 테스트 공백(있다면 이유 필수)
- 실제 모바일 앱 OAuth end-to-end 플로우는 외부 OAuth provider와 앱 딥링크 환경이 필요해 이 PR에서는 단위 회귀 테스트로 세션 보존 로직을 검증했습니다.

---

## 🧭 영향 범위 (필수)
- [x] API 스펙 변경 없음
- [ ] API 스펙 변경 있음 (요약: )
- [x] DB 스키마 변경 없음
- [ ] DB 스키마 변경 있음 (마이그레이션/락/시간: )
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음 (항목: )
- [x] 캐시/큐/외부 연동 영향 없음
- [ ] 캐시/큐/외부 연동 영향 있음 (요약: )

---

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음
- [ ] Breaking change 있음 → 무엇이 깨지는지 / 마이그레이션 / 롤아웃 전략:

---

## 🚀 배포/릴리즈 (해당 시 필수)
### Feature Flag
- [x] 사용 안함
- [ ] 사용함 → Flag/기본값/롤아웃:

### 모니터링/알림
- 확인할 대시보드/지표: OAuth callback 성공률, 앱 딥링크 로그인 성공률, `/app.html` fallback 발생 비율
- 에러/로그 키워드: OAuth callback failure, redirect URI rejection

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 동일 OAuth session 안에서 callback 요청이 `redirect_uri` 없이 들어오는 정상 경로는 보존되지만, 예외적인 OAuth 재시작/중복 요청이 같은 session에서 섞이면 이전 redirect URI가 유지될 수 있습니다.
- 명시적으로 유효하지 않은 `redirect_uri`가 들어오는 경우에는 기존처럼 세션 값을 제거해 stale redirect를 방지합니다.

### 롤백
- [ ] 플래그/설정으로 우회 가능
- [x] 배포 롤백(이전 태그/이미지) 가능
- [ ] 데이터 롤백/역마이그레이션 필요 (절차: )

---

## 📸 증빙 (선택)
- `./gradlew.bat test --tests "com.sagongsa.backend.auth.AppRedirectUriSupportTest"` 통과
- 변경 파일: `AppRedirectUriSupport`, `AppRedirectUriSupportTest`

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직: `AppRedirectUriSupport.captureRedirectUri()`, `AppRedirectUriSupportTest.keepsCapturedRedirectUriWhenLaterRequestOmitsParameter`
- 트레이드오프/대안: callback 요청에서 parameter가 없을 때 session을 삭제하지 않고 유지해 앱 OAuth redirect 흐름을 보존합니다. invalid parameter가 명시된 경우에는 기존 삭제 동작을 유지합니다.
- 성능/보안/호환성 영향: 추가 I/O나 DB 변경은 없으며, 허용된 redirect URI 검증 정책은 그대로 유지됩니다.
