### PR TITLE
fix: 월초 CI 플래키 테스트 — minusDays(1) → minusHours(1)

### DIFF
--- a/src/test/java/com/sagongsa/backend/decision/DecisionApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/decision/DecisionApiIntegrationTest.java
@@ -503,7 +503,7 @@ class DecisionApiIntegrationTest extends PostgreSqlContainerTest {
 
 	private void insertPreviousGoDecision(UUID userId, String title, String category, int finalPrice) {
 		UUID itemId = insertSavedItem(userId, title, category, "GO", finalPrice);
-		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusHours(1);
 		jdbcTemplate.update(
 			"""
 			insert into purchase_decisions (

--- a/src/test/java/com/sagongsa/backend/mvp/MvpBackendGapIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/mvp/MvpBackendGapIntegrationTest.java
@@ -295,7 +295,7 @@ class MvpBackendGapIntegrationTest extends PostgreSqlContainerTest {
 		UUID budgetCycleId
 	) {
 		UUID decisionId = UUID.randomUUID();
-		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusHours(1);
 		jdbcTemplate.update(
 			"""
 			insert into purchase_decisions (
@@ -323,7 +323,7 @@ class MvpBackendGapIntegrationTest extends PostgreSqlContainerTest {
 
 	private void insertSelfCheck(UUID decisionId, int yesCount, String rationalityResult, boolean first, boolean second, boolean third, boolean fourth) {
 		UUID responseSetId = UUID.randomUUID();
-		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusHours(1);
 		jdbcTemplate.update(
 			"""
 			insert into self_check_response_sets (
@@ -346,7 +346,7 @@ class MvpBackendGapIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	private void insertSelfCheckAnswer(UUID responseSetId, String questionCode, boolean answerBoolean) {
-		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusHours(1);
 		jdbcTemplate.update(
 			"""
 			insert into self_check_answers (
@@ -365,7 +365,7 @@ class MvpBackendGapIntegrationTest extends PostgreSqlContainerTest {
 
 	private UUID insertReminder(UUID userId, UUID itemId, UUID decisionId, String status) {
 		UUID reminderId = UUID.randomUUID();
-		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusHours(1);
 		OffsetDateTime scheduledFor = now.plusDays(7);
 		OffsetDateTime sentAt = status.equals("SENT") ? now : null;
 		OffsetDateTime canceledAt = status.equals("CANCELED") ? now : null;
@@ -392,7 +392,7 @@ class MvpBackendGapIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	private void insertMascotEvent(UUID userId, UUID itemId, UUID decisionId) {
-		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).minusHours(1);
 		jdbcTemplate.update(
 			"""
 			insert into mascot_state_events (


### PR DESCRIPTION
## 🔗 작업 키 / 이슈 링크
- 별도 이슈 없음 (플래키 테스트 핫픽스)

---

## 🧩 변경사항

`DecisionApiIntegrationTest`, `MvpBackendGapIntegrationTest` 의 헬퍼 메서드에서 과거 시점 timestamp를 생성할 때 `minusDays(1)`을 사용하고 있었음.

**재현 조건**: 매월 1일 00:00~09:00 KST(= UTC 전날 15:00~00:00) 사이에 CI 실행 시

**실패 원인**:
- `now(UTC).minusDays(1)` → 서울 시간 기준 전월로 넘어감
- `similarCategorySpendAmount` 쿼리가 당월 데이터만 집계하므로 0 반환
- `.value(20_000)` 단언 실패

**수정**: `minusDays(1)` → `minusHours(1)` 로 교체. 1시간 전은 항상 당월 데이터로 유지됨.

---

## 🧪 영향 범위
- [ ] 런타임 코드 변경 없음 (테스트 헬퍼만 수정)
- 2개 파일, 6개 라인 변경