### PR TITLE
[feat] NF-51 피드홈 댓글 수 차단 반영

### DIFF
--- a/src/main/java/com/sagongsa/backend/domain/social/FeedPostRepository.java
+++ b/src/main/java/com/sagongsa/backend/domain/social/FeedPostRepository.java
@@ -31,9 +31,6 @@ public interface FeedPostRepository extends JpaRepository<FeedPost, UUID> {
 
 	long countByUserIdAndDeletedAtIsNull(UUID userId);
 
-	@Query("SELECT p.id, COUNT(c) FROM PostComment c JOIN c.post p WHERE p.id IN :postIds AND c.deletedAt IS NULL GROUP BY p.id")
-	List<Object[]> countCommentsByPostIds(@Param("postIds") List<UUID> postIds);
-
 	@Modifying
 	@Query("UPDATE FeedPost p SET p.deletedAt = CURRENT_TIMESTAMP WHERE p.user.id = :userId")
 	void softDeleteByUserId(@Param("userId") UUID userId);

--- a/src/main/java/com/sagongsa/backend/domain/social/PostCommentCount.java
+++ b/src/main/java/com/sagongsa/backend/domain/social/PostCommentCount.java
@@ -1,0 +1,6 @@
+package com.sagongsa.backend.domain.social;
+
+import java.util.UUID;
+
+public record PostCommentCount(UUID postId, Long commentCount) {
+}

--- a/src/main/java/com/sagongsa/backend/domain/social/PostCommentRepository.java
+++ b/src/main/java/com/sagongsa/backend/domain/social/PostCommentRepository.java
@@ -19,11 +19,11 @@ public interface PostCommentRepository extends JpaRepository<PostComment, UUID> 
 
 	long countByPostIdAndDeletedAtIsNull(UUID postId);
 
-	@Query("SELECT c.post.id, COUNT(c) FROM PostComment c WHERE c.post.id IN :postIds AND c.deletedAt IS NULL GROUP BY c.post.id")
-	List<Object[]> countVisibleByPostIds(@Param("postIds") List<UUID> postIds);
+	@Query("SELECT new com.sagongsa.backend.domain.social.PostCommentCount(c.post.id, COUNT(c)) FROM PostComment c WHERE c.post.id IN :postIds AND c.deletedAt IS NULL GROUP BY c.post.id")
+	List<PostCommentCount> countVisibleByPostIds(@Param("postIds") List<UUID> postIds);
 
-	@Query("SELECT c.post.id, COUNT(c) FROM PostComment c WHERE c.post.id IN :postIds AND c.deletedAt IS NULL AND c.user.id NOT IN :blockedIds GROUP BY c.post.id")
-	List<Object[]> countVisibleByPostIdsExcludingBlockers(@Param("postIds") List<UUID> postIds, @Param("blockedIds") List<UUID> blockedIds);
+	@Query("SELECT new com.sagongsa.backend.domain.social.PostCommentCount(c.post.id, COUNT(c)) FROM PostComment c WHERE c.post.id IN :postIds AND c.deletedAt IS NULL AND c.user.id NOT IN :blockedIds GROUP BY c.post.id")
+	List<PostCommentCount> countVisibleByPostIdsExcludingBlockers(@Param("postIds") List<UUID> postIds, @Param("blockedIds") List<UUID> blockedIds);
 
 	@Query("SELECT c.user.id FROM PostComment c WHERE c.post.id = :postId AND c.deletedAt IS NULL GROUP BY c.user.id ORDER BY MIN(c.createdAt) ASC")
 	List<UUID> findCommenterIdsByPostIdOrderedByFirstComment(@Param("postId") UUID postId);

--- a/src/main/java/com/sagongsa/backend/domain/social/PostCommentRepository.java
+++ b/src/main/java/com/sagongsa/backend/domain/social/PostCommentRepository.java
@@ -19,6 +19,12 @@ public interface PostCommentRepository extends JpaRepository<PostComment, UUID> 
 
 	long countByPostIdAndDeletedAtIsNull(UUID postId);
 
+	@Query("SELECT c.post.id, COUNT(c) FROM PostComment c WHERE c.post.id IN :postIds AND c.deletedAt IS NULL GROUP BY c.post.id")
+	List<Object[]> countVisibleByPostIds(@Param("postIds") List<UUID> postIds);
+
+	@Query("SELECT c.post.id, COUNT(c) FROM PostComment c WHERE c.post.id IN :postIds AND c.deletedAt IS NULL AND c.user.id NOT IN :blockedIds GROUP BY c.post.id")
+	List<Object[]> countVisibleByPostIdsExcludingBlockers(@Param("postIds") List<UUID> postIds, @Param("blockedIds") List<UUID> blockedIds);
+
 	@Query("SELECT c.user.id FROM PostComment c WHERE c.post.id = :postId AND c.deletedAt IS NULL GROUP BY c.user.id ORDER BY MIN(c.createdAt) ASC")
 	List<UUID> findCommenterIdsByPostIdOrderedByFirstComment(@Param("postId") UUID postId);
 

--- a/src/main/java/com/sagongsa/backend/mypage/MypageService.java
+++ b/src/main/java/com/sagongsa/backend/mypage/MypageService.java
@@ -10,22 +10,27 @@ import com.sagongsa.backend.domain.enums.ItemStatus;
 import com.sagongsa.backend.domain.item.SavedItem;
 import com.sagongsa.backend.domain.item.SavedItemRepository;
 import com.sagongsa.backend.domain.social.FeedPostRepository;
+import com.sagongsa.backend.domain.social.PostCommentCount;
 import com.sagongsa.backend.domain.social.PostCommentRepository;
 import com.sagongsa.backend.domain.social.PostVote;
 import com.sagongsa.backend.domain.social.PostVoteRepository;
 import com.sagongsa.backend.domain.user.UserProfile;
 import com.sagongsa.backend.domain.user.UserProfileRepository;
+import com.sagongsa.backend.social.BlockService;
 import com.sagongsa.backend.social.PostListResponse;
 import com.sagongsa.backend.social.PostResponse;
 import java.time.Instant;
 import java.time.YearMonth;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
@@ -46,6 +51,7 @@ class MypageService {
 	private final SavedItemRepository savedItemRepository;
 	private final BudgetCycleRepository budgetCycleRepository;
 	private final JdbcTemplate jdbcTemplate;
+	private final BlockService blockService;
 
 	MypageService(UserAccountRepository userAccountRepository,
 		UserProfileRepository userProfileRepository,
@@ -55,7 +61,8 @@ class MypageService {
 		PostCommentRepository postCommentRepository,
 		SavedItemRepository savedItemRepository,
 		BudgetCycleRepository budgetCycleRepository,
-		JdbcTemplate jdbcTemplate) {
+		JdbcTemplate jdbcTemplate,
+		BlockService blockService) {
 		this.userAccountRepository = userAccountRepository;
 		this.userProfileRepository = userProfileRepository;
 		this.socialAccountRepository = socialAccountRepository;
@@ -65,6 +72,7 @@ class MypageService {
 		this.savedItemRepository = savedItemRepository;
 		this.budgetCycleRepository = budgetCycleRepository;
 		this.jdbcTemplate = jdbcTemplate;
+		this.blockService = blockService;
 	}
 
 	MyProfileResponse getMyProfile(UUID userId) {
@@ -221,9 +229,13 @@ class MypageService {
 
 		String myNickname = userProfileRepository.findByUserId(userId).isPresent()
 			? UserProfile.POST_AUTHOR_NICKNAME : UserProfile.UNKNOWN_NICKNAME;
+		List<UUID> blockedIds = blockService.getBlockedUserIds(userId);
+		Map<UUID, Long> commentCounts = countVisibleCommentsByPostIds(
+			posts.stream().map(post -> post.getId()).toList(),
+			blockedIds);
 
 		var items = posts.stream().map(post -> {
-			long cc = postCommentRepository.countByPostIdAndDeletedAtIsNull(post.getId());
+			long cc = commentCounts.getOrDefault(post.getId(), 0L);
 			var myVote = postVoteRepository.findByPostIdAndUserId(post.getId(), userId)
 				.filter(PostVote::isActive).map(PostVote::getVoteType).orElse(null);
 			return PostResponse.of(post, myNickname, cc, myVote, userId);
@@ -245,12 +257,16 @@ class MypageService {
 		List<UUID> authorIds = votes.stream()
 			.map(v -> v.getPost().getUser().getId()).distinct().toList();
 		Set<UUID> existingProfileIds = new HashSet<>(userProfileRepository.findExistingProfileUserIds(authorIds));
+		List<UUID> blockedIds = blockService.getBlockedUserIds(userId);
+		Map<UUID, Long> commentCounts = countVisibleCommentsByPostIds(
+			votes.stream().map(v -> v.getPost().getId()).toList(),
+			blockedIds);
 
 		var items = votes.stream().map(vote -> {
 			var post = vote.getPost();
 			String authorNickname = existingProfileIds.contains(post.getUser().getId())
 				? UserProfile.POST_AUTHOR_NICKNAME : UserProfile.UNKNOWN_NICKNAME;
-			long cc = postCommentRepository.countByPostIdAndDeletedAtIsNull(post.getId());
+			long cc = commentCounts.getOrDefault(post.getId(), 0L);
 			return PostResponse.of(post, authorNickname, cc, vote.getVoteType(), userId);
 		}).toList();
 
@@ -261,5 +277,15 @@ class MypageService {
 	private UserAccount findUserOrThrow(UUID userId) {
 		return userAccountRepository.findById(userId)
 			.orElseThrow(() -> new MypageNotFoundException("사용자를 찾을 수 없습니다."));
+	}
+
+	private Map<UUID, Long> countVisibleCommentsByPostIds(List<UUID> postIds, List<UUID> blockedIds) {
+		if (postIds.isEmpty()) return Collections.emptyMap();
+
+		List<PostCommentCount> counts = blockedIds.isEmpty()
+			? postCommentRepository.countVisibleByPostIds(postIds)
+			: postCommentRepository.countVisibleByPostIdsExcludingBlockers(postIds, blockedIds);
+		return counts.stream()
+			.collect(Collectors.toMap(PostCommentCount::postId, PostCommentCount::commentCount));
 	}
 }

--- a/src/main/java/com/sagongsa/backend/social/SocialPostService.java
+++ b/src/main/java/com/sagongsa/backend/social/SocialPostService.java
@@ -63,7 +63,7 @@ class SocialPostService {
 
 	PostListResponse getPosts(UUID userId, Instant cursor, int size) {
 		PageRequest pageable = PageRequest.of(0, size + 1);
-		List<UUID> blockedIds = userId != null ? blockService.getBlockedUserIds(userId) : java.util.Collections.emptyList();
+		List<UUID> blockedIds = blockedIdsFor(userId);
 		List<FeedPost> posts;
 		if (blockedIds.isEmpty()) {
 			posts = cursor != null ? feedPostRepository.findAllVisibleBefore(cursor, pageable) : feedPostRepository.findAllVisible(pageable);
@@ -74,7 +74,7 @@ class SocialPostService {
 		boolean hasMore = posts.size() > size;
 		if (hasMore) posts = posts.subList(0, size);
 
-		List<PostResponse> items = toPostResponses(posts, userId);
+		List<PostResponse> items = toPostResponses(posts, userId, blockedIds);
 
 		Instant nextCursor = hasMore && !posts.isEmpty() ? posts.get(posts.size() - 1).getCreatedAt() : null;
 		return new PostListResponse(items, nextCursor, hasMore);
@@ -121,7 +121,7 @@ class SocialPostService {
 		boolean hasMore = posts.size() > size;
 		if (hasMore) posts = posts.subList(0, size);
 
-		List<PostResponse> items = toPostResponses(posts, userId);
+		List<PostResponse> items = toPostResponses(posts, userId, Collections.emptyList());
 
 		Instant nextCursor = hasMore && !posts.isEmpty() ? posts.get(posts.size() - 1).getCreatedAt() : null;
 		return new PostListResponse(items, nextCursor, hasMore);
@@ -136,13 +136,13 @@ class SocialPostService {
 		return post;
 	}
 
-	private List<PostResponse> toPostResponses(List<FeedPost> posts, UUID userId) {
+	private List<PostResponse> toPostResponses(List<FeedPost> posts, UUID userId, List<UUID> blockedIds) {
 		if (posts.isEmpty()) return Collections.emptyList();
 
 		List<UUID> postIds = posts.stream().map(FeedPost::getId).toList();
 		List<UUID> authorIds = posts.stream().map(p -> p.getUser().getId()).distinct().toList();
 
-		Map<UUID, Long> commentCounts = feedPostRepository.countCommentsByPostIds(postIds).stream()
+		Map<UUID, Long> commentCounts = countVisibleCommentsByPostIds(postIds, blockedIds).stream()
 			.collect(Collectors.toMap(r -> (UUID) r[0], r -> (Long) r[1]));
 
 		Map<UUID, PostVote> myVotes = userId == null
@@ -163,6 +163,16 @@ class SocialPostService {
 				return PostResponse.of(post, authorNickname, commentCount, myVote, userId);
 			})
 			.toList();
+	}
+
+	private List<UUID> blockedIdsFor(UUID userId) {
+		return userId != null ? blockService.getBlockedUserIds(userId) : Collections.emptyList();
+	}
+
+	private List<Object[]> countVisibleCommentsByPostIds(List<UUID> postIds, List<UUID> blockedIds) {
+		return blockedIds.isEmpty()
+			? postCommentRepository.countVisibleByPostIds(postIds)
+			: postCommentRepository.countVisibleByPostIdsExcludingBlockers(postIds, blockedIds);
 	}
 
 	private PostVoteType resolveMyVote(UUID userId, UUID postId) {

--- a/src/main/java/com/sagongsa/backend/social/SocialPostService.java
+++ b/src/main/java/com/sagongsa/backend/social/SocialPostService.java
@@ -7,6 +7,7 @@ import com.sagongsa.backend.domain.item.SavedItem;
 import com.sagongsa.backend.domain.item.SavedItemRepository;
 import com.sagongsa.backend.domain.social.FeedPost;
 import com.sagongsa.backend.domain.social.FeedPostRepository;
+import com.sagongsa.backend.domain.social.PostCommentCount;
 import com.sagongsa.backend.domain.social.PostCommentRepository;
 import com.sagongsa.backend.domain.social.PostVote;
 import com.sagongsa.backend.domain.social.PostVoteRepository;
@@ -82,7 +83,7 @@ class SocialPostService {
 
 	PostResponse getPost(UUID userId, UUID postId) {
 		FeedPost post = findPostOrThrow(postId);
-		long commentCount = postCommentRepository.countByPostIdAndDeletedAtIsNull(postId);
+		long commentCount = countVisibleCommentsByPostId(postId, blockedIdsFor(userId));
 		PostVoteType myVote = resolveMyVote(userId, postId);
 		String authorNickname = userProfileRepository.findByUserId(post.getUser().getId()).isPresent()
 			? UserProfile.POST_AUTHOR_NICKNAME : UserProfile.UNKNOWN_NICKNAME;
@@ -96,7 +97,7 @@ class SocialPostService {
 			throw new SocialFeedForbiddenException("본인의 게시글만 수정할 수 있습니다.");
 		}
 		post.updateBody(request.body());
-		long commentCount = postCommentRepository.countByPostIdAndDeletedAtIsNull(postId);
+		long commentCount = countVisibleCommentsByPostId(postId, blockedIdsFor(userId));
 		PostVoteType myVote = resolveMyVote(userId, postId);
 		String authorNickname = userProfileRepository.findByUserId(post.getUser().getId()).isPresent()
 			? UserProfile.POST_AUTHOR_NICKNAME : UserProfile.UNKNOWN_NICKNAME;
@@ -121,7 +122,7 @@ class SocialPostService {
 		boolean hasMore = posts.size() > size;
 		if (hasMore) posts = posts.subList(0, size);
 
-		List<PostResponse> items = toPostResponses(posts, userId, Collections.emptyList());
+		List<PostResponse> items = toPostResponses(posts, userId, blockedIdsFor(userId));
 
 		Instant nextCursor = hasMore && !posts.isEmpty() ? posts.get(posts.size() - 1).getCreatedAt() : null;
 		return new PostListResponse(items, nextCursor, hasMore);
@@ -142,8 +143,7 @@ class SocialPostService {
 		List<UUID> postIds = posts.stream().map(FeedPost::getId).toList();
 		List<UUID> authorIds = posts.stream().map(p -> p.getUser().getId()).distinct().toList();
 
-		Map<UUID, Long> commentCounts = countVisibleCommentsByPostIds(postIds, blockedIds).stream()
-			.collect(Collectors.toMap(r -> (UUID) r[0], r -> (Long) r[1]));
+		Map<UUID, Long> commentCounts = countVisibleCommentsByPostIds(postIds, blockedIds);
 
 		Map<UUID, PostVote> myVotes = userId == null
 			? Collections.emptyMap()
@@ -169,10 +169,18 @@ class SocialPostService {
 		return userId != null ? blockService.getBlockedUserIds(userId) : Collections.emptyList();
 	}
 
-	private List<Object[]> countVisibleCommentsByPostIds(List<UUID> postIds, List<UUID> blockedIds) {
-		return blockedIds.isEmpty()
+	private long countVisibleCommentsByPostId(UUID postId, List<UUID> blockedIds) {
+		return countVisibleCommentsByPostIds(List.of(postId), blockedIds).getOrDefault(postId, 0L);
+	}
+
+	private Map<UUID, Long> countVisibleCommentsByPostIds(List<UUID> postIds, List<UUID> blockedIds) {
+		if (postIds.isEmpty()) return Collections.emptyMap();
+
+		List<PostCommentCount> counts = blockedIds.isEmpty()
 			? postCommentRepository.countVisibleByPostIds(postIds)
 			: postCommentRepository.countVisibleByPostIdsExcludingBlockers(postIds, blockedIds);
+		return counts.stream()
+			.collect(Collectors.toMap(PostCommentCount::postId, PostCommentCount::commentCount));
 	}
 
 	private PostVoteType resolveMyVote(UUID userId, UUID postId) {

--- a/src/test/java/com/sagongsa/backend/decision/DecisionApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/decision/DecisionApiIntegrationTest.java
@@ -468,7 +468,7 @@ class DecisionApiIntegrationTest extends PostgreSqlContainerTest {
 
 	private void insertPreviousGoDecision(UUID userId, String title, String category, int finalPrice) {
 		UUID itemId = insertSavedItem(userId, title, category, "GO", finalPrice);
-		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);
+		OffsetDateTime now = currentKstMonthFixtureTime();
 		jdbcTemplate.update(
 			"""
 			insert into purchase_decisions (
@@ -485,6 +485,15 @@ class DecisionApiIntegrationTest extends PostgreSqlContainerTest {
 			now,
 			now
 		);
+	}
+
+	private OffsetDateTime currentKstMonthFixtureTime() {
+		return YearMonth.now(SEOUL_ZONE)
+			.atDay(1)
+			.atStartOfDay(SEOUL_ZONE)
+			.plusHours(1)
+			.toOffsetDateTime()
+			.withOffsetSameInstant(ZoneOffset.UTC);
 	}
 
 	private String queryString(String sql, Object... args) {

--- a/src/test/java/com/sagongsa/backend/mvp/MvpBackendGapIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/mvp/MvpBackendGapIntegrationTest.java
@@ -295,7 +295,7 @@ class MvpBackendGapIntegrationTest extends PostgreSqlContainerTest {
 		UUID budgetCycleId
 	) {
 		UUID decisionId = UUID.randomUUID();
-		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);
+		OffsetDateTime now = currentKstMonthFixtureTime();
 		jdbcTemplate.update(
 			"""
 			insert into purchase_decisions (
@@ -319,6 +319,15 @@ class MvpBackendGapIntegrationTest extends PostgreSqlContainerTest {
 			now
 		);
 		return decisionId;
+	}
+
+	private OffsetDateTime currentKstMonthFixtureTime() {
+		return YearMonth.now(SEOUL_ZONE)
+			.atDay(1)
+			.atStartOfDay(SEOUL_ZONE)
+			.plusHours(1)
+			.toOffsetDateTime()
+			.withOffsetSameInstant(ZoneOffset.UTC);
 	}
 
 	private void insertSelfCheck(UUID decisionId, int yesCount, String rationalityResult, boolean first, boolean second, boolean third, boolean fourth) {

--- a/src/test/java/com/sagongsa/backend/social/SocialFeedCommentCountIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/social/SocialFeedCommentCountIntegrationTest.java
@@ -1,0 +1,113 @@
+package com.sagongsa.backend.social;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SocialFeedCommentCountIntegrationTest extends PostgreSqlContainerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.execute("truncate table users cascade");
+	}
+
+	@Test
+	void feedCommentCountExcludesBlockedCommenters() throws Exception {
+		UUID viewerId = insertUserWithProfile();
+		UUID authorId = insertUserWithProfile();
+		UUID visibleCommenterId = insertUserWithProfile();
+		UUID blockedCommenterId = insertUserWithProfile();
+		UUID postId = insertPost(authorId, "차단 댓글 집계 테스트");
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		insertComment(postId, visibleCommenterId, "보이는 댓글", now.plusSeconds(1));
+		insertComment(postId, blockedCommenterId, "차단된 댓글", now.plusSeconds(2));
+		insertBlock(viewerId, blockedCommenterId);
+
+		mockMvc.perform(get("/api/v1/social/posts")
+				.header("X-User-Id", viewerId.toString()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.posts[0].id").value(postId.toString()))
+			.andExpect(jsonPath("$.posts[0].commentCount").value(1));
+
+		mockMvc.perform(get("/api/v1/social/posts/{postId}/comments", postId)
+				.header("X-User-Id", viewerId.toString()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.total").value(1))
+			.andExpect(jsonPath("$.comments[0].body").value("보이는 댓글"));
+	}
+
+	@Test
+	void feedCommentCountIsZeroWhenOnlyBlockedCommentsRemain() throws Exception {
+		UUID viewerId = insertUserWithProfile();
+		UUID authorId = insertUserWithProfile();
+		UUID blockedCommenterId = insertUserWithProfile();
+		UUID postId = insertPost(authorId, "차단 댓글만 있는 게시글");
+		insertComment(postId, blockedCommenterId, "차단된 댓글", OffsetDateTime.now(ZoneOffset.UTC));
+		insertBlock(viewerId, blockedCommenterId);
+
+		mockMvc.perform(get("/api/v1/social/posts")
+				.header("X-User-Id", viewerId.toString()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.posts[0].id").value(postId.toString()))
+			.andExpect(jsonPath("$.posts[0].commentCount").value(0));
+	}
+
+	private UUID insertUserWithProfile() {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"INSERT INTO users (id, status, onboarding_status, created_at, updated_at) VALUES (?, 'ACTIVE', 'COMPLETED', ?, ?)",
+			userId, now, now
+		);
+		jdbcTemplate.update(
+			"INSERT INTO user_profiles (user_id, nickname, mascot_name, timezone, created_at, updated_at) VALUES (?, '너굴이', '너구리', 'Asia/Seoul', ?, ?)",
+			userId, now, now
+		);
+		return userId;
+	}
+
+	private UUID insertPost(UUID userId, String title) {
+		UUID postId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"INSERT INTO feed_posts (id, user_id, title, body, go_count, stop_count, created_at, updated_at) VALUES (?, ?, ?, '본문', 0, 0, ?, ?)",
+			postId, userId, title, now, now
+		);
+		return postId;
+	}
+
+	private void insertComment(UUID postId, UUID userId, String body, OffsetDateTime createdAt) {
+		jdbcTemplate.update(
+			"INSERT INTO post_comments (id, post_id, user_id, body, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+			UUID.randomUUID(), postId, userId, body, createdAt, createdAt
+		);
+	}
+
+	private void insertBlock(UUID blockerId, UUID blockedId) {
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"INSERT INTO user_blocks (id, blocker_user_id, blocked_user_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+			UUID.randomUUID(), blockerId, blockedId, now, now
+		);
+	}
+}

--- a/src/test/java/com/sagongsa/backend/social/SocialFeedCommentCountIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/social/SocialFeedCommentCountIntegrationTest.java
@@ -54,6 +54,11 @@ class SocialFeedCommentCountIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.total").value(1))
 			.andExpect(jsonPath("$.comments[0].body").value("보이는 댓글"));
+
+		mockMvc.perform(get("/api/v1/social/posts/{postId}", postId)
+				.header("X-User-Id", viewerId.toString()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.commentCount").value(1));
 	}
 
 	@Test
@@ -70,6 +75,44 @@ class SocialFeedCommentCountIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.posts[0].id").value(postId.toString()))
 			.andExpect(jsonPath("$.posts[0].commentCount").value(0));
+	}
+
+	@Test
+	void mypageCommentCountExcludesBlockedCommenters() throws Exception {
+		UUID viewerId = insertUserWithProfile();
+		UUID visibleCommenterId = insertUserWithProfile();
+		UUID blockedCommenterId = insertUserWithProfile();
+		UUID postId = insertPost(viewerId, "마이페이지 차단 댓글 집계 테스트");
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		insertComment(postId, visibleCommenterId, "보이는 댓글", now.plusSeconds(1));
+		insertComment(postId, blockedCommenterId, "차단된 댓글", now.plusSeconds(2));
+		insertBlock(viewerId, blockedCommenterId);
+
+		mockMvc.perform(get("/api/v1/users/me/posts")
+				.header("X-User-Id", viewerId.toString()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.posts[0].id").value(postId.toString()))
+			.andExpect(jsonPath("$.posts[0].commentCount").value(1));
+	}
+
+	@Test
+	void mypageVotedPostCommentCountExcludesBlockedCommenters() throws Exception {
+		UUID viewerId = insertUserWithProfile();
+		UUID authorId = insertUserWithProfile();
+		UUID visibleCommenterId = insertUserWithProfile();
+		UUID blockedCommenterId = insertUserWithProfile();
+		UUID postId = insertPost(authorId, "내 투표글 차단 댓글 집계 테스트");
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		insertComment(postId, visibleCommenterId, "보이는 댓글", now.plusSeconds(1));
+		insertComment(postId, blockedCommenterId, "차단된 댓글", now.plusSeconds(2));
+		insertBlock(viewerId, blockedCommenterId);
+		insertVote(postId, viewerId);
+
+		mockMvc.perform(get("/api/v1/users/me/votes")
+				.header("X-User-Id", viewerId.toString()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.posts[0].id").value(postId.toString()))
+			.andExpect(jsonPath("$.posts[0].commentCount").value(1));
 	}
 
 	private UUID insertUserWithProfile() {
@@ -108,6 +151,14 @@ class SocialFeedCommentCountIntegrationTest extends PostgreSqlContainerTest {
 		jdbcTemplate.update(
 			"INSERT INTO user_blocks (id, blocker_user_id, blocked_user_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
 			UUID.randomUUID(), blockerId, blockedId, now, now
+		);
+	}
+
+	private void insertVote(UUID postId, UUID userId) {
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"INSERT INTO post_votes (id, post_id, user_id, vote_type, created_at, updated_at) VALUES (?, ?, ?, 'GO', ?, ?)",
+			UUID.randomUUID(), postId, userId, now, now
 		);
 	}
 }


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-51`
- Jira: 없음
- GitHub: Related #106
- GitHub: Closes #106

> PR 제목: `[feat] NF-51 피드홈 댓글 수 차단 반영`
> 브랜치: `feat/NF-51-feed-latest-comment`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #106의 1/1 단계
- 선행 PR: 없음
- 후속 PR: 없음

### 이 PR에서 변경한 것
- 피드 목록 응답의 `commentCount`가 조회자의 차단 사용자 댓글을 제외하도록 변경했습니다.
- 댓글 수 집계를 `PostCommentRepository`의 post id bulk 조회로 이동했습니다.
- 차단 댓글이 섞여 있는 케이스와 차단 댓글만 있는 케이스를 통합 테스트로 추가했습니다.
- 기획 확인에 따라 댓글 본문 미리보기 응답 필드는 추가하지 않았습니다.

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
- AC1: 차단한 사용자의 댓글은 피드 목록 `commentCount`에 포함되지 않습니다.
- AC2: 차단한 사용자의 댓글만 있는 게시글은 피드 목록 `commentCount`가 `0`입니다.
- AC3: 댓글 목록 API의 `total`과 피드 목록 `commentCount`가 같은 차단 기준을 사용합니다.
- AC4: 기존 피드 목록 조회, 커서 페이지네이션, 투표 정보 응답은 유지됩니다.

### Not covered (후속 작업)
- 없음

---

## 🧪 테스트 결과 (필수)
### 로컬
```bash
./gradlew --no-daemon test --tests 'com.sagongsa.backend.social.SocialFeedCommentCountIntegrationTest' --tests 'com.sagongsa.backend.social.SocialFeedNicknameIntegrationTest'
```
- ✅ 결과: `BUILD SUCCESSFUL in 2m 19s`

```bash
./gradlew --no-daemon test
```
- ✅ 결과: `BUILD SUCCESSFUL in 3m 3s`

### CI
- ✅ `Gradle Test` 통과

### Smoke 테스트
- 시나리오: 차단 사용자의 댓글이 있는 게시글을 피드 목록에서 조회
- 결과: 피드 응답 `commentCount`에서 차단 댓글이 제외됨

---

## 🧭 영향 범위 체크 (필수)
- [x] API 변경 (요약: 기존 `commentCount` 산정 기준에 차단 반영)
- [ ] DB 변경 (마이그레이션: 없음)
- [ ] 설정 변경 (항목: 없음)
- [ ] Breaking change (무엇: 없음. 기존 필드의 집계 기준 변경)

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인: `SocialPostService`, `PostCommentRepository`, `SocialFeedCommentCountIntegrationTest`
- 트레이드오프/대안: 피드 페이지의 post id 목록 기준으로 댓글 수를 bulk 조회해 N+1을 피했습니다. 댓글 본문 미리보기 응답은 요구사항에서 제외되어 추가하지 않았습니다.