### PR TITLE
[Test] NF-46 MypageService 통합 테스트 작성 (1/2)

### DIFF
--- a/src/main/java/com/sagongsa/backend/dev/DevController.java
+++ b/src/main/java/com/sagongsa/backend/dev/DevController.java
@@ -134,7 +134,7 @@ public class DevController {
 	}
 
 	// 마이페이지 소비관리 테스트용: GO 2건 + STOP 1건 결정 데이터 생성
-	@PostMapping("/decisions/test")
+	@PostMapping("/decisions/test-batch")
 	@Transactional
 	public ResponseEntity<Map<String, Object>> createTestDecisions(@CurrentUserId UUID userId) {
 		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);

--- a/src/main/java/com/sagongsa/backend/mypage/MypageExceptionHandler.java
+++ b/src/main/java/com/sagongsa/backend/mypage/MypageExceptionHandler.java
@@ -15,4 +15,14 @@ class MypageExceptionHandler {
 	ErrorBody handleNotFound(MypageNotFoundException ex) {
 		return new ErrorBody("NOT_FOUND", ex.getMessage());
 	}
+
+	@ExceptionHandler(jakarta.validation.ConstraintViolationException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	ErrorBody handleConstraintViolation(jakarta.validation.ConstraintViolationException ex) {
+		String message = ex.getConstraintViolations().stream()
+			.map(v -> v.getPropertyPath() + ": " + v.getMessage())
+			.findFirst()
+			.orElse("잘못된 요청입니다.");
+		return new ErrorBody("BAD_REQUEST", message);
+	}
 }

--- a/src/test/java/com/sagongsa/backend/mypage/MypageServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/mypage/MypageServiceTest.java
@@ -341,15 +341,15 @@ class MypageServiceTest extends PostgreSqlContainerTest {
 		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
 		ZoneId kst = ZoneId.of("Asia/Seoul");
 		java.time.YearMonth ym = java.time.YearMonth.parse(yearMonth);
-		java.time.Instant decidedAt = ym.atDay(15).atStartOfDay(kst).toInstant();
+		OffsetDateTime monthMid = OffsetDateTime.ofInstant(
+			ym.atDay(15).atStartOfDay(kst).toInstant(), ZoneOffset.UTC);
 
 		jdbcTemplate.update(
 			"INSERT INTO saved_items (id, user_id, input_source, title, listed_price, currency_code, category, category_locked_by_user, status, created_at, updated_at) VALUES (?, ?, 'DIRECT_INPUT', '테스트 상품', ?, 'KRW', 'DIGITAL', false, ?, ?, ?)",
-			itemId, userId, price, result, now, now);
+			itemId, userId, price, result, monthMid, monthMid);
 		jdbcTemplate.update(
 			"INSERT INTO purchase_decisions (id, user_id, item_id, result, final_price, rationality_result, self_check_yes_count, is_changed, change_count, decided_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 'RATIONAL', 0, false, 0, ?, ?, ?)",
-			decisionId, userId, itemId, result, price,
-			OffsetDateTime.ofInstant(decidedAt, ZoneOffset.UTC), now, now);
+			decisionId, userId, itemId, result, price, monthMid, now, now);
 		return decisionId;
 	}
 }

--- a/src/test/java/com/sagongsa/backend/mypage/MypageServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/mypage/MypageServiceTest.java
@@ -1,0 +1,355 @@
+package com.sagongsa.backend.mypage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@SpringBootTest
+class MypageServiceTest extends PostgreSqlContainerTest {
+
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+	@Autowired
+	private MypageService mypageService;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.execute("truncate table users cascade");
+	}
+
+	// ── 프로필 조회 ──────────────────────────────────────────────────────────
+
+	@Test
+	void 프로필_조회_성공() {
+		UUID userId = insertUser("너굴이", "너구리");
+
+		MyProfileResponse response = mypageService.getMyProfile(userId);
+
+		assertThat(response.id()).isEqualTo(userId);
+		assertThat(response.nickname()).isEqualTo("너굴이");
+		assertThat(response.mascotName()).isEqualTo("너구리");
+	}
+
+	@Test
+	void 존재하지_않는_유저_프로필_조회시_예외() {
+		assertThatThrownBy(() -> mypageService.getMyProfile(UUID.randomUUID()))
+			.isInstanceOf(MypageNotFoundException.class);
+	}
+
+	@Test
+	void 게시글_수_프로필에_포함() {
+		UUID userId = insertUser("너굴이", "너구리");
+		insertPost(userId);
+		insertPost(userId);
+
+		MyProfileResponse response = mypageService.getMyProfile(userId);
+
+		assertThat(response.postCount()).isEqualTo(2);
+	}
+
+	@Test
+	void 삭제된_게시글은_프로필_게시글_수에_미포함() {
+		UUID userId = insertUser("너굴이", "너구리");
+		UUID postId = insertPost(userId);
+		jdbcTemplate.update("UPDATE feed_posts SET deleted_at = NOW() WHERE id = ?", postId);
+
+		MyProfileResponse response = mypageService.getMyProfile(userId);
+
+		assertThat(response.postCount()).isZero();
+	}
+
+	// ── 프로필 수정 ──────────────────────────────────────────────────────────
+
+	@Test
+	void 닉네임_수정_반영() {
+		UUID userId = insertUser("원래닉네임", "너구리");
+
+		MyProfileResponse response = mypageService.updateProfile(userId,
+			new UpdateProfileRequest("새닉네임", null));
+
+		assertThat(response.nickname()).isEqualTo("새닉네임");
+	}
+
+	@Test
+	void 마스코트_이름_수정_반영() {
+		UUID userId = insertUser("너굴이", "원래이름");
+
+		MyProfileResponse response = mypageService.updateProfile(userId,
+			new UpdateProfileRequest(null, "새이름"));
+
+		assertThat(response.mascotName()).isEqualTo("새이름");
+	}
+
+	// ── 예산 수정 ────────────────────────────────────────────────────────────
+
+	@Test
+	void 예산_신규_생성() {
+		UUID userId = insertUser("너굴이", "너구리");
+
+		MypageService.BudgetUpdateResponse response =
+			mypageService.updateBudget(userId, new UpdateBudgetRequest(300_000));
+
+		assertThat(response.monthlyBudget()).isEqualTo(300_000);
+	}
+
+	@Test
+	void 예산_기존_사이클_업데이트() {
+		UUID userId = insertUser("너굴이", "너구리");
+		String yearMonth = YearMonth.now(KST).toString();
+		insertBudgetCycle(userId, yearMonth, 200_000, 0);
+
+		MypageService.BudgetUpdateResponse response =
+			mypageService.updateBudget(userId, new UpdateBudgetRequest(500_000));
+
+		assertThat(response.monthlyBudget()).isEqualTo(500_000);
+		Integer stored = jdbcTemplate.queryForObject(
+			"SELECT monthly_budget_amount FROM budget_cycles WHERE user_id = ? AND year_month = ?",
+			Integer.class, userId, yearMonth);
+		assertThat(stored).isEqualTo(500_000);
+	}
+
+	// ── 알림 설정 ────────────────────────────────────────────────────────────
+
+	@Test
+	void 알림_설정_조회_프로필_없으면_기본값_true() {
+		UUID userId = insertUserNoProfile();
+
+		MypageService.NotificationSettingsResponse response =
+			mypageService.getNotificationSettings(userId);
+
+		assertThat(response.notificationEnabled()).isTrue();
+	}
+
+	@Test
+	void 알림_설정_변경_반영() {
+		UUID userId = insertUser("너굴이", "너구리");
+
+		MypageService.NotificationSettingsResponse response =
+			mypageService.updateNotificationSettings(userId,
+				new NotificationSettingsRequest(false));
+
+		assertThat(response.notificationEnabled()).isFalse();
+	}
+
+	@Test
+	void 알림_설정_다시_켜기() {
+		UUID userId = insertUser("너굴이", "너구리");
+		mypageService.updateNotificationSettings(userId, new NotificationSettingsRequest(false));
+
+		MypageService.NotificationSettingsResponse response =
+			mypageService.updateNotificationSettings(userId, new NotificationSettingsRequest(true));
+
+		assertThat(response.notificationEnabled()).isTrue();
+	}
+
+	// ── 통계 ─────────────────────────────────────────────────────────────────
+
+	@Test
+	void 통계_예산_없으면_null() {
+		UUID userId = insertUser("너굴이", "너구리");
+		String yearMonth = YearMonth.now(KST).toString();
+
+		StatsResponse response = mypageService.getStats(userId, yearMonth);
+
+		assertThat(response.budgetAmount()).isNull();
+		assertThat(response.spentAmount()).isZero();
+	}
+
+	@Test
+	void 통계_지출액_GO_결정만_집계() {
+		UUID userId = insertUser("너굴이", "너구리");
+		String yearMonth = YearMonth.now(KST).toString();
+		insertBudgetCycle(userId, yearMonth, 500_000, 100_000);
+		insertDecision(userId, "GO", 100_000, yearMonth);
+		insertDecision(userId, "STOP", 50_000, yearMonth);
+
+		StatsResponse response = mypageService.getStats(userId, yearMonth);
+
+		assertThat(response.spentAmount()).isEqualTo(100_000);
+		assertThat(response.restrainedAmount()).isEqualTo(50_000);
+		assertThat(response.boughtCount()).isEqualTo(1);
+		assertThat(response.restrainedCount()).isEqualTo(1);
+	}
+
+	@Test
+	void 통계_예산_사용률_계산() {
+		UUID userId = insertUser("너굴이", "너구리");
+		String yearMonth = YearMonth.now(KST).toString();
+		insertBudgetCycle(userId, yearMonth, 200_000, 0);
+		insertDecision(userId, "GO", 100_000, yearMonth);
+
+		StatsResponse response = mypageService.getStats(userId, yearMonth);
+
+		assertThat(response.usageRate()).isEqualTo(50.0);
+	}
+
+	@Test
+	void 통계_연월_없으면_현재_달_사용() {
+		UUID userId = insertUser("너굴이", "너구리");
+
+		StatsResponse response = mypageService.getStats(userId, null);
+
+		assertThat(response.yearMonth()).isEqualTo(YearMonth.now(KST).toString());
+	}
+
+	// ── 이용 가능 월 목록 ────────────────────────────────────────────────────
+
+	@Test
+	void 이용_가능_월_현재_달_항상_포함() {
+		UUID userId = insertUser("너굴이", "너구리");
+
+		AvailableMonthsResponse response = mypageService.getAvailableMonths(userId);
+
+		assertThat(response.months()).contains(YearMonth.now(KST).toString());
+		assertThat(response.currentMonth()).isEqualTo(YearMonth.now(KST).toString());
+	}
+
+	@Test
+	void 이용_가능_월_예산_사이클_있으면_포함() {
+		UUID userId = insertUser("너굴이", "너구리");
+		insertBudgetCycle(userId, "2026-03", 300_000, 0);
+		insertBudgetCycle(userId, "2026-04", 300_000, 0);
+
+		AvailableMonthsResponse response = mypageService.getAvailableMonths(userId);
+
+		assertThat(response.months()).contains("2026-03", "2026-04");
+	}
+
+	@Test
+	void 이용_가능_월_내림차순_정렬() {
+		UUID userId = insertUser("너굴이", "너구리");
+		insertBudgetCycle(userId, "2026-01", 100_000, 0);
+		insertBudgetCycle(userId, "2026-03", 100_000, 0);
+
+		AvailableMonthsResponse response = mypageService.getAvailableMonths(userId);
+
+		int idxCurrentOrLater = response.months().indexOf(YearMonth.now(KST).toString());
+		int idx01 = response.months().indexOf("2026-01");
+		assertThat(idxCurrentOrLater).isLessThan(idx01);
+	}
+
+	// ── 위시 히스토리 ────────────────────────────────────────────────────────
+
+	@Test
+	void 위시_히스토리_GO_필터링() {
+		UUID userId = insertUser("너굴이", "너구리");
+		String yearMonth = YearMonth.now(KST).toString();
+		insertDecision(userId, "GO", 50_000, yearMonth);
+		insertDecision(userId, "STOP", 30_000, yearMonth);
+
+		WishHistoryResponse response = mypageService.getWishHistory(
+			userId, com.sagongsa.backend.domain.enums.ItemStatus.GO, yearMonth, 0, 20);
+
+		assertThat(response.wishes()).hasSize(1);
+		assertThat(response.wishes().get(0).status()).isEqualTo(com.sagongsa.backend.domain.enums.ItemStatus.GO);
+	}
+
+	// ── 회원 탈퇴 ────────────────────────────────────────────────────────────
+
+	@Test
+	void 탈퇴_후_유저_상태_WITHDRAWN() {
+		UUID userId = insertUser("너굴이", "너구리");
+
+		mypageService.deleteAccount(userId);
+
+		String status = jdbcTemplate.queryForObject(
+			"SELECT status FROM users WHERE id = ?", String.class, userId);
+		assertThat(status).isEqualTo("WITHDRAWN");
+	}
+
+	@Test
+	void 탈퇴_후_프로필_삭제() {
+		UUID userId = insertUser("너굴이", "너구리");
+
+		mypageService.deleteAccount(userId);
+
+		Integer count = jdbcTemplate.queryForObject(
+			"SELECT COUNT(*) FROM user_profiles WHERE user_id = ?", Integer.class, userId);
+		assertThat(count).isZero();
+	}
+
+	@Test
+	void 탈퇴_후_게시글_소프트_삭제() {
+		UUID userId = insertUser("너굴이", "너구리");
+		insertPost(userId);
+
+		mypageService.deleteAccount(userId);
+
+		Integer count = jdbcTemplate.queryForObject(
+			"SELECT COUNT(*) FROM feed_posts WHERE user_id = ? AND deleted_at IS NULL", Integer.class, userId);
+		assertThat(count).isZero();
+	}
+
+	// ── 헬퍼 ─────────────────────────────────────────────────────────────────
+
+	private UUID insertUser(String nickname, String mascotName) {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"INSERT INTO users (id, status, onboarding_status, created_at, updated_at) VALUES (?, 'ACTIVE', 'COMPLETED', ?, ?)",
+			userId, now, now);
+		jdbcTemplate.update(
+			"INSERT INTO user_profiles (user_id, nickname, mascot_name, timezone, created_at, updated_at) VALUES (?, ?, ?, 'Asia/Seoul', ?, ?)",
+			userId, nickname, mascotName, now, now);
+		return userId;
+	}
+
+	private UUID insertUserNoProfile() {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"INSERT INTO users (id, status, onboarding_status, created_at, updated_at) VALUES (?, 'ACTIVE', 'COMPLETED', ?, ?)",
+			userId, now, now);
+		return userId;
+	}
+
+	private UUID insertPost(UUID userId) {
+		UUID postId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"INSERT INTO feed_posts (id, user_id, title, body, go_count, stop_count, created_at, updated_at) VALUES (?, ?, '테스트 게시글', '내용', 0, 0, ?, ?)",
+			postId, userId, now, now);
+		return postId;
+	}
+
+	private UUID insertBudgetCycle(UUID userId, String yearMonth, int monthlyBudget, int spentAmount) {
+		UUID id = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"INSERT INTO budget_cycles (id, user_id, year_month, monthly_budget_amount, spent_amount, warning_threshold_rate, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 80.00, ?, ?)",
+			id, userId, yearMonth, monthlyBudget, spentAmount, now, now);
+		return id;
+	}
+
+	private UUID insertDecision(UUID userId, String result, int price, String yearMonth) {
+		UUID itemId = UUID.randomUUID();
+		UUID decisionId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		ZoneId kst = ZoneId.of("Asia/Seoul");
+		java.time.YearMonth ym = java.time.YearMonth.parse(yearMonth);
+		java.time.Instant decidedAt = ym.atDay(15).atStartOfDay(kst).toInstant();
+
+		jdbcTemplate.update(
+			"INSERT INTO saved_items (id, user_id, input_source, title, listed_price, currency_code, category, category_locked_by_user, status, created_at, updated_at) VALUES (?, ?, 'DIRECT_INPUT', '테스트 상품', ?, 'KRW', 'DIGITAL', false, ?, ?, ?)",
+			itemId, userId, price, result, now, now);
+		jdbcTemplate.update(
+			"INSERT INTO purchase_decisions (id, user_id, item_id, result, final_price, rationality_result, self_check_yes_count, is_changed, change_count, decided_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 'RATIONAL', 0, false, 0, ?, ?, ?)",
+			decisionId, userId, itemId, result, price,
+			OffsetDateTime.ofInstant(decidedAt, ZoneOffset.UTC), now, now);
+		return decisionId;
+	}
+}


### PR DESCRIPTION
## 🔗 작업 키 / 이슈 링크

- GitHub: Related #93
- 전체 이슈 #93의 1/2 단계
- 후속 PR: test/mypage-api-tests

---

## 🧾 이 PR의 테스트 범위

### 변경/추가 테스트 상세
- [x] 신규 테스트 추가
  - Integration: 21개 (MypageServiceTest)

### 대상 모듈/시나리오
1. 프로필 조회/수정 — 닉네임, 마스코트, 게시글 수 포함 여부
2. 예산 — 신규 생성 vs 기존 사이클 업데이트
3. 알림 설정 — 프로필 없을 때 기본값 true, 변경/재전환
4. 통계 — GO/STOP 금액 집계, 사용률 계산, yearMonth null → 현재 달
5. 이용 가능 월 — 현재 달 항상 포함, 내림차순 정렬
6. 위시 히스토리 — status 필터링
7. 회원 탈퇴 — WITHDRAWN 상태 전환, 프로필·게시글 삭제 확인

---

## ✅ 테스트 실행 결과

### 로컬
```
./gradlew test --tests "com.sagongsa.backend.mypage.MypageServiceTest"
```
- ✅ 21개 전부 통과

---

## 🌐 영향 범위 체크

- [x] 런타임 코드 변경
  - `MypageExceptionHandler`: `ConstraintViolationException` 핸들러 추가 — 쿼리 파라미터 유효성 오류 시 500 반환되던 문제 수정
  - `DevController`: `POST /decisions/test` 중복 매핑 → `/decisions/test-batch` 로 분리 (동일 문제가 develop에도 존재)

---

## 💬 리뷰 포인트

- `insertDecision` 헬퍼에서 `decided_at`을 해당 월 15일로 고정해 통계 범위 계산을 안정적으로 처리한 부분
- `MypageExceptionHandler` 핸들러 추가가 기존 ConsumptionExceptionHandler 패턴과 일치하는지 확인