### PR TITLE
[Test] NF-42 OnboardingService 단위 테스트 보강

### DIFF
--- a/src/test/java/com/sagongsa/backend/onboarding/OnboardingServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/onboarding/OnboardingServiceTest.java
@@ -1,0 +1,242 @@
+package com.sagongsa.backend.onboarding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@SpringBootTest
+class OnboardingServiceTest extends PostgreSqlContainerTest {
+
+	@Autowired
+	private OnboardingService onboardingService;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void cleanDatabase() {
+		jdbcTemplate.execute("truncate table users cascade");
+	}
+
+	// ── TC1: 입력값 검증 ───────────────────────────────────────────────────────
+
+	@Test
+	void rejectsMascotNameNull() {
+		UUID userId = insertUser("NOT_STARTED");
+		assertThatThrownBy(() -> onboardingService.complete(userId, request(null, "Asia/Seoul", 100000, "LESS_THAN_ONCE")))
+			.isInstanceOf(OnboardingBadRequestException.class);
+	}
+
+	@Test
+	void rejectsMascotNameBlank() {
+		UUID userId = insertUser("NOT_STARTED");
+		assertThatThrownBy(() -> onboardingService.complete(userId, request("   ", "Asia/Seoul", 100000, "LESS_THAN_ONCE")))
+			.isInstanceOf(OnboardingBadRequestException.class);
+	}
+
+	@Test
+	void rejectsMascotNameExceeding40Characters() {
+		UUID userId = insertUser("NOT_STARTED");
+		assertThatThrownBy(() -> onboardingService.complete(userId, request("a".repeat(41), "Asia/Seoul", 100000, "LESS_THAN_ONCE")))
+			.isInstanceOf(OnboardingBadRequestException.class);
+	}
+
+	@Test
+	void acceptsMascotNameExactly40Characters() {
+		UUID userId = insertUser("NOT_STARTED");
+		OnboardingCompleteResponse response = onboardingService.complete(userId, request("a".repeat(40), "Asia/Seoul", 100000, "LESS_THAN_ONCE"));
+		assertThat(response.onboardingStatus()).isEqualTo("COMPLETED");
+	}
+
+	@Test
+	void defaultsTimezoneToSeoulWhenNull() {
+		UUID userId = insertUser("NOT_STARTED");
+		onboardingService.complete(userId, request("너굴", null, 100000, "LESS_THAN_ONCE"));
+		assertThat(queryString("select timezone from user_profiles where user_id = ?", userId))
+			.isEqualTo("Asia/Seoul");
+	}
+
+	@Test
+	void rejectsBlankTimezone() {
+		UUID userId = insertUser("NOT_STARTED");
+		assertThatThrownBy(() -> onboardingService.complete(userId, request("너굴", "  ", 100000, "LESS_THAN_ONCE")))
+			.isInstanceOf(OnboardingBadRequestException.class);
+	}
+
+	@Test
+	void rejectsInvalidTimezone() {
+		UUID userId = insertUser("NOT_STARTED");
+		assertThatThrownBy(() -> onboardingService.complete(userId, request("너굴", "Not/AValidZone", 100000, "LESS_THAN_ONCE")))
+			.isInstanceOf(OnboardingBadRequestException.class);
+	}
+
+	@Test
+	void rejectsNullMonthlyBudgetAmount() {
+		UUID userId = insertUser("NOT_STARTED");
+		assertThatThrownBy(() -> onboardingService.complete(userId, request("너굴", "Asia/Seoul", null, "LESS_THAN_ONCE")))
+			.isInstanceOf(OnboardingBadRequestException.class);
+	}
+
+	@Test
+	void rejectsNegativeMonthlyBudgetAmount() {
+		UUID userId = insertUser("NOT_STARTED");
+		assertThatThrownBy(() -> onboardingService.complete(userId, request("너굴", "Asia/Seoul", -1, "LESS_THAN_ONCE")))
+			.isInstanceOf(OnboardingBadRequestException.class);
+	}
+
+	@Test
+	void acceptsZeroMonthlyBudgetAmount() {
+		UUID userId = insertUser("NOT_STARTED");
+		OnboardingCompleteResponse response = onboardingService.complete(userId, request("너굴", "Asia/Seoul", 0, "LESS_THAN_ONCE"));
+		assertThat(response.onboardingStatus()).isEqualTo("COMPLETED");
+	}
+
+	@Test
+	void rejectsInvalidRegretFrequencyChoice() {
+		UUID userId = insertUser("NOT_STARTED");
+		assertThatThrownBy(() -> onboardingService.complete(userId, request("너굴", "Asia/Seoul", 100000, "INVALID_CHOICE")))
+			.isInstanceOf(OnboardingBadRequestException.class);
+	}
+
+	// ── TC2: 접근 제어 및 중복 방지 ──────────────────────────────────────────
+
+	@Test
+	void throwsNotFoundWhenUserDoesNotExist() {
+		assertThatThrownBy(() -> onboardingService.complete(UUID.randomUUID(), defaultRequest()))
+			.isInstanceOf(OnboardingNotFoundException.class);
+	}
+
+	@Test
+	void throwsForbiddenWhenUserIsNotActive() {
+		UUID userId = insertUser("SUSPENDED", "NOT_STARTED");
+		assertThatThrownBy(() -> onboardingService.complete(userId, defaultRequest()))
+			.isInstanceOf(OnboardingForbiddenException.class);
+	}
+
+	@Test
+	void throwsConflictWhenOnboardingAlreadyCompleted() {
+		UUID userId = insertUser("COMPLETED");
+		assertThatThrownBy(() -> onboardingService.complete(userId, defaultRequest()))
+			.isInstanceOf(OnboardingConflictException.class);
+	}
+
+	@Test
+	void throwsConflictWhenSurveyAlreadyExists() {
+		UUID userId = insertUser("NOT_STARTED");
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"insert into survey_response_sets (id, user_id, survey_type, submitted_at, created_at, updated_at) values (?, ?, 'ONBOARDING', ?, ?, ?)",
+			UUID.randomUUID(), userId, now, now, now
+		);
+		assertThatThrownBy(() -> onboardingService.complete(userId, defaultRequest()))
+			.isInstanceOf(OnboardingConflictException.class);
+	}
+
+	// ── TC3: 정상 완료 ────────────────────────────────────────────────────────
+
+	@Test
+	void completesOnboardingAndMarksUserCompleted() {
+		UUID userId = insertUser("NOT_STARTED");
+		OnboardingCompleteResponse response = onboardingService.complete(userId, defaultRequest());
+
+		assertThat(response.userId()).isEqualTo(userId);
+		assertThat(response.onboardingStatus()).isEqualTo("COMPLETED");
+		assertThat(queryString("select onboarding_status from users where id = ?", userId)).isEqualTo("COMPLETED");
+	}
+
+	@Test
+	void insertsAllFiveTablesOnComplete() {
+		UUID userId = insertUser("NOT_STARTED");
+		onboardingService.complete(userId, defaultRequest());
+
+		assertThat(queryCount("select count(*) from user_profiles where user_id = ?", userId)).isEqualTo(1);
+		assertThat(queryCount("select count(*) from budget_cycles where user_id = ?", userId)).isEqualTo(1);
+		assertThat(queryCount("select count(*) from survey_response_sets where user_id = ?", userId)).isEqualTo(1);
+		assertThat(queryCount("select count(*) from mascot_profiles where user_id = ?", userId)).isEqualTo(1);
+	}
+
+	@Test
+	void storesBudgetCycleWithCorrectAmounts() {
+		UUID userId = insertUser("NOT_STARTED");
+		onboardingService.complete(userId, request("너굴", "Asia/Seoul", 200000, "ONE_TO_THREE"));
+
+		assertThat(queryInteger("select monthly_budget_amount from budget_cycles where user_id = ?", userId)).isEqualTo(200000);
+		assertThat(queryInteger("select spent_amount from budget_cycles where user_id = ?", userId)).isZero();
+	}
+
+	@Test
+	void storesCorrectSurveyAnswerForEachChoice() {
+		UUID userId1 = insertUser("NOT_STARTED");
+		onboardingService.complete(userId1, request("너굴1", "Asia/Seoul", 100000, "LESS_THAN_ONCE"));
+
+		UUID userId2 = insertUser("NOT_STARTED");
+		onboardingService.complete(userId2, request("너굴2", "Asia/Seoul", 100000, "ONE_TO_THREE"));
+
+		UUID userId3 = insertUser("NOT_STARTED");
+		onboardingService.complete(userId3, request("너굴3", "Asia/Seoul", 100000, "FOUR_OR_MORE"));
+
+		assertThat(querySurveyAnswerNumber(userId1)).isEqualTo(1);
+		assertThat(querySurveyAnswerNumber(userId2)).isEqualTo(2);
+		assertThat(querySurveyAnswerNumber(userId3)).isEqualTo(3);
+	}
+
+	@Test
+	void storesMascotStateAsDefault() {
+		UUID userId = insertUser("NOT_STARTED");
+		onboardingService.complete(userId, defaultRequest());
+
+		assertThat(queryString("select mascot_state from mascot_profiles where user_id = ?", userId)).isEqualTo("DEFAULT");
+	}
+
+	// ── 헬퍼 ─────────────────────────────────────────────────────────────────
+
+	private UUID insertUser(String onboardingStatus) {
+		return insertUser("ACTIVE", onboardingStatus);
+	}
+
+	private UUID insertUser(String status, String onboardingStatus) {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"insert into users (id, status, onboarding_status, created_at, updated_at) values (?, ?, ?, ?, ?)",
+			userId, status, onboardingStatus, now, now
+		);
+		return userId;
+	}
+
+	private OnboardingCompleteRequest defaultRequest() {
+		return request("너굴", "Asia/Seoul", 100000, "LESS_THAN_ONCE");
+	}
+
+	private OnboardingCompleteRequest request(String mascotName, String timezone, Integer monthlyBudgetAmount, String regretFrequencyChoice) {
+		return new OnboardingCompleteRequest(mascotName, timezone, monthlyBudgetAmount, regretFrequencyChoice);
+	}
+
+	private String queryString(String sql, UUID userId) {
+		return jdbcTemplate.queryForObject(sql, String.class, userId);
+	}
+
+	private Integer queryInteger(String sql, UUID userId) {
+		return jdbcTemplate.queryForObject(sql, Integer.class, userId);
+	}
+
+	private Integer queryCount(String sql, UUID userId) {
+		return jdbcTemplate.queryForObject(sql, Integer.class, userId);
+	}
+
+	private Integer querySurveyAnswerNumber(UUID userId) {
+		return jdbcTemplate.queryForObject(
+			"select a.answer_number from survey_answers a join survey_response_sets s on s.id = a.response_set_id where s.user_id = ?",
+			Integer.class, userId
+		);
+	}
+}

--- a/src/test/java/com/sagongsa/backend/onboarding/OnboardingServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/onboarding/OnboardingServiceTest.java
@@ -161,6 +161,7 @@ class OnboardingServiceTest extends PostgreSqlContainerTest {
 		assertThat(queryCount("select count(*) from user_profiles where user_id = ?", userId)).isEqualTo(1);
 		assertThat(queryCount("select count(*) from budget_cycles where user_id = ?", userId)).isEqualTo(1);
 		assertThat(queryCount("select count(*) from survey_response_sets where user_id = ?", userId)).isEqualTo(1);
+		assertThat(queryCount("select count(*) from survey_answers a join survey_response_sets s on s.id = a.response_set_id where s.user_id = ?", userId)).isEqualTo(1);
 		assertThat(queryCount("select count(*) from mascot_profiles where user_id = ?", userId)).isEqualTo(1);
 	}
 


### PR DESCRIPTION
# 🧪 Test PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: 없음 (내부 품질 개선)
- GitHub: Related #82
- GitHub: Closes #82

> PR 제목: `#82 Test: OnboardingService 단위 테스트 보강`
> 브랜치: `test/82-unit-onboarding-service`

---

## 🧾 이 PR의 테스트 범위 (필수)
### 전체 중 위치
- 전체 이슈 #82의 1/1 단계 (Single PR)
- 선행 PR: #78 (WishlistServiceTest — 동일 패턴)

### 변경/추가 테스트 상세
- [x] 신규 테스트 추가
  - Unit: 20개 (TC1~TC3, `OnboardingServiceTest.java`)
  - Integration: 0개

### 대상 모듈/시나리오
1. `com.sagongsa.backend.onboarding.OnboardingService`
2. `@SpringBootTest` + `PostgreSqlContainerTest` 패턴 — MockMvc 없이 서비스 직접 주입

---

## ✅ 이 PR이 커버하는 TC (필수)
### Covers
- TC1 (입력값 검증): mascotName null·blank·41자·40자 경계, timezone null 기본값·blank·invalid, monthlyBudgetAmount null·음수·0 경계, regretFrequencyChoice 유효하지 않은 값 — **11개**
- TC2 (접근 제어 / 중복 방지): userId 없음, SUSPENDED 유저, onboarding 이미 COMPLETED, survey 이미 존재 — **4개**
- TC3 (정상 완료): onboarding_status = COMPLETED, 5개 테이블 삽입, budget_cycle 금액, 서베이 답변 숫자(3가지 choice), mascot_state — **5개**

### Not covered
- `OnboardingCompleteIntegrationTest` (기존)에서 커버하는 HTTP 레이어 및 nickname 유일성 검증은 제외

---

## ✅ 테스트 실행 결과 (필수)
### 로컬
```
./gradlew compileTestJava
```
- ✅ 컴파일 성공 (20개 테스트)

### CI
- (자동 첨부)

---

## 🌐 영향 범위 체크 (필수)
- [ ] 런타임 코드 변경 (없음 — 테스트 파일만 추가)
- [ ] DB/마이그레이션 변경 (없음)
- [ ] CI 파이프라인 변경 (없음)
- [ ] 플래키 테스트 (없음 — `truncate table users cascade`로 격리)

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 테스트/로직: `throwsConflictWhenSurveyAlreadyExists` — `survey_response_sets`를 JdbcTemplate으로 직접 삽입해 "서베이만 존재, onboarding_status는 미완료" 상태를 만드는 픽스처 접근
- 트레이드오프: `storesCorrectSurveyAnswerForEachChoice`에서 3개 유저를 한 테스트에 넣어 3가지 choice를 한 번에 검증 — 개별 분리 대신 테스트 실행 시간 단축 선택