### PR TITLE
[fix] NF-50 CommentResponse authorUserId 필드 누락 수정

### DIFF
--- a/src/main/java/com/sagongsa/backend/social/CommentResponse.java
+++ b/src/main/java/com/sagongsa/backend/social/CommentResponse.java
@@ -8,6 +8,7 @@ record CommentResponse(
 	UUID id,
 	String body,
 	boolean mine,
+	UUID authorUserId,
 	String authorNickname,
 	Instant createdAt
 ) {
@@ -16,6 +17,7 @@ record CommentResponse(
 			comment.getId(),
 			comment.getBody(),
 			comment.getUser().getId().equals(currentUserId),
+			comment.getUser().getId(),
 			authorNickname,
 			comment.getCreatedAt()
 		);


### PR DESCRIPTION
## 🔗 작업 키 / 이슈 링크 (필수)
- Jira Key: `NF-50`
- Jira: https://parkjaehong.atlassian.net/browse/NF-50
- GitHub: Closes #105

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
`CommentResponse`에 `authorUserId` 필드가 없어 댓글 신고/차단 시 FE에서 대상 userId를 알 수 없는 상태였습니다.

### 왜 발생했나?
`PostResponse`에는 `authorUserId`와 `mine`이 모두 있지만, `CommentResponse`에는 `mine`만 있고 `authorUserId`가 누락되었습니다.

### 어떻게 고쳤나?
`CommentResponse` 레코드에 `authorUserId` 필드를 추가하고, `of()` 팩토리 메서드에서 `comment.getUser().getId()`로 채우도록 수정했습니다.

---

## ✅ Acceptance Criteria
- [x] `GET /api/v1/social/posts/{postId}/comments` 응답에 각 댓글의 `authorUserId`가 포함된다.
- [x] `PostResponse.authorUserId`와 동일한 방식으로 일관성이 맞춰진다.

---

## 🧭 영향 범위
- [x] API 스펙 변경 있음: `CommentResponse`에 `authorUserId(UUID)` 필드 추가 (하위 호환 — 기존 필드 유지)
- [x] DB/설정/환경변수 변경 없음