### PR TITLE
[chore] NF-44 GitHub Actions CI 설정 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   test:
     name: Gradle Test
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+  push:
+    branches:
+      - develop
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Gradle Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      - name: Grant execute permission for Gradle wrapper
+        run: chmod +x gradlew
+
+      - name: Run tests
+        run: ./gradlew test


### PR DESCRIPTION
# 🧰 Chore PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-44**
- Jira: https://parkjaehong.atlassian.net/browse/NF-44

> PR 제목: `NF-44 Chore: GitHub Actions CI 설정 추가`  
> 브랜치: `chore/NF-44-github-actions-ci`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #89

---

## 🧩 한눈에 요약 (필수)
### 무엇을 변경했나? (인프라/빌드/CI/의존성 등)
- [ ] 인프라
- [x] 설정파일
- [ ] 빌드 파일
- [x] CI
- [x] 의존성 / 런타임 / 비즈니스 로직 리팩터링 없음

### 왜 필요한가? (안정성/속도/보안/개발경험)
- 현재 저장소에 GitHub Actions 워크플로가 없어 PR 단계에서 자동 테스트 결과를 확인할 수 없습니다.
- `develop` 대상 PR과 `develop` push에서 Gradle 테스트를 자동 실행해 회귀를 빠르게 확인할 수 있도록 합니다.

### 범위(스코프)
- Included: GitHub Actions CI 워크플로 추가, Java 21 설정, Gradle 캐시, `./gradlew test` 실행
- Not included: 브랜치 보호 규칙 설정, JaCoCo 커버리지 게이트, 배포/CD 설정

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew.bat test`
- Result: `BUILD SUCCESSFUL in 24s`

### CI
- 링크/결과: 현재 저장소 최초 workflow 추가 PR이라 `gh pr checks 90` 기준 reported checks 없음
- 후속 확인: 이 PR이 `develop`에 반영된 뒤 `develop` 대상 PR / `develop` push에서 자동 실행됨

### Smoke / 수동 검증 (해당 시)
- 시나리오: GitHub Actions YAML에서 `develop` 대상 PR / `develop` push 트리거, Java 21, Gradle 테스트 실행 단계 확인
- 결과: 워크플로 설정 확인 완료

### 테스트 공백(있다면 이유 필수)
- 신규 워크플로가 GitHub-hosted runner에서 실제 실행되는지는 workflow가 `develop`에 반영된 뒤 후속 PR 또는 `develop` push에서 확인합니다.

---

## 🧭 영향 범위 (필수)
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음 (항목: )
- [ ] CI/빌드 파이프라인 영향 없음
- [x] CI/빌드 파이프라인 영향 있음 (요약: PR/push 시 Gradle 테스트 자동 실행)
- [x] 의존성(dependency) 변경 없음
- [ ] 의존성(dependency) 변경 있음 (패키지/버전/주요 변경점: )

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- Testcontainers 기반 통합 테스트가 GitHub-hosted runner의 Docker 환경에 의존합니다.
- 전체 테스트 시간이 PR 피드백 시간에 추가됩니다.

### 롤백
- [x] 단순 revert로 가능
- [ ] 버전 pin/되돌리기 필요 (대상: , 방법: )
- [ ] 배포 롤백(이전 태그/이미지) 가능

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/설정: `.github/workflows/ci.yml`
- 트레이드오프/대안: 초기 CI는 `./gradlew test`만 실행하고, 커버리지 게이트나 CD는 후속 작업으로 분리했습니다.
- 성능/보안/호환성 영향: `contents: read` 최소 권한으로 실행하며, Java 21 / Gradle Wrapper 기준으로 현재 테스트 환경과 맞췄습니다.
