### PR TITLE
[test] NF-38 서비스/API 회귀 테스트 보강

### DIFF
--- a/docs/prs/NF-38-SERVICE_API_REGRESSION_TEST_SCOPE.md
+++ b/docs/prs/NF-38-SERVICE_API_REGRESSION_TEST_SCOPE.md
@@ -1,0 +1,44 @@
+# NF-38 Service/API Regression Test Scope
+
+## Context
+
+- Tracking Key: `NF-38`
+- GitHub Issue: #65
+- Base PR: #66 `[test] NF-38 QA 대비 단위 테스트 보강`
+- Branch: `test/NF-38-service-api-regression`
+
+This PR is the next stacked slice after the unit-test-only PR #66.
+It keeps runtime behavior unchanged and adds service/controller/API regression coverage.
+
+## Scope
+
+- Add MockMvc integration coverage for `POST /api/v1/items/import-link`.
+- Verify import preview API response fields that the frontend passes to wishlist save.
+- Keep external shopping-page access stubbed with a fake `PageFetcher`.
+- Extend wishlist cursor API coverage for blank and malformed cursor parameters.
+- Extend decision update API coverage for unknown self-check `questionCode`.
+
+## Covered Cases
+
+- SHARE import returns extracted item, source metadata, save request, and normalization warnings.
+- DIRECT_INPUT import without URL returns null URL fields and manual metadata.
+- SHARE import rejects URL userinfo with `400`.
+- SHARE import maps failed shopping-page fetch to `502`.
+- Wishlist list treats blank cursor as first page.
+- Wishlist list rejects malformed cursor with `400`.
+- Decision update rejects unknown self-check question code with `400`.
+
+## Not Covered
+
+- Full MVP end-to-end flow from import to home summary.
+- Reminder worker and notification read/reflection flow.
+- External live shopping-site crawling.
+- Runtime code changes, migrations, or CI pipeline changes.
+
+## Validation
+
+```powershell
+.\gradlew.bat test --tests "com.sagongsa.backend.itemimport.ItemImportApiIntegrationTest" --tests "com.sagongsa.backend.wishlist.WishlistApiIntegrationTest" --tests "com.sagongsa.backend.decision.DecisionApiIntegrationTest"
+```
+
+- Passed locally on 2026-05-27.

--- a/src/main/java/com/sagongsa/backend/dev/DevController.java
+++ b/src/main/java/com/sagongsa/backend/dev/DevController.java
@@ -17,6 +17,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.UUID;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
@@ -76,7 +77,7 @@ public class DevController {
 
 	record TestDecisionRequest(String title, Integer price, String result) {}
 
-	@PostMapping("/decisions/test")
+	@PostMapping(value = "/decisions/test", consumes = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional
 	public ResponseEntity<Map<String, String>> createTestDecision(
 		@CurrentUserId UUID userId,

--- a/src/main/java/com/sagongsa/backend/reflection/PurchaseReflectionService.java
+++ b/src/main/java/com/sagongsa/backend/reflection/PurchaseReflectionService.java
@@ -198,12 +198,13 @@ public class PurchaseReflectionService {
 
 	private PurchaseReflectionResponse mapReflection(ResultSet rs, int rowNumber) throws SQLException {
 		int score = rs.getInt("satisfaction_score");
+		boolean scoreWasNull = rs.wasNull();
 		return new PurchaseReflectionResponse(
 			rs.getObject("id", UUID.class),
 			rs.getObject("decision_id", UUID.class),
 			rs.getObject("item_id", UUID.class),
 			rs.getObject("reminder_id", UUID.class),
-			rs.wasNull() ? null : score,
+			scoreWasNull ? null : score,
 			rs.getString("regret_level"),
 			rs.getObject("still_using", Boolean.class),
 			rs.getString("reflection_note"),

--- a/src/test/java/com/sagongsa/backend/decision/DecisionApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/decision/DecisionApiIntegrationTest.java
@@ -260,6 +260,41 @@ class DecisionApiIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void rejectsUnknownSelfCheckQuestionCodeOnUpdate() throws Exception {
+		UUID userId = createReadyUser();
+		insertBudgetCycle(userId, YearMonth.now(SEOUL_ZONE).toString(), 500_000, 0);
+		UUID itemId = insertSavedItem(userId, "Update bad question target", "LIVING", "SAVED", 50_000);
+
+		String body = mockMvc.perform(post(DECISIONS_PATH)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(decisionRequest(itemId, "GO", 50_000, true, false, false, false)))
+			.andExpect(status().isCreated())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+		String decisionId = objectMapper.readTree(body).get("decisionId").asText();
+
+		mockMvc.perform(patch(DECISIONS_PATH + "/{decisionId}/result", decisionId)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"result": "GO",
+					"finalPrice": 50000,
+					"selfCheckAnswers": [
+						{"questionCode": "NEED", "answerBoolean": true},
+						{"questionCode": "BUDGET", "answerBoolean": false},
+						{"questionCode": "UNKNOWN", "answerBoolean": false},
+						{"questionCode": "DELAY", "answerBoolean": false}
+					]
+				}
+				"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("BAD_REQUEST"));
+	}
+
+	@Test
 	void blocksNonSavedItemDecision() throws Exception {
 		UUID userId = createReadyUser();
 		insertBudgetCycle(userId, YearMonth.now(SEOUL_ZONE).toString(), 500_000, 0);

--- a/src/test/java/com/sagongsa/backend/itemimport/ItemImportApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/ItemImportApiIntegrationTest.java
@@ -1,0 +1,176 @@
+package com.sagongsa.backend.itemimport;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sagongsa.backend.itemimport.item.FetchedPage;
+import com.sagongsa.backend.itemimport.item.PageFetcher;
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = "app.notification.reminder-worker.enabled=false")
+@AutoConfigureMockMvc
+class ItemImportApiIntegrationTest extends PostgreSqlContainerTest {
+
+	private static final String IMPORT_LINK_PATH = "/api/v1/items/import-link";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private FakePageFetcher pageFetcher;
+
+	@BeforeEach
+	void setUp() {
+		pageFetcher.reset();
+	}
+
+	@Test
+	void importsSharedLinkThroughApiAndReturnsWishlistSaveDraft() throws Exception {
+		pageFetcher.stub(
+			"https://shop.example.com/products/100",
+			"""
+			<html>
+			<head>
+			  <meta property="og:title" content="Noise Canceling Headphones" />
+			  <meta property="og:description" content="가벼운 무선 헤드폰" />
+			  <meta property="og:image" content="https://cdn.example.com/headphones.jpg" />
+			  <meta property="product:price:amount" content="129000" />
+			</head>
+			<body></body>
+			</html>
+			"""
+		);
+
+		mockMvc.perform(post(IMPORT_LINK_PATH)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"inputSource": "SHARE",
+					"url": "https://shop.example.com/products/100?utm_source=kakao"
+				}
+				"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.retrievalStatus").value("SUCCESS"))
+			.andExpect(jsonPath("$.item.inputSource").value("SHARE"))
+			.andExpect(jsonPath("$.item.originalUrl").value("https://shop.example.com/products/100?utm_source=kakao"))
+			.andExpect(jsonPath("$.item.normalizedUrl").value("https://shop.example.com/products/100"))
+			.andExpect(jsonPath("$.item.title").value("Noise Canceling Headphones"))
+			.andExpect(jsonPath("$.item.listedPrice").value(129000))
+			.andExpect(jsonPath("$.item.currencyCode").value("KRW"))
+			.andExpect(jsonPath("$.item.category").value("DIGITAL"))
+			.andExpect(jsonPath("$.sourceMetadata.sourceDomain").value("shop.example.com"))
+			.andExpect(jsonPath("$.sourceMetadata.extractionMethod").value("HTML_META"))
+			.andExpect(jsonPath("$.saveRequest.normalizedUrl").value("https://shop.example.com/products/100"))
+			.andExpect(jsonPath("$.saveRequest.sourceDomain").value("shop.example.com"))
+			.andExpect(jsonPath("$.warnings", hasItem("추적성 query parameter를 제거했습니다.")));
+	}
+
+	@Test
+	void importsDirectInputWithoutUrlThroughApi() throws Exception {
+		mockMvc.perform(post(IMPORT_LINK_PATH)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"inputSource": "DIRECT_INPUT",
+					"title": "수동 입력 머그컵",
+					"brandName": "Daily Cup",
+					"price": 18000,
+					"imageUrl": "https://cdn.example.com/cup.jpg"
+				}
+				"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.retrievalStatus").value("SUCCESS"))
+			.andExpect(jsonPath("$.item.inputSource").value("DIRECT_INPUT"))
+			.andExpect(jsonPath("$.item.originalUrl").value(nullValue()))
+			.andExpect(jsonPath("$.item.normalizedUrl").value(nullValue()))
+			.andExpect(jsonPath("$.item.title").value("수동 입력 머그컵"))
+			.andExpect(jsonPath("$.item.brandName").value("Daily Cup"))
+			.andExpect(jsonPath("$.item.listedPrice").value(18000))
+			.andExpect(jsonPath("$.item.currencyCode").value("KRW"))
+			.andExpect(jsonPath("$.item.category").value("LIVING"))
+			.andExpect(jsonPath("$.sourceMetadata.extractionMethod").value("MANUAL"))
+			.andExpect(jsonPath("$.saveRequest.originalUrl").value(nullValue()))
+			.andExpect(jsonPath("$.saveRequest.normalizedUrl").value(nullValue()));
+	}
+
+	@Test
+	void rejectsShareUrlWithUserInfoThroughApi() throws Exception {
+		mockMvc.perform(post(IMPORT_LINK_PATH)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"inputSource": "SHARE",
+					"url": "https://user:password@shop.example.com/products/100"
+				}
+				"""))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void rejectsFailedShoppingPageThroughApi() throws Exception {
+		pageFetcher.stub("https://shop.example.com/products/missing", 404, "<html></html>");
+
+		mockMvc.perform(post(IMPORT_LINK_PATH)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"inputSource": "SHARE",
+					"url": "https://shop.example.com/products/missing"
+				}
+				"""))
+			.andExpect(status().isBadGateway());
+	}
+
+	@TestConfiguration
+	static class TestPageFetcherConfig {
+
+		@Bean
+		@Primary
+		FakePageFetcher fakePageFetcher() {
+			return new FakePageFetcher();
+		}
+	}
+
+	static final class FakePageFetcher implements PageFetcher {
+
+		private final Map<String, FetchedPage> pages = new HashMap<>();
+
+		void reset() {
+			pages.clear();
+		}
+
+		void stub(String url, String body) {
+			stub(url, 200, body);
+		}
+
+		void stub(String url, int statusCode, String body) {
+			URI uri = URI.create(url);
+			pages.put(url, new FetchedPage(uri, uri, statusCode, "text/html", body));
+		}
+
+		@Override
+		public FetchedPage fetch(URI uri) {
+			FetchedPage page = pages.get(uri.toString());
+			if (page == null) {
+				throw new AssertionError("No stubbed page for " + uri);
+			}
+			return page;
+		}
+	}
+}

--- a/src/test/java/com/sagongsa/backend/notification/NotificationServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/notification/NotificationServiceTest.java
@@ -1,0 +1,125 @@
+package com.sagongsa.backend.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.server.ResponseStatusException;
+
+@SpringBootTest
+class NotificationServiceTest extends PostgreSqlContainerTest {
+
+	@Autowired
+	private NotificationService notificationService;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.execute("truncate table users cascade");
+	}
+
+	@Test
+	void listsUnreadNotificationsNewestFirst() {
+		UUID userId = createUser("ACTIVE", "COMPLETED");
+		UUID oldUnreadId = insertNotification(userId, "WISHLIST_REMINDER", false, OffsetDateTime.now(ZoneOffset.UTC).minusHours(2));
+		insertNotification(userId, "SOCIAL_VOTE", true, OffsetDateTime.now(ZoneOffset.UTC).minusHours(1));
+		UUID newUnreadId = insertNotification(userId, "BUDGET_WARNING", false, OffsetDateTime.now(ZoneOffset.UTC));
+
+		List<NotificationResponse> responses = notificationService.list(userId, true);
+
+		assertThat(responses).extracting(NotificationResponse::id)
+			.containsExactly(newUnreadId, oldUnreadId);
+		assertThat(responses).allSatisfy(response -> assertThat(response.read()).isFalse());
+	}
+
+	@Test
+	void markAsReadSetsReadAtOnlyOnce() {
+		UUID userId = createUser("ACTIVE", "COMPLETED");
+		UUID notificationId = insertNotification(userId, "REGRET_CHECK_READY", false, OffsetDateTime.now(ZoneOffset.UTC));
+
+		NotificationResponse first = notificationService.markAsRead(userId, notificationId);
+		NotificationResponse second = notificationService.markAsRead(userId, notificationId);
+
+		assertThat(first.read()).isTrue();
+		assertThat(first.readAt()).isNotNull();
+		assertThat(second.readAt()).isEqualTo(first.readAt());
+		assertThat(queryBoolean("select is_read from notifications where id = ?", notificationId)).isTrue();
+	}
+
+	@Test
+	void rejectsNotificationsBeforeOnboardingCompletion() {
+		UUID userId = createUser("ACTIVE", "NOT_STARTED");
+
+		assertThatThrownBy(() -> notificationService.list(userId, false))
+			.isInstanceOf(ResponseStatusException.class)
+			.satisfies(exception -> assertThat(((ResponseStatusException) exception).getStatusCode())
+				.isEqualTo(HttpStatus.FORBIDDEN));
+	}
+
+	@Test
+	void throwsNotFoundWhenMarkingAnotherUsersNotification() {
+		UUID ownerId = createUser("ACTIVE", "COMPLETED");
+		UUID otherUserId = createUser("ACTIVE", "COMPLETED");
+		UUID notificationId = insertNotification(ownerId, "WISHLIST_REMINDER", false, OffsetDateTime.now(ZoneOffset.UTC));
+
+		assertThatThrownBy(() -> notificationService.markAsRead(otherUserId, notificationId))
+			.isInstanceOf(ResponseStatusException.class)
+			.satisfies(exception -> assertThat(((ResponseStatusException) exception).getStatusCode())
+				.isEqualTo(HttpStatus.NOT_FOUND));
+	}
+
+	private UUID createUser(String status, String onboardingStatus) {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into users (id, status, onboarding_status, created_at, updated_at)
+			values (?, ?, ?, ?, ?)
+			""",
+			userId,
+			status,
+			onboardingStatus,
+			now,
+			now
+		);
+		return userId;
+	}
+
+	private UUID insertNotification(UUID userId, String type, boolean read, OffsetDateTime createdAt) {
+		UUID notificationId = UUID.randomUUID();
+		OffsetDateTime readAt = read ? createdAt.plusMinutes(1) : null;
+		jdbcTemplate.update(
+			"""
+			insert into notifications (
+				id, user_id, notification_type, title, body, target_path,
+				is_read, read_at, created_at, updated_at
+			)
+			values (?, ?, ?, '알림', '내용', '/notifications', ?, ?, ?, ?)
+			""",
+			notificationId,
+			userId,
+			type,
+			read,
+			readAt,
+			createdAt,
+			createdAt
+		);
+		return notificationId;
+	}
+
+	private Boolean queryBoolean(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(sql, Boolean.class, args);
+	}
+}

--- a/src/test/java/com/sagongsa/backend/reflection/PurchaseReflectionControllerTest.java
+++ b/src/test/java/com/sagongsa/backend/reflection/PurchaseReflectionControllerTest.java
@@ -1,0 +1,109 @@
+package com.sagongsa.backend.reflection;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sagongsa.backend.auth.CurrentUserId;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class PurchaseReflectionControllerTest {
+
+	private PurchaseReflectionService purchaseReflectionService;
+	private MockMvc mockMvc;
+
+	@BeforeEach
+	void setUp() {
+		purchaseReflectionService = mock(PurchaseReflectionService.class);
+		mockMvc = MockMvcBuilders
+			.standaloneSetup(new PurchaseReflectionController(purchaseReflectionService))
+			.setCustomArgumentResolvers(new HeaderUserIdArgumentResolver())
+			.build();
+	}
+
+	@Test
+	void createsReflectionAndReturnsLocationHeader() throws Exception {
+		UUID userId = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+		UUID reflectionId = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+		UUID decisionId = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+		UUID itemId = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+		UUID reminderId = UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+		given(purchaseReflectionService.create(eq(userId), argThat(request -> decisionId.equals(request.decisionId()))))
+			.willReturn(new PurchaseReflectionResponse(
+				reflectionId,
+				decisionId,
+				itemId,
+				reminderId,
+				5,
+				"NONE",
+				true,
+				"잘 쓰고 있어요",
+				Instant.parse("2026-05-28T00:00:00Z")
+			));
+
+		mockMvc.perform(post("/api/v1/reflections")
+				.header("X-User-Id", userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"decisionId": "%s",
+					"satisfactionScore": 5,
+					"regretLevel": "NONE",
+					"stillUsing": true,
+					"reflectionNote": "잘 쓰고 있어요"
+				}
+				""".formatted(decisionId)))
+			.andExpect(status().isCreated())
+			.andExpect(header().string(HttpHeaders.LOCATION, "/api/v1/reflections/" + reflectionId))
+			.andExpect(jsonPath("$.id").value(reflectionId.toString()))
+			.andExpect(jsonPath("$.decisionId").value(decisionId.toString()))
+			.andExpect(jsonPath("$.itemId").value(itemId.toString()))
+			.andExpect(jsonPath("$.reminderId").value(reminderId.toString()))
+			.andExpect(jsonPath("$.regretLevel").value("NONE"));
+
+		verify(purchaseReflectionService).create(eq(userId), argThat(request ->
+			decisionId.equals(request.decisionId())
+				&& request.satisfactionScore() == 5
+				&& "NONE".equals(request.regretLevel())
+				&& Boolean.TRUE.equals(request.stillUsing())
+				&& "잘 쓰고 있어요".equals(request.reflectionNote())
+		));
+	}
+
+	private static final class HeaderUserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+		@Override
+		public boolean supportsParameter(MethodParameter parameter) {
+			return parameter.hasParameterAnnotation(CurrentUserId.class)
+				&& UUID.class.equals(parameter.getParameterType());
+		}
+
+		@Override
+		public Object resolveArgument(
+			MethodParameter parameter,
+			ModelAndViewContainer mavContainer,
+			NativeWebRequest webRequest,
+			WebDataBinderFactory binderFactory
+		) {
+			return UUID.fromString(webRequest.getHeader("X-User-Id"));
+		}
+	}
+}

--- a/src/test/java/com/sagongsa/backend/reflection/PurchaseReflectionControllerTest.java
+++ b/src/test/java/com/sagongsa/backend/reflection/PurchaseReflectionControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -16,14 +17,17 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.server.ResponseStatusException;
 
 class PurchaseReflectionControllerTest {
 
@@ -85,7 +89,26 @@ class PurchaseReflectionControllerTest {
 				&& "NONE".equals(request.regretLevel())
 				&& Boolean.TRUE.equals(request.stillUsing())
 				&& "잘 쓰고 있어요".equals(request.reflectionNote())
-		));
+			));
+	}
+
+	@Test
+	void rejectsMissingUserHeader() throws Exception {
+		UUID decisionId = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+
+		mockMvc.perform(post("/api/v1/reflections")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"decisionId": "%s",
+					"satisfactionScore": 5,
+					"regretLevel": "NONE",
+					"stillUsing": true
+				}
+				""".formatted(decisionId)))
+			.andExpect(status().isBadRequest());
+
+		verifyNoInteractions(purchaseReflectionService);
 	}
 
 	private static final class HeaderUserIdArgumentResolver implements HandlerMethodArgumentResolver {
@@ -103,7 +126,16 @@ class PurchaseReflectionControllerTest {
 			NativeWebRequest webRequest,
 			WebDataBinderFactory binderFactory
 		) {
-			return UUID.fromString(webRequest.getHeader("X-User-Id"));
+			String rawUserId = webRequest.getHeader("X-User-Id");
+			if (!StringUtils.hasText(rawUserId)) {
+				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "X-User-Id header is required.");
+			}
+			try {
+				return UUID.fromString(rawUserId.trim());
+			}
+			catch (IllegalArgumentException exception) {
+				throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "X-User-Id header must be a UUID.");
+			}
 		}
 	}
 }

--- a/src/test/java/com/sagongsa/backend/reflection/PurchaseReflectionServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/reflection/PurchaseReflectionServiceTest.java
@@ -1,0 +1,181 @@
+package com.sagongsa.backend.reflection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.server.ResponseStatusException;
+
+@SpringBootTest
+class PurchaseReflectionServiceTest extends PostgreSqlContainerTest {
+
+	@Autowired
+	private PurchaseReflectionService purchaseReflectionService;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.execute("truncate table users cascade");
+	}
+
+	@Test
+	void createsReflectionForGoDecisionAndTrimsOptionalNote() {
+		UUID userId = createReadyUser();
+		UUID itemId = insertSavedItem(userId, "구매 상품", "GO");
+		UUID decisionId = insertDecision(userId, itemId, "GO");
+		UUID reminderId = insertReminder(userId, itemId, decisionId);
+
+		PurchaseReflectionResponse response = purchaseReflectionService.create(
+			userId,
+			new PurchaseReflectionRequest(decisionId, 5, "low", true, "  잘 쓰고 있어요  ")
+		);
+
+		assertThat(response.decisionId()).isEqualTo(decisionId);
+		assertThat(response.itemId()).isEqualTo(itemId);
+		assertThat(response.reminderId()).isEqualTo(reminderId);
+		assertThat(response.satisfactionScore()).isEqualTo(5);
+		assertThat(response.regretLevel()).isEqualTo("LOW");
+		assertThat(response.stillUsing()).isTrue();
+		assertThat(response.reflectionNote()).isEqualTo("잘 쓰고 있어요");
+		assertThat(queryInteger("select count(*) from purchase_reflections where decision_id = ?", decisionId)).isEqualTo(1);
+	}
+
+	@Test
+	void rejectsDuplicateReflectionForSameDecision() {
+		UUID userId = createReadyUser();
+		UUID itemId = insertSavedItem(userId, "중복 상품", "GO");
+		UUID decisionId = insertDecision(userId, itemId, "GO");
+
+		purchaseReflectionService.create(userId, new PurchaseReflectionRequest(decisionId, 4, "NONE", true, null));
+
+		assertThatThrownBy(() -> purchaseReflectionService.create(
+			userId,
+			new PurchaseReflectionRequest(decisionId, 3, "LOW", true, null)
+		))
+			.isInstanceOf(ResponseStatusException.class)
+			.satisfies(exception -> assertThat(((ResponseStatusException) exception).getStatusCode())
+				.isEqualTo(HttpStatus.CONFLICT));
+	}
+
+	@Test
+	void rejectsStopDecisionReflection() {
+		UUID userId = createReadyUser();
+		UUID itemId = insertSavedItem(userId, "참은 상품", "STOP");
+		UUID decisionId = insertDecision(userId, itemId, "STOP");
+
+		assertThatThrownBy(() -> purchaseReflectionService.create(
+			userId,
+			new PurchaseReflectionRequest(decisionId, 3, "MEDIUM", false, null)
+		))
+			.isInstanceOf(ResponseStatusException.class)
+			.satisfies(exception -> assertThat(((ResponseStatusException) exception).getStatusCode())
+				.isEqualTo(HttpStatus.CONFLICT));
+	}
+
+	@Test
+	void rejectsInvalidRequestBody() {
+		UUID userId = createReadyUser();
+
+		assertThatThrownBy(() -> purchaseReflectionService.create(userId, null))
+			.isInstanceOf(ResponseStatusException.class)
+			.satisfies(exception -> assertThat(((ResponseStatusException) exception).getStatusCode())
+				.isEqualTo(HttpStatus.BAD_REQUEST));
+	}
+
+	private UUID createReadyUser() {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into users (id, status, onboarding_status, created_at, updated_at)
+			values (?, 'ACTIVE', 'COMPLETED', ?, ?)
+			""",
+			userId,
+			now,
+			now
+		);
+		return userId;
+	}
+
+	private UUID insertSavedItem(UUID userId, String title, String status) {
+		UUID itemId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into saved_items (
+				id, user_id, input_source, title, listed_price, currency_code,
+				category, category_locked_by_user, status, created_at, updated_at
+			)
+			values (?, ?, 'DIRECT_INPUT', ?, 30000, 'KRW', 'BEAUTY', false, ?, ?, ?)
+			""",
+			itemId,
+			userId,
+			title,
+			status,
+			now,
+			now
+		);
+		return itemId;
+	}
+
+	private UUID insertDecision(UUID userId, UUID itemId, String result) {
+		UUID decisionId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusDays(7);
+		jdbcTemplate.update(
+			"""
+			insert into purchase_decisions (
+				id, user_id, item_id, result, final_price, budget_after_amount,
+				similar_category_spend_amount, rationality_result, self_check_yes_count,
+				decided_at, created_at, updated_at
+			)
+			values (?, ?, ?, ?, 30000, 30000, 0, 'RATIONAL', 1, ?, ?, ?)
+			""",
+			decisionId,
+			userId,
+			itemId,
+			result,
+			now,
+			now,
+			now
+		);
+		return decisionId;
+	}
+
+	private UUID insertReminder(UUID userId, UUID itemId, UUID decisionId) {
+		UUID reminderId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into reminder_schedules (
+				id, user_id, item_id, decision_id, reminder_type, scheduled_for,
+				status, sent_at, created_at, updated_at
+			)
+			values (?, ?, ?, ?, 'REGRET_CHECK_7_DAYS', ?, 'SENT', ?, ?, ?)
+			""",
+			reminderId,
+			userId,
+			itemId,
+			decisionId,
+			now.minusMinutes(1),
+			now,
+			now,
+			now
+		);
+		return reminderId;
+	}
+
+	private Integer queryInteger(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(sql, Integer.class, args);
+	}
+}

--- a/src/test/java/com/sagongsa/backend/reflection/PurchaseReflectionServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/reflection/PurchaseReflectionServiceTest.java
@@ -57,8 +57,13 @@ class PurchaseReflectionServiceTest extends PostgreSqlContainerTest {
 		UUID itemId = insertSavedItem(userId, "중복 상품", "GO");
 		UUID decisionId = insertDecision(userId, itemId, "GO");
 
-		purchaseReflectionService.create(userId, new PurchaseReflectionRequest(decisionId, 4, "NONE", true, null));
+		PurchaseReflectionResponse created = purchaseReflectionService.create(
+			userId,
+			new PurchaseReflectionRequest(decisionId, 4, "NONE", true, null)
+		);
 
+		assertThat(created.reminderId()).isNull();
+		assertThat(created.satisfactionScore()).isEqualTo(4);
 		assertThatThrownBy(() -> purchaseReflectionService.create(
 			userId,
 			new PurchaseReflectionRequest(decisionId, 3, "LOW", true, null)
@@ -66,6 +71,22 @@ class PurchaseReflectionServiceTest extends PostgreSqlContainerTest {
 			.isInstanceOf(ResponseStatusException.class)
 			.satisfies(exception -> assertThat(((ResponseStatusException) exception).getStatusCode())
 				.isEqualTo(HttpStatus.CONFLICT));
+	}
+
+	@Test
+	void keepsNullableSatisfactionScoreWhenReminderExists() {
+		UUID userId = createReadyUser();
+		UUID itemId = insertSavedItem(userId, "점수 없는 상품", "GO");
+		UUID decisionId = insertDecision(userId, itemId, "GO");
+		UUID reminderId = insertReminder(userId, itemId, decisionId);
+
+		PurchaseReflectionResponse response = purchaseReflectionService.create(
+			userId,
+			new PurchaseReflectionRequest(decisionId, null, "NONE", true, null)
+		);
+
+		assertThat(response.reminderId()).isEqualTo(reminderId);
+		assertThat(response.satisfactionScore()).isNull();
 	}
 
 	@Test

--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistApiIntegrationTest.java
@@ -263,6 +263,32 @@ class WishlistApiIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void treatsBlankCursorAsFirstPage() throws Exception {
+		UUID userId = createUser();
+		UUID itemId = insertItem(userId, "Blank cursor target", "FASHION", "SAVED", OffsetDateTime.now(ZoneOffset.UTC));
+
+		mockMvc.perform(get(WISHLIST_ITEMS_PATH)
+				.header(USER_ID_HEADER, userId)
+				.queryParam("cursor", "   "))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.items", hasSize(1)))
+			.andExpect(jsonPath("$.items[0].id").value(itemId.toString()))
+			.andExpect(jsonPath("$.hasMore").value(false))
+			.andExpect(jsonPath("$.nextCursor").value(nullValue()));
+	}
+
+	@Test
+	void rejectsMalformedCursorQueryParameter() throws Exception {
+		UUID userId = createUser();
+
+		mockMvc.perform(get(WISHLIST_ITEMS_PATH)
+				.header(USER_ID_HEADER, userId)
+				.queryParam("cursor", "not-a-cursor"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("BAD_REQUEST"));
+	}
+
+	@Test
 	void listsWithStableCursorWhenCreatedAtTies() throws Exception {
 		UUID userId = createUser();
 		OffsetDateTime sameCreatedAt = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);


### PR DESCRIPTION
## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-38`
- Jira: https://parkjaehong.atlassian.net/browse/NF-38
- GitHub: Related #65
- GitHub: Closes #65

> PR 제목: `[test] NF-38 서비스/API 회귀 테스트 보강`
> 브랜치: `test/NF-38-service-api-regression`

---

## 🧾 이 PR의 테스트 범위 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #65의 최종 테스트 보강 단계
- 선행 PR: #66 `[test] NF-38 QA 대비 단위 테스트 보강`
- Base branch: `develop`

### 변경/추가 테스트 상세
- [x] 신규 테스트 추가
  - Unit/Service: 8개 (`NotificationServiceTest`, `PurchaseReflectionServiceTest`)
  - Controller: 1개 (`PurchaseReflectionControllerTest`)
  - Integration: 5개 (`ItemImportApiIntegrationTest`)
  - E2E: 0개
- [x] 기존 테스트 수정
  - `WishlistApiIntegrationTest`: cursor 경계 케이스 추가
  - `DecisionApiIntegrationTest`: self-check questionCode 경계 케이스 추가
- [ ] 테스트 삭제
  - 없음
- [x] 테스트 데이터/픽스처 변경
  - 외부 쇼핑몰 호출 대신 테스트 전용 fake `PageFetcher` 사용

### 대상 모듈/시나리오
1. 상품 링크 가져오기 API의 controller → service → response 계약
2. 위시리스트 cursor query parameter의 blank/malformed API 경계
3. 구매 결정 update API의 unknown self-check questionCode 거절
4. 리마인더/알림/구매 회고 서비스 및 컨트롤러 회귀 시나리오

---

## ✅ 이 PR이 커버하는 TC (필수)
### Covers (이 PR에서 구현)
- TC1: SHARE import API가 item/sourceMetadata/saveRequest/warnings를 반환
- TC2: DIRECT_INPUT import API가 URL 없이 수동 입력 상품을 반환
- TC3: SHARE import API가 userinfo URL을 400으로 거절
- TC4: SHARE import API가 쇼핑 페이지 실패를 502로 매핑
- TC5: wishlist list API가 blank cursor를 첫 페이지로 처리하고 malformed cursor를 400으로 거절
- TC6: decision update API가 unknown questionCode를 400으로 거절
- TC7: 알림 서비스가 리마인더 대상과 읽음 처리 계약을 유지
- TC8: 구매 회고 서비스/컨트롤러가 회고 조회 및 제출 계약을 유지

### Not covered (후속 작업)
- 외부 쇼핑몰 실호출 / 브라우저 렌더링 기반 E2E: 별도 E2E 환경 필요
- 운영 스케줄러 기반 reminder worker end-to-end 검증: 통합 환경에서 후속 확인

---

## ✅ 테스트 실행 결과 (필수)
### 로컬
```
./gradlew test
```
- ✅ 통과

### CI
- 현재 PR branch에 reported checks 없음
- 동일 변경 기준 로컬 전체 테스트 통과

---

## 🌐 영향 범위 체크 (필수)
- [x] 런타임 코드 변경 (요약: develop CI를 막던 dev endpoint 중복 매핑을 `consumes` 조건으로 분리)
- [ ] DB/마이그레이션 변경 (요약: 없음)
- [ ] CI 파이프라인 변경 (요약: 없음)
- [ ] 플래키 테스트 (원인/대응: 없음)

---

## 💬 리뷰 포인트 (필수)
- `ItemImportApiIntegrationTest`는 외부 네트워크 호출 없이 fake `PageFetcher`로 controller/service/API 계약만 확인합니다.
- wishlist/decision API 케이스는 단위 테스트로 고정한 계약을 HTTP 경계까지 확장합니다.
- dev endpoint 매핑 수정은 NF-48 PR #100과 동일한 CI 복구 패치이므로 #100이 먼저 머지되면 이 PR diff에서는 자연스럽게 사라질 수 있습니다.

