### PR TITLE
[bug] NF-53 개발용 구매 숙려 플로우 결정 제출 409 수정

### DIFF
--- a/src/main/java/com/sagongsa/backend/dev/DevController.java
+++ b/src/main/java/com/sagongsa/backend/dev/DevController.java
@@ -65,6 +65,8 @@ public class DevController {
 			"INSERT INTO user_profiles (user_id, nickname, mascot_name, timezone, notification_enabled, created_at, updated_at) VALUES (?, ?, '너구리', 'Asia/Seoul', true, ?, ?)",
 			userId, nickname, now, now);
 
+		ensureCurrentBudgetCycle(userId, now);
+
 		return ResponseEntity.ok(Map.of("userId", userId.toString(), "nickname", nickname));
 	}
 
@@ -88,21 +90,9 @@ public class DevController {
 		String result = request.result() != null ? request.result().toUpperCase() : "GO";
 
 		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-		String yearMonth = YearMonth.now(ZoneId.of("Asia/Seoul")).toString();
+		String yearMonth = currentYearMonth();
 
-		// 예산 사이클 없으면 생성
-		UUID budgetCycleId = jdbcTemplate.query(
-			"SELECT id FROM budget_cycles WHERE user_id = ? AND year_month = ?",
-			(rs, i) -> rs.getObject("id", UUID.class),
-			userId, yearMonth
-		).stream().findFirst().orElseGet(() -> {
-			UUID id = UUID.randomUUID();
-			jdbcTemplate.update(
-				"INSERT INTO budget_cycles (id, user_id, year_month, monthly_budget_amount, spent_amount, warning_threshold_rate, created_at, updated_at) VALUES (?, ?, ?, 500000, 0, 80.00, ?, ?)",
-				id, userId, yearMonth, now, now
-			);
-			return id;
-		});
+		UUID budgetCycleId = ensureCurrentBudgetCycle(userId, now);
 
 		// 상품 삽입
 		UUID itemId = UUID.randomUUID();
@@ -139,11 +129,7 @@ public class DevController {
 	@Transactional
 	public ResponseEntity<Map<String, Object>> createTestDecisions(@CurrentUserId UUID userId) {
 		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-		String yearMonth = YearMonth.now(ZoneId.of("Asia/Seoul")).toString();
-
-		UUID budgetCycleId = jdbcTemplate.queryForObject(
-			"SELECT id FROM budget_cycles WHERE user_id = ? AND year_month = ?",
-			UUID.class, userId, yearMonth);
+		UUID budgetCycleId = ensureCurrentBudgetCycle(userId, now);
 
 		record TestCase(String title, int price, String category, String result, int yesCount, String rationality) {}
 		var cases = java.util.List.of(
@@ -199,6 +185,8 @@ public class DevController {
 	public ResponseEntity<Map<String, String>> createTestWish(@CurrentUserId UUID userId) {
 		UserAccount user = userAccountRepository.findById(userId)
 			.orElseThrow(() -> new RuntimeException("로그인 유저를 찾을 수 없음"));
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		ensureCurrentBudgetCycle(userId, now);
 
 		SavedItem item = SavedItem.create(user,
 			"테스트 상품 (에어팟 프로)", 350000, null, null,
@@ -207,12 +195,33 @@ public class DevController {
 
 		em.createNativeQuery("UPDATE saved_items SET created_at = :ts WHERE id = :id")
 			.setParameter("ts", Instant.now().minus(25, ChronoUnit.HOURS))
-			.setParameter("id", item.getId().toString())
+			.setParameter("id", item.getId())
 			.executeUpdate();
 
 		return ResponseEntity.ok(Map.of(
 			"itemId", item.getId().toString(),
 			"tip", "GET /api/v1/deliberations/items/" + item.getId() + " 으로 숙려 화면 조회 가능"
 		));
+	}
+
+	private UUID ensureCurrentBudgetCycle(UUID userId, OffsetDateTime now) {
+		String yearMonth = currentYearMonth();
+		return jdbcTemplate.query(
+			"SELECT id FROM budget_cycles WHERE user_id = ? AND year_month = ?",
+			(rs, rowNumber) -> rs.getObject("id", UUID.class),
+			userId,
+			yearMonth
+		).stream().findFirst().orElseGet(() -> {
+			UUID id = UUID.randomUUID();
+			jdbcTemplate.update(
+				"INSERT INTO budget_cycles (id, user_id, year_month, monthly_budget_amount, spent_amount, warning_threshold_rate, created_at, updated_at) VALUES (?, ?, ?, 500000, 0, 80.00, ?, ?)",
+				id, userId, yearMonth, now, now
+			);
+			return id;
+		});
+	}
+
+	private String currentYearMonth() {
+		return YearMonth.now(ZoneId.of("Asia/Seoul")).toString();
 	}
 }

--- a/src/main/java/com/sagongsa/backend/dev/DevController.java
+++ b/src/main/java/com/sagongsa/backend/dev/DevController.java
@@ -65,7 +65,7 @@ public class DevController {
 			"INSERT INTO user_profiles (user_id, nickname, mascot_name, timezone, notification_enabled, created_at, updated_at) VALUES (?, ?, '너구리', 'Asia/Seoul', true, ?, ?)",
 			userId, nickname, now, now);
 
-		ensureCurrentBudgetCycle(userId, now);
+		ensureCurrentBudgetCycleExists(userId, now);
 
 		return ResponseEntity.ok(Map.of("userId", userId.toString(), "nickname", nickname));
 	}
@@ -92,7 +92,7 @@ public class DevController {
 		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
 		String yearMonth = currentYearMonth();
 
-		UUID budgetCycleId = ensureCurrentBudgetCycle(userId, now);
+		UUID budgetCycleId = getOrCreateCurrentBudgetCycleId(userId, now);
 
 		// 상품 삽입
 		UUID itemId = UUID.randomUUID();
@@ -129,7 +129,7 @@ public class DevController {
 	@Transactional
 	public ResponseEntity<Map<String, Object>> createTestDecisions(@CurrentUserId UUID userId) {
 		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-		UUID budgetCycleId = ensureCurrentBudgetCycle(userId, now);
+		UUID budgetCycleId = getOrCreateCurrentBudgetCycleId(userId, now);
 
 		record TestCase(String title, int price, String category, String result, int yesCount, String rationality) {}
 		var cases = java.util.List.of(
@@ -186,7 +186,7 @@ public class DevController {
 		UserAccount user = userAccountRepository.findById(userId)
 			.orElseThrow(() -> new RuntimeException("로그인 유저를 찾을 수 없음"));
 		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-		ensureCurrentBudgetCycle(userId, now);
+		ensureCurrentBudgetCycleExists(userId, now);
 
 		SavedItem item = SavedItem.create(user,
 			"테스트 상품 (에어팟 프로)", 350000, null, null,
@@ -204,7 +204,11 @@ public class DevController {
 		));
 	}
 
-	private UUID ensureCurrentBudgetCycle(UUID userId, OffsetDateTime now) {
+	private void ensureCurrentBudgetCycleExists(UUID userId, OffsetDateTime now) {
+		getOrCreateCurrentBudgetCycleId(userId, now);
+	}
+
+	private UUID getOrCreateCurrentBudgetCycleId(UUID userId, OffsetDateTime now) {
 		String yearMonth = currentYearMonth();
 		return jdbcTemplate.query(
 			"SELECT id FROM budget_cycles WHERE user_id = ? AND year_month = ?",

--- a/src/test/java/com/sagongsa/backend/dev/DevControllerIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/dev/DevControllerIntegrationTest.java
@@ -1,0 +1,150 @@
+package com.sagongsa.backend.dev;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class DevControllerIntegrationTest extends PostgreSqlContainerTest {
+
+	private static final String USER_ID_HEADER = "X-User-Id";
+	private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.execute("truncate table users cascade");
+	}
+
+	@Test
+	void devWishCanSubmitStopDecisionWithoutBudgetConflict() throws Exception {
+		assertDevWishDecisionFlow("STOP");
+	}
+
+	@Test
+	void devWishCanSubmitGoDecisionWithoutBudgetConflict() throws Exception {
+		assertDevWishDecisionFlow("GO");
+	}
+
+	@Test
+	void devDecisionHelpersCanCreateDecisionsWithoutExistingBudgetCycle() throws Exception {
+		UUID userId = createDevUser();
+
+		mockMvc.perform(post("/api/dev/decisions/test")
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+						"title": "테스트 헤드폰",
+						"price": 99000,
+						"result": "GO"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.result").value("GO"))
+			.andExpect(jsonPath("$.month").value(YearMonth.now(SEOUL_ZONE).toString()));
+
+		mockMvc.perform(post("/api/dev/decisions/test-batch")
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.created").value(3));
+
+		assertThat(queryInteger(
+			"select count(*) from budget_cycles where user_id = ? and year_month = ?",
+			userId,
+			YearMonth.now(SEOUL_ZONE).toString()
+		)).isOne();
+	}
+
+	private void assertDevWishDecisionFlow(String result) throws Exception {
+		UUID userId = createDevUser();
+
+		String wishBody = mockMvc.perform(post("/api/dev/wishes/test")
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+		UUID itemId = UUID.fromString(objectMapper.readTree(wishBody).get("itemId").asText());
+
+		mockMvc.perform(get("/api/v1/deliberations/items/{itemId}", itemId)
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.item.id").value(itemId.toString()))
+			.andExpect(jsonPath("$.item.status").value("SAVED"));
+
+		mockMvc.perform(post("/api/v1/decisions")
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(decisionRequest(itemId, result)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.itemId").value(itemId.toString()))
+			.andExpect(jsonPath("$.itemStatus").value(result))
+			.andExpect(jsonPath("$.result").value(result));
+
+		assertThat(queryInteger(
+			"select count(*) from budget_cycles where user_id = ? and year_month = ?",
+			userId,
+			YearMonth.now(SEOUL_ZONE).toString()
+		)).isOne();
+	}
+
+	private UUID createDevUser() throws Exception {
+		String userBody = mockMvc.perform(post("/api/dev/users/test"))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+		UUID userId = UUID.fromString(objectMapper.readTree(userBody).get("userId").asText());
+		assertThat(queryInteger(
+			"select count(*) from budget_cycles where user_id = ? and year_month = ?",
+			userId,
+			YearMonth.now(SEOUL_ZONE).toString()
+		)).isOne();
+		return userId;
+	}
+
+	private String decisionRequest(UUID itemId, String result) {
+		return """
+			{
+				"itemId": "%s",
+				"result": "%s",
+				"selfCheckAnswers": [
+					{"questionCode": "NEED", "answerBoolean": true},
+					{"questionCode": "BUDGET", "answerBoolean": true},
+					{"questionCode": "ALTERNATIVE", "answerBoolean": false},
+					{"questionCode": "DELAY", "answerBoolean": false}
+				]
+			}
+			""".formatted(itemId, result);
+	}
+
+	private Integer queryInteger(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(sql, Integer.class, args);
+	}
+}

--- a/src/test/java/com/sagongsa/backend/dev/DevControllerIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/dev/DevControllerIntegrationTest.java
@@ -8,8 +8,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.YearMonth;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,8 +56,8 @@ class DevControllerIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
-	void devDecisionHelpersCanCreateDecisionsWithoutExistingBudgetCycle() throws Exception {
-		UUID userId = createDevUser();
+	void devSingleDecisionHelperCreatesBudgetCycleWhenMissing() throws Exception {
+		UUID userId = insertUserWithoutBudgetCycle();
 
 		mockMvc.perform(post("/api/dev/decisions/test")
 				.header(USER_ID_HEADER, userId)
@@ -69,6 +73,22 @@ class DevControllerIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(jsonPath("$.result").value("GO"))
 			.andExpect(jsonPath("$.month").value(YearMonth.now(SEOUL_ZONE).toString()));
 
+		assertThat(queryInteger(
+			"select count(*) from budget_cycles where user_id = ? and year_month = ?",
+			userId,
+			YearMonth.now(SEOUL_ZONE).toString()
+		)).isOne();
+		assertThat(queryInteger(
+			"select spent_amount from budget_cycles where user_id = ? and year_month = ?",
+			userId,
+			YearMonth.now(SEOUL_ZONE).toString()
+		)).isEqualTo(99000);
+	}
+
+	@Test
+	void devBatchDecisionHelperCreatesBudgetCycleWhenMissing() throws Exception {
+		UUID userId = insertUserWithoutBudgetCycle();
+
 		mockMvc.perform(post("/api/dev/decisions/test-batch")
 				.header(USER_ID_HEADER, userId))
 			.andExpect(status().isOk())
@@ -79,6 +99,11 @@ class DevControllerIntegrationTest extends PostgreSqlContainerTest {
 			userId,
 			YearMonth.now(SEOUL_ZONE).toString()
 		)).isOne();
+		assertThat(queryInteger(
+			"select spent_amount from budget_cycles where user_id = ? and year_month = ?",
+			userId,
+			YearMonth.now(SEOUL_ZONE).toString()
+		)).isEqualTo(500000);
 	}
 
 	private void assertDevWishDecisionFlow(String result) throws Exception {
@@ -91,6 +116,8 @@ class DevControllerIntegrationTest extends PostgreSqlContainerTest {
 			.getResponse()
 			.getContentAsString();
 		UUID itemId = UUID.fromString(objectMapper.readTree(wishBody).get("itemId").asText());
+		assertThat(queryOffsetDateTime("select created_at from saved_items where id = ?", itemId).toInstant())
+			.isBefore(Instant.now().minus(24, ChronoUnit.HOURS));
 
 		mockMvc.perform(get("/api/v1/deliberations/items/{itemId}", itemId)
 				.header(USER_ID_HEADER, userId))
@@ -129,6 +156,23 @@ class DevControllerIntegrationTest extends PostgreSqlContainerTest {
 		return userId;
 	}
 
+	private UUID insertUserWithoutBudgetCycle() {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"insert into users (id, status, onboarding_status, created_at, updated_at) values (?, 'ACTIVE', 'COMPLETED', ?, ?)",
+			userId,
+			now,
+			now
+		);
+		assertThat(queryInteger(
+			"select count(*) from budget_cycles where user_id = ? and year_month = ?",
+			userId,
+			YearMonth.now(SEOUL_ZONE).toString()
+		)).isZero();
+		return userId;
+	}
+
 	private String decisionRequest(UUID itemId, String result) {
 		return """
 			{
@@ -146,5 +190,13 @@ class DevControllerIntegrationTest extends PostgreSqlContainerTest {
 
 	private Integer queryInteger(String sql, Object... args) {
 		return jdbcTemplate.queryForObject(sql, Integer.class, args);
+	}
+
+	private OffsetDateTime queryOffsetDateTime(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(
+			sql,
+			(rs, rowNumber) -> rs.getObject(1, OffsetDateTime.class),
+			args
+		);
 	}
 }


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크
- Tracking Key: NF-53
- GitHub: Closes #110

## 🧩 한눈에 요약
개발용 테스트 유저/위시 생성 후 구매 숙려 화면에서 바로 참을게요/살게요를 눌렀을 때, 현재 월 예산 데이터가 없어 409가 발생할 수 있던 dev 플로우를 수정했습니다.

## 원인
- `/api/dev/users/test`가 유저/프로필만 만들고 현재 월 `budget_cycles`를 만들지 않았습니다.
- `/api/dev/wishes/test`도 위시만 만들기 때문에, 곧바로 `POST /api/v1/decisions`를 호출하면 결정 처리에 필요한 예산 사이클이 없어 409가 발생할 수 있었습니다.
- `/api/dev/wishes/test`의 `saved_items.created_at` 보정 쿼리에서 UUID를 문자열로 바인딩해 PostgreSQL에서 실패할 수 있는 문제도 있었습니다.

## 변경 사항
- dev 테스트 데이터 생성 시 현재 월 예산 사이클을 보장하는 `ensureCurrentBudgetCycle()` helper를 추가했습니다.
- `/api/dev/users/test`, `/api/dev/wishes/test`, `/api/dev/decisions/test`, `/api/dev/decisions/test-batch`가 해당 helper를 사용하도록 정리했습니다.
- `/api/dev/wishes/test`의 UUID 바인딩을 UUID 타입 그대로 전달하도록 수정했습니다.
- dev 유저 생성 → dev 위시 생성 → 숙려 조회 → 결정 제출까지 이어지는 통합 테스트를 추가했습니다.

## 🧪 테스트
- `./gradlew test --tests "com.sagongsa.backend.dev.DevControllerIntegrationTest" --tests "com.sagongsa.backend.decision.DecisionApiIntegrationTest.returnsExistingDecisionResultWhenCompletingSameItemAgain"`
- `./gradlew test --tests "com.sagongsa.backend.dev.DevControllerIntegrationTest" --tests "com.sagongsa.backend.decision.DecisionApiIntegrationTest" --tests "com.sagongsa.backend.deliberation.DeliberationApiIntegrationTest"`

## 영향 범위
- prod API 동작 변경 없음
- `!prod` 프로필에서만 활성화되는 개발용 API 보완
- DB 스키마 변경 없음