### PR TITLE
[fix] NF-48 CI 오류 해결

### DIFF
--- a/src/main/java/com/sagongsa/backend/dev/DevController.java
+++ b/src/main/java/com/sagongsa/backend/dev/DevController.java
@@ -17,6 +17,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.UUID;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
@@ -76,7 +77,7 @@ public class DevController {
 
 	record TestDecisionRequest(String title, Integer price, String result) {}
 
-	@PostMapping("/decisions/test")
+	@PostMapping(value = "/decisions/test", consumes = MediaType.APPLICATION_JSON_VALUE)
 	@Transactional
 	public ResponseEntity<Map<String, String>> createTestDecision(
 		@CurrentUserId UUID userId,


### PR DESCRIPTION
## 🔗 작업 키 / 이슈 링크 (필수)
- Jira Key: `NF-48`
- Jira Issue: https://parkjaehong.atlassian.net/browse/NF-48
- Tracking Key: `NF-48`

> PR 제목: `[fix] NF-48 CI 오류 해결`  
> 브랜치: `fix/NF-48-develop-ci-dev-mapping`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #101

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- `develop` CI에서 Spring context 로딩 중 `Ambiguous mapping` 예외가 발생했습니다.
- 동일한 `POST /api/dev/decisions/test` 경로가 두 dev endpoint 메서드에 매핑되어 테스트 실행 전에 애플리케이션 컨텍스트가 실패했습니다.

### 왜 발생했나? (Root Cause)
- 요청 바디를 받는 단건 테스트 결정 생성 API와, 요청 바디 없는 마이페이지 소비관리 테스트 데이터 생성 API가 같은 HTTP method/path 조건만 가지고 있었습니다.
- Spring MVC 입장에서는 두 핸들러를 구분할 추가 조건이 없어 중복 매핑으로 판단했습니다.

### 어떻게 고쳤나?
- 요청 바디를 받는 단건 생성 API에 `consumes = application/json` 조건을 추가했습니다.
- 바디 없는 테스트 데이터 생성 API는 기존 매핑을 유지해 두 endpoint가 서로 다른 매핑 조건을 갖도록 분리했습니다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법(가능하면)
- Steps: `develop` 기준 GitHub Actions CI 또는 `./gradlew test` 실행
- 기대 결과: Spring context 로딩 및 테스트 통과
- 실제 결과: `Ambiguous mapping`으로 context 로딩 실패

### 재발 방지(있다면)
- [ ] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [ ] 런북/문서 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] AC1: `develop` CI에서 발생한 Spring MVC 중복 매핑 오류가 사라진다.
- [x] AC2: 요청 바디를 받는 dev endpoint와 바디 없는 dev endpoint가 모두 유지된다.
- [x] AC3: 로컬 전체 테스트와 GitHub Actions Gradle Test가 통과한다.

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew test --console=plain`
- Result: ✅ 통과

### CI
- 링크/결과: ✅ Gradle Test 통과
- https://github.com/SaGongSa-404/404_BE/actions/runs/26572770599/job/78283936884

### Smoke / 수동 검증
- 시나리오: Spring context 로딩이 필요한 전체 테스트 실행
- 결과: ✅ context 로딩 및 테스트 통과

### 테스트 공백(있다면 이유 필수)
- dev 전용 endpoint 매핑 조건 수정이며, 별도 신규 기능 테스트는 추가하지 않았습니다.

---

## 🧭 영향 범위 (필수)
- [x] API 스펙 변경 없음
- [ ] API 스펙 변경 있음 (요약: )
- [x] DB 스키마 변경 없음
- [ ] DB 스키마 변경 있음 (마이그레이션/락/시간: )
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음 (항목: )
- [x] 캐시/큐/외부 연동 영향 없음
- [ ] 캐시/큐/외부 연동 영향 있음 (요약: )

---

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음
- [ ] Breaking change 있음 → 무엇이 깨지는지 / 마이그레이션 / 롤아웃 전략:

---

## 🚀 배포/릴리즈 (해당 시 필수)
### Feature Flag
- [x] 사용 안함
- [ ] 사용함 → Flag/기본값/롤아웃:

### 모니터링/알림
- 확인할 대시보드/지표: 해당 없음
- 에러/로그 키워드: `Ambiguous mapping`, `/api/dev/decisions/test`

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- JSON `Content-Type` 없이 바디를 보내던 dev 전용 호출은 단건 생성 API가 아니라 바디 없는 테스트 데이터 생성 API로 매칭될 수 있습니다.
- 운영 프로필에서는 `DevController`가 제외되므로 운영 런타임 영향은 없습니다.

### 롤백
- [ ] 플래그/설정으로 우회 가능
- [x] 배포 롤백(이전 태그/이미지) 가능
- [ ] 데이터 롤백/역마이그레이션 필요 (절차: )

---

## 📸 증빙 (선택)
- 스크린샷/로그/메트릭 링크: GitHub Actions Gradle Test 통과 링크 참고
- 전/후 비교(가능하면): 수정 전 `Ambiguous mapping`, 수정 후 전체 테스트 통과

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직: `src/main/java/com/sagongsa/backend/dev/DevController.java`
- 트레이드오프/대안: path를 분리하는 대신 `consumes` 조건으로 기존 dev endpoint 경로를 유지했습니다.
- 성능/보안/호환성 영향: 성능/보안 영향 없음, dev profile 한정 변경




