### PR TITLE
[Test] NF-47 DeliberationController API 통합 테스트 작성

### DIFF
--- a/src/main/java/com/sagongsa/backend/deliberation/DeliberationController.java
+++ b/src/main/java/com/sagongsa/backend/deliberation/DeliberationController.java
@@ -29,8 +29,8 @@ public class DeliberationController {
 		responses = {
 			@ApiResponse(responseCode = "200", description = "Deliberation summary returned"),
 			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication"),
-			@ApiResponse(responseCode = "403", description = "Item belongs to another user"),
-			@ApiResponse(responseCode = "404", description = "Item does not exist")
+			@ApiResponse(responseCode = "403", description = "User not eligible (onboarding incomplete or suspended)"),
+			@ApiResponse(responseCode = "404", description = "Item does not exist or belongs to another user")
 		}
 	)
 	public DeliberationSummaryResponse getSummary(

--- a/src/main/java/com/sagongsa/backend/dev/DevController.java
+++ b/src/main/java/com/sagongsa/backend/dev/DevController.java
@@ -134,7 +134,7 @@ public class DevController {
 	}
 
 	// 마이페이지 소비관리 테스트용: GO 2건 + STOP 1건 결정 데이터 생성
-	@PostMapping("/decisions/test")
+	@PostMapping("/decisions/test-batch")
 	@Transactional
 	public ResponseEntity<Map<String, Object>> createTestDecisions(@CurrentUserId UUID userId) {
 		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);

--- a/src/test/java/com/sagongsa/backend/deliberation/DeliberationApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/deliberation/DeliberationApiIntegrationTest.java
@@ -6,6 +6,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.sagongsa.backend.support.PostgreSqlContainerTest;
 import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,6 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
 class DeliberationApiIntegrationTest extends PostgreSqlContainerTest {
 
 	private static final String BASE = "/api/v1/deliberations/items";
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
 	@Autowired
 	private MockMvc mockMvc;
@@ -56,7 +59,7 @@ class DeliberationApiIntegrationTest extends PostgreSqlContainerTest {
 	void 예산_사이클_있으면_예산_정보_포함() throws Exception {
 		UUID userId = insertUser("ACTIVE", "COMPLETED");
 		UUID itemId = insertSavedItem(userId, "맥북", 1_500_000, "DIGITAL", "SAVED");
-		insertBudgetCycle(userId, "2026-05", 2_000_000, 300_000);
+		insertBudgetCycle(userId, YearMonth.now(KST).toString(), 2_000_000, 300_000);
 
 		mockMvc.perform(get(BASE + "/{itemId}", itemId)
 				.header("X-User-Id", userId))

--- a/src/test/java/com/sagongsa/backend/deliberation/DeliberationApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/deliberation/DeliberationApiIntegrationTest.java
@@ -1,0 +1,183 @@
+package com.sagongsa.backend.deliberation;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class DeliberationApiIntegrationTest extends PostgreSqlContainerTest {
+
+	private static final String BASE = "/api/v1/deliberations/items";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.execute("truncate table users cascade");
+	}
+
+	// ── 정상 응답 ─────────────────────────────────────────────────────────
+
+	@Test
+	void 숙려_요약_조회_200_응답_필드_확인() throws Exception {
+		UUID userId = insertUser("ACTIVE", "COMPLETED");
+		UUID itemId = insertSavedItem(userId, "에어팟 프로", 350_000, "DIGITAL", "SAVED");
+
+		mockMvc.perform(get(BASE + "/{itemId}", itemId)
+				.header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.item").exists())
+			.andExpect(jsonPath("$.item.id").value(itemId.toString()))
+			.andExpect(jsonPath("$.item.title").value("에어팟 프로"))
+			.andExpect(jsonPath("$.item.listedPrice").value(350_000))
+			.andExpect(jsonPath("$.budget").exists())
+			.andExpect(jsonPath("$.opportunityCostMessage").isString())
+			.andExpect(jsonPath("$.similarCategorySpendAmount").isNumber());
+	}
+
+	@Test
+	void 예산_사이클_있으면_예산_정보_포함() throws Exception {
+		UUID userId = insertUser("ACTIVE", "COMPLETED");
+		UUID itemId = insertSavedItem(userId, "맥북", 1_500_000, "DIGITAL", "SAVED");
+		insertBudgetCycle(userId, "2026-05", 2_000_000, 300_000);
+
+		mockMvc.perform(get(BASE + "/{itemId}", itemId)
+				.header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.budget.monthlyBudgetAmount").value(2_000_000))
+			.andExpect(jsonPath("$.budget.spentAmount").value(300_000));
+	}
+
+	@Test
+	void 가격_있으면_기회비용_메시지에_금액_포함() throws Exception {
+		UUID userId = insertUser("ACTIVE", "COMPLETED");
+		UUID itemId = insertSavedItem(userId, "운동화", 120_000, "FASHION", "SAVED");
+
+		mockMvc.perform(get(BASE + "/{itemId}", itemId)
+				.header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.opportunityCostMessage").value("120,000원을 다른 곳에 쓸 수도 있어요."));
+	}
+
+	@Test
+	void 가격_없으면_기회비용_안내_메시지() throws Exception {
+		UUID userId = insertUser("ACTIVE", "COMPLETED");
+		UUID itemId = insertSavedItem(userId, "가격_미입력_상품", null, "FASHION", "SAVED");
+
+		mockMvc.perform(get(BASE + "/{itemId}", itemId)
+				.header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.opportunityCostMessage").value("가격을 입력하면 다른 선택지와 비교하기 쉬워요."));
+	}
+
+	// ── 접근 제어 ─────────────────────────────────────────────────────────
+
+	@Test
+	void 존재하지_않는_유저_404() throws Exception {
+		mockMvc.perform(get(BASE + "/{itemId}", UUID.randomUUID())
+				.header("X-User-Id", UUID.randomUUID()))
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void 온보딩_미완료_유저_403() throws Exception {
+		UUID userId = insertUser("ACTIVE", "NOT_STARTED");
+		UUID itemId = insertSavedItem(userId, "상품", 10_000, "DIGITAL", "SAVED");
+
+		mockMvc.perform(get(BASE + "/{itemId}", itemId)
+				.header("X-User-Id", userId))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	void SUSPENDED_유저_403() throws Exception {
+		UUID userId = insertUser("SUSPENDED", "COMPLETED");
+		UUID itemId = insertSavedItem(userId, "상품", 10_000, "DIGITAL", "SAVED");
+
+		mockMvc.perform(get(BASE + "/{itemId}", itemId)
+				.header("X-User-Id", userId))
+			.andExpect(status().isForbidden());
+	}
+
+	// ── 아이템 상태 검증 ──────────────────────────────────────────────────
+
+	@Test
+	void 존재하지_않는_아이템_404() throws Exception {
+		UUID userId = insertUser("ACTIVE", "COMPLETED");
+
+		mockMvc.perform(get(BASE + "/{itemId}", UUID.randomUUID())
+				.header("X-User-Id", userId))
+			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void DROPPED_아이템_409() throws Exception {
+		UUID userId = insertUser("ACTIVE", "COMPLETED");
+		UUID itemId = insertSavedItem(userId, "포기한 상품", 50_000, "DIGITAL", "DROPPED");
+
+		mockMvc.perform(get(BASE + "/{itemId}", itemId)
+				.header("X-User-Id", userId))
+			.andExpect(status().isConflict());
+	}
+
+	@Test
+	void 타인_아이템_접근_404() throws Exception {
+		UUID owner = insertUser("ACTIVE", "COMPLETED");
+		UUID other = insertUser("ACTIVE", "COMPLETED");
+		UUID itemId = insertSavedItem(owner, "타인 상품", 30_000, "DIGITAL", "SAVED");
+
+		mockMvc.perform(get(BASE + "/{itemId}", itemId)
+				.header("X-User-Id", other))
+			.andExpect(status().isNotFound());
+	}
+
+	// ── 헬퍼 ─────────────────────────────────────────────────────────────
+
+	private UUID insertUser(String status, String onboardingStatus) {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"INSERT INTO users (id, status, onboarding_status, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+			userId, status, onboardingStatus, now, now);
+		jdbcTemplate.update(
+			"INSERT INTO user_profiles (user_id, nickname, mascot_name, timezone, created_at, updated_at) VALUES (?, '너굴이', '너구리', 'Asia/Seoul', ?, ?)",
+			userId, now, now);
+		return userId;
+	}
+
+	private UUID insertSavedItem(UUID userId, String title, Integer price, String category, String status) {
+		UUID itemId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			INSERT INTO saved_items (id, user_id, input_source, title, listed_price, currency_code, category, category_locked_by_user, status, created_at, updated_at)
+			VALUES (?, ?, 'DIRECT_INPUT', ?, ?, 'KRW', ?, false, ?, ?, ?)
+			""",
+			itemId, userId, title, price, category, status, now, now);
+		return itemId;
+	}
+
+	private void insertBudgetCycle(UUID userId, String yearMonth, int monthlyBudget, int spentAmount) {
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"INSERT INTO budget_cycles (id, user_id, year_month, monthly_budget_amount, spent_amount, warning_threshold_rate, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 80.00, ?, ?)",
+			UUID.randomUUID(), userId, yearMonth, monthlyBudget, spentAmount, now, now);
+	}
+}


### PR DESCRIPTION
## 🔗 작업 키 / 이슈 링크

- GitHub: Related #94

---

## 🧾 이 PR의 테스트 범위

`DeliberationServiceTest`(서비스 단위 테스트 16개)는 이미 존재하므로 HTTP 레이어 검증에 집중합니다.

### 변경/추가 테스트 상세
- [x] 신규 테스트 추가
  - Integration: 10개 (DeliberationApiIntegrationTest)

### 대상 모듈/시나리오 — `GET /api/v1/deliberations/items/{itemId}`

| 케이스 | 기대 상태코드 |
|--------|------------|
| 정상 응답 필드 확인 (item / budget / opportunityCostMessage 등) | 200 |
| 예산 사이클 있을 때 budget 수치 포함 | 200 |
| 가격 있을 때 기회비용 메시지에 금액 포함 | 200 |
| 가격 없을 때 안내 메시지 | 200 |
| 존재하지 않는 유저 | 404 |
| 온보딩 미완료 유저 | 403 |
| SUSPENDED 유저 | 403 |
| 존재하지 않는 아이템 | 404 |
| DROPPED 아이템 | 409 |
| 타인 소유 아이템 접근 | 404 |

---

## ✅ 테스트 실행 결과

### 로컬
```
./gradlew test --tests "com.sagongsa.backend.deliberation.DeliberationApiIntegrationTest"
```
- ✅ 10개 전부 통과

---

## 🌐 영향 범위 체크

- [x] 런타임 코드 변경
  - `DevController`: `POST /decisions/test` 중복 매핑 → `/decisions/test-batch` (develop 브랜치에 동일 버그 존재)

---

## 💬 리뷰 포인트

- 타인 소유 아이템 접근 시 403이 아닌 404가 반환되는 이유: `findSavedItem`이 `WHERE user_id = ? AND id = ?`로 필터링하므로 소유권 위반과 미존재를 동일하게 처리함 — 의도된 동작인지 확인 필요