### PR TITLE
[chore] NF-49 JaCoCo 커버리지 리포트 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,14 @@ jobs:
       - name: Grant execute permission for Gradle wrapper
         run: chmod +x gradlew
 
-      - name: Run tests
-        run: ./gradlew test
+      - name: Run tests and coverage
+        run: ./gradlew test jacocoTestReport
+
+      - name: Upload JaCoCo report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: jacoco-report
+          path: |
+            build/reports/jacoco/test/html
+            build/reports/jacoco/test/jacocoTestReport.xml

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@
 ./gradlew test
 ```
 
+## Coverage
+
+JaCoCo 커버리지 리포트는 테스트 실행 후 생성됩니다.
+HTML 리포트는 브라우저로 확인하고, XML 리포트는 CI/외부 도구 연동에 사용할 수 있습니다.
+
+```bash
+./gradlew test jacocoTestReport
+```
+
+- HTML: `build/reports/jacoco/test/html/index.html`
+- XML: `build/reports/jacoco/test/jacocoTestReport.xml`
+
 ## Notes
 
 - 기준 문서: `docs/DOMAIN_SCHEMA_REVISED_FROM_PLANNING_2026_04_16.md`

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'java'
+	id 'jacoco'
 	id 'org.springframework.boot' version '3.5.11'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
@@ -12,6 +13,10 @@ java {
 	toolchain {
 		languageVersion = JavaLanguageVersion.of(21)
 	}
+}
+
+jacoco {
+	toolVersion = '0.8.13'
 }
 
 repositories {
@@ -39,4 +44,15 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy tasks.named('jacocoTestReport')
+}
+
+tasks.named('jacocoTestReport') {
+	dependsOn tasks.named('test')
+
+	reports {
+		xml.required = true
+		html.required = true
+		csv.required = false
+	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
-	finalizedBy tasks.named('jacocoTestReport')
 }
 
 tasks.named('jacocoTestReport') {

--- a/docs/prs/NF-49-JACOCO_COVERAGE_BASELINE.md
+++ b/docs/prs/NF-49-JACOCO_COVERAGE_BASELINE.md
@@ -1,0 +1,37 @@
+# NF-49 JaCoCo Coverage Baseline
+
+## 목적
+
+NF-49에서는 테스트 커버리지 기준선을 확인할 수 있도록 JaCoCo 리포트 생성을 추가한다.
+이번 범위에서는 커버리지 미달 시 빌드를 실패시키는 gate는 적용하지 않는다.
+
+## 실행
+
+```bash
+./gradlew test jacocoTestReport
+```
+
+## 산출물
+
+- HTML: `build/reports/jacoco/test/html/index.html`
+- XML: `build/reports/jacoco/test/jacocoTestReport.xml`
+- CI artifact: `jacoco-report`
+
+## 최초 기준선
+
+`./gradlew test jacocoTestReport --console=plain` 기준:
+
+| Counter | Covered / Total | Coverage |
+| --- | ---: | ---: |
+| Instruction | 12,138 / 16,173 | 75.05% |
+| Branch | 548 / 970 | 56.49% |
+| Line | 2,239 / 2,962 | 75.59% |
+| Complexity | 758 / 1,249 | 60.69% |
+| Method | 578 / 763 | 75.75% |
+| Class | 196 / 218 | 89.91% |
+
+## 후속 검토
+
+- NF-38 회귀 테스트 대상 패키지의 라인/브랜치 커버리지 확인
+- 80% 기준 적용 여부 검토
+- 필요 시 `jacocoTestCoverageVerification` 기준 추가

--- a/src/main/java/com/sagongsa/backend/dev/DevController.java
+++ b/src/main/java/com/sagongsa/backend/dev/DevController.java
@@ -17,6 +17,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.UUID;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
@@ -76,7 +77,7 @@ public class DevController {
 
 	record TestDecisionRequest(String title, Integer price, String result) {}
 
-	@PostMapping("/decisions/test")
+	@PostMapping(value = "/decisions/test", consumes = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional
 	public ResponseEntity<Map<String, String>> createTestDecision(
 		@CurrentUserId UUID userId,


### PR DESCRIPTION
## 🔗 작업 키 / 이슈 링크 (필수)
- Jira Key: `NF-49`
- Jira Issue: https://parkjaehong.atlassian.net/browse/NF-49
- Tracking Key: `NF-49`

> PR 제목: `[chore] NF-49 JaCoCo 커버리지 리포트 추가`  
> 브랜치: `chore/NF-49-jacoco-coverage`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #102

---

## 🧩 한눈에 요약 (필수)
### 무엇을 변경했나? (인프라/빌드/CI/의존성 등)
- [ ] 인프라
- [x] 설정파일
- [x] 빌드 파일
- [x] CI
- [ ] 의존성
- [x] 런타임/비즈니스 로직 리팩터링 없음

### 왜 필요한가? (안정성/속도/보안/개발경험)
- 테스트 커버리지 현황을 PR/CI에서 확인할 수 있도록 JaCoCo HTML/XML 리포트를 생성합니다.
- 이후 80% coverage gate 적용 여부를 판단하기 위한 기준선 문서를 남깁니다.

### 범위(스코프)
- Included: Gradle JaCoCo 설정, CI 리포트 생성 및 artifact 업로드, README 안내, NF-49 기준선 문서
- Not included: coverage verification gate 적용, 커버리지 미달 모듈 테스트 추가

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew test jacocoTestReport --console=plain`
- Result: ✅ 통과

### CI
- 링크/결과: ✅ Gradle Test 통과
- https://github.com/SaGongSa-404/404_BE/actions/runs/26572402113/job/78282664693

### Smoke / 수동 검증 (해당 시)
- 시나리오: `build/reports/jacoco/test/html` 및 `build/reports/jacoco/test/jacocoTestReport.xml` 생성 확인
- 결과: ✅ 생성 확인

### 테스트 공백(있다면 이유 필수)
- coverage gate는 현재 기준선이 약 75%라 이번 PR에는 적용하지 않았습니다.

---

## 🧭 영향 범위 (필수)
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음 (항목: )
- [ ] CI/빌드 파이프라인 영향 없음
- [x] CI/빌드 파이프라인 영향 있음 (요약: CI에서 `jacocoTestReport` 실행 및 report artifact 업로드)
- [x] 의존성(dependency) 변경 없음
- [ ] 의존성(dependency) 변경 있음 (패키지/버전/주요 변경점: )

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- CI 실행 시간이 JaCoCo 리포트 생성 및 artifact 업로드만큼 소폭 증가할 수 있습니다.
- NF-48 PR #100이 먼저 머지되면 dev endpoint 매핑 수정은 이 PR diff에서 중복 해소될 수 있습니다.

### 롤백
- [x] 단순 revert로 가능
- [ ] 버전 pin/되돌리기 필요 (대상: , 방법: )
- [ ] 배포 롤백(이전 태그/이미지) 가능

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/설정: `build.gradle`, `.github/workflows/ci.yml`, `docs/prs/NF-49-JACOCO_COVERAGE_BASELINE.md`
- 트레이드오프/대안: 이번 PR은 리포트 생성까지만 포함하고 coverage gate는 후속 PR로 분리합니다.
- 성능/보안/호환성 영향: 런타임 영향 없음, CI 시간만 소폭 증가 가능



