### PR TITLE
[codex] NF-56 B안 FCM 푸시 알림 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'com.google.firebase:firebase-admin:9.9.0'
 	implementation 'org.jsoup:jsoup:1.18.3'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.17'
 	runtimeOnly 'org.flywaydb:flyway-database-postgresql'

--- a/src/main/java/com/sagongsa/backend/config/FirebasePushConfig.java
+++ b/src/main/java/com/sagongsa/backend/config/FirebasePushConfig.java
@@ -1,0 +1,51 @@
+package com.sagongsa.backend.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.sagongsa.backend.notification.FcmMessageSender;
+import com.sagongsa.backend.notification.FirebaseFcmMessageSender;
+import com.sagongsa.backend.notification.NoopFcmMessageSender;
+import java.io.IOException;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+
+@Configuration
+@EnableConfigurationProperties(FirebasePushProperties.class)
+public class FirebasePushConfig {
+
+	private static final String FIREBASE_APP_NAME = "sagongsa-fcm";
+
+	@Bean
+	FcmMessageSender fcmMessageSender(FirebasePushProperties properties, ResourceLoader resourceLoader) throws IOException {
+		if (!properties.enabled()) {
+			return new NoopFcmMessageSender();
+		}
+		if (properties.credentialsLocation() == null || properties.credentialsLocation().isBlank()) {
+			throw new IllegalStateException("app.push.fcm.credentials-location must be configured when FCM is enabled.");
+		}
+
+		FirebaseApp app = FirebaseApp.getApps().stream()
+			.filter(existing -> FIREBASE_APP_NAME.equals(existing.getName()))
+			.findFirst()
+			.orElseGet(() -> initializeFirebaseApp(properties, resourceLoader));
+		return new FirebaseFcmMessageSender(FirebaseMessaging.getInstance(app));
+	}
+
+	private FirebaseApp initializeFirebaseApp(FirebasePushProperties properties, ResourceLoader resourceLoader) {
+		Resource resource = resourceLoader.getResource(properties.credentialsLocation());
+		try (var inputStream = resource.getInputStream()) {
+			FirebaseOptions options = FirebaseOptions.builder()
+				.setCredentials(GoogleCredentials.fromStream(inputStream))
+				.build();
+			return FirebaseApp.initializeApp(options, FIREBASE_APP_NAME);
+		}
+		catch (IOException exception) {
+			throw new IllegalStateException("Failed to load Firebase credentials.", exception);
+		}
+	}
+}

--- a/src/main/java/com/sagongsa/backend/config/FirebasePushProperties.java
+++ b/src/main/java/com/sagongsa/backend/config/FirebasePushProperties.java
@@ -1,0 +1,10 @@
+package com.sagongsa.backend.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.push.fcm")
+public record FirebasePushProperties(
+	boolean enabled,
+	String credentialsLocation
+) {
+}

--- a/src/main/java/com/sagongsa/backend/domain/common/UserScopedEntity.java
+++ b/src/main/java/com/sagongsa/backend/domain/common/UserScopedEntity.java
@@ -20,6 +20,10 @@ public abstract class UserScopedEntity extends BaseEntity {
 		this.user = user;
 	}
 
+	protected void assignUser(UserAccount user) {
+		this.user = user;
+	}
+
 	public UserAccount getUser() {
 		return user;
 	}

--- a/src/main/java/com/sagongsa/backend/domain/notification/DevicePushToken.java
+++ b/src/main/java/com/sagongsa/backend/domain/notification/DevicePushToken.java
@@ -1,6 +1,7 @@
 package com.sagongsa.backend.domain.notification;
 
 import com.sagongsa.backend.domain.common.UserScopedEntity;
+import com.sagongsa.backend.domain.auth.UserAccount;
 import com.sagongsa.backend.domain.enums.PushPlatform;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -40,5 +41,60 @@ public class DevicePushToken extends UserScopedEntity {
 	private Instant disabledAt;
 
 	protected DevicePushToken() {
+	}
+
+	private DevicePushToken(UserAccount user, String deviceId, PushPlatform platform, String pushToken) {
+		super(user);
+		this.deviceId = normalizeDeviceId(deviceId);
+		this.platform = platform;
+		this.pushToken = pushToken;
+		this.isActive = true;
+	}
+
+	public static DevicePushToken create(UserAccount user, String deviceId, PushPlatform platform, String pushToken) {
+		return new DevicePushToken(user, deviceId, platform, pushToken);
+	}
+
+	public void activateFor(UserAccount user, String deviceId, PushPlatform platform) {
+		assignUser(user);
+		this.deviceId = normalizeDeviceId(deviceId);
+		this.platform = platform;
+		this.isActive = true;
+		this.disabledAt = null;
+	}
+
+	public void deactivate() {
+		if (!isActive) {
+			return;
+		}
+		this.isActive = false;
+		this.disabledAt = Instant.now();
+	}
+
+	public String getDeviceId() {
+		return deviceId;
+	}
+
+	public PushPlatform getPlatform() {
+		return platform;
+	}
+
+	public String getPushToken() {
+		return pushToken;
+	}
+
+	public boolean isActive() {
+		return isActive;
+	}
+
+	public Instant getDisabledAt() {
+		return disabledAt;
+	}
+
+	private static String normalizeDeviceId(String deviceId) {
+		if (deviceId == null || deviceId.isBlank()) {
+			return null;
+		}
+		return deviceId;
 	}
 }

--- a/src/main/java/com/sagongsa/backend/domain/notification/DevicePushTokenRepository.java
+++ b/src/main/java/com/sagongsa/backend/domain/notification/DevicePushTokenRepository.java
@@ -1,0 +1,20 @@
+package com.sagongsa.backend.domain.notification;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface DevicePushTokenRepository extends JpaRepository<DevicePushToken, UUID> {
+
+	Optional<DevicePushToken> findByPushToken(String pushToken);
+
+	List<DevicePushToken> findByUserIdAndIsActiveTrue(UUID userId);
+
+	@Modifying
+	@Query("DELETE FROM DevicePushToken t WHERE t.user.id = :userId")
+	void deleteByUserId(@Param("userId") UUID userId);
+}

--- a/src/main/java/com/sagongsa/backend/mypage/MypageService.java
+++ b/src/main/java/com/sagongsa/backend/mypage/MypageService.java
@@ -9,6 +9,7 @@ import com.sagongsa.backend.domain.budget.BudgetCycleRepository;
 import com.sagongsa.backend.domain.enums.ItemStatus;
 import com.sagongsa.backend.domain.item.SavedItem;
 import com.sagongsa.backend.domain.item.SavedItemRepository;
+import com.sagongsa.backend.domain.notification.DevicePushTokenRepository;
 import com.sagongsa.backend.domain.social.FeedPostRepository;
 import com.sagongsa.backend.domain.social.PostCommentCount;
 import com.sagongsa.backend.domain.social.PostCommentRepository;
@@ -50,6 +51,7 @@ class MypageService {
 	private final PostCommentRepository postCommentRepository;
 	private final SavedItemRepository savedItemRepository;
 	private final BudgetCycleRepository budgetCycleRepository;
+	private final DevicePushTokenRepository devicePushTokenRepository;
 	private final JdbcTemplate jdbcTemplate;
 	private final BlockService blockService;
 
@@ -61,6 +63,7 @@ class MypageService {
 		PostCommentRepository postCommentRepository,
 		SavedItemRepository savedItemRepository,
 		BudgetCycleRepository budgetCycleRepository,
+		DevicePushTokenRepository devicePushTokenRepository,
 		JdbcTemplate jdbcTemplate,
 		BlockService blockService) {
 		this.userAccountRepository = userAccountRepository;
@@ -71,6 +74,7 @@ class MypageService {
 		this.postCommentRepository = postCommentRepository;
 		this.savedItemRepository = savedItemRepository;
 		this.budgetCycleRepository = budgetCycleRepository;
+		this.devicePushTokenRepository = devicePushTokenRepository;
 		this.jdbcTemplate = jdbcTemplate;
 		this.blockService = blockService;
 	}
@@ -156,6 +160,7 @@ class MypageService {
 		jdbcTemplate.update("DELETE FROM purchase_decisions WHERE user_id = ?", userId);
 		jdbcTemplate.update("DELETE FROM item_source_metadata WHERE item_id IN (SELECT id FROM saved_items WHERE user_id = ?)", userId);
 
+		devicePushTokenRepository.deleteByUserId(userId);
 		savedItemRepository.deleteByUserId(userId);
 		budgetCycleRepository.deleteByUserId(userId);
 		userProfileRepository.deleteByUserId(userId);

--- a/src/main/java/com/sagongsa/backend/notification/FcmMessageSender.java
+++ b/src/main/java/com/sagongsa/backend/notification/FcmMessageSender.java
@@ -1,0 +1,6 @@
+package com.sagongsa.backend.notification;
+
+public interface FcmMessageSender {
+
+	FcmSendResult send(FcmSendRequest request);
+}

--- a/src/main/java/com/sagongsa/backend/notification/FcmSendRequest.java
+++ b/src/main/java/com/sagongsa/backend/notification/FcmSendRequest.java
@@ -1,0 +1,11 @@
+package com.sagongsa.backend.notification;
+
+import java.util.Map;
+
+public record FcmSendRequest(
+	String token,
+	String title,
+	String body,
+	Map<String, String> data
+) {
+}

--- a/src/main/java/com/sagongsa/backend/notification/FcmSendResult.java
+++ b/src/main/java/com/sagongsa/backend/notification/FcmSendResult.java
@@ -1,0 +1,19 @@
+package com.sagongsa.backend.notification;
+
+public record FcmSendResult(
+	boolean sent,
+	boolean invalidToken
+) {
+
+	public static FcmSendResult success() {
+		return new FcmSendResult(true, false);
+	}
+
+	public static FcmSendResult invalid() {
+		return new FcmSendResult(false, true);
+	}
+
+	public static FcmSendResult failed() {
+		return new FcmSendResult(false, false);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/notification/FirebaseFcmMessageSender.java
+++ b/src/main/java/com/sagongsa/backend/notification/FirebaseFcmMessageSender.java
@@ -1,0 +1,54 @@
+package com.sagongsa.backend.notification;
+
+import com.google.firebase.ErrorCode;
+import com.google.firebase.messaging.AndroidConfig;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.Notification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FirebaseFcmMessageSender implements FcmMessageSender {
+
+	private static final Logger log = LoggerFactory.getLogger(FirebaseFcmMessageSender.class);
+
+	private final FirebaseMessaging firebaseMessaging;
+
+	public FirebaseFcmMessageSender(FirebaseMessaging firebaseMessaging) {
+		this.firebaseMessaging = firebaseMessaging;
+	}
+
+	@Override
+	public FcmSendResult send(FcmSendRequest request) {
+		Message message = Message.builder()
+			.setToken(request.token())
+			.setNotification(Notification.builder()
+				.setTitle(request.title())
+				.setBody(request.body())
+				.build())
+			.putAllData(request.data())
+			.setAndroidConfig(AndroidConfig.builder()
+				.setPriority(AndroidConfig.Priority.HIGH)
+				.build())
+			.build();
+		try {
+			firebaseMessaging.send(message);
+			return FcmSendResult.success();
+		}
+		catch (FirebaseMessagingException exception) {
+			if (isInvalidToken(exception)) {
+				return FcmSendResult.invalid();
+			}
+			log.warn("Failed to send FCM message.", exception);
+			return FcmSendResult.failed();
+		}
+	}
+
+	private boolean isInvalidToken(FirebaseMessagingException exception) {
+		return exception.getMessagingErrorCode() == MessagingErrorCode.UNREGISTERED
+			|| exception.getMessagingErrorCode() == MessagingErrorCode.INVALID_ARGUMENT
+			|| exception.getErrorCode() == ErrorCode.INVALID_ARGUMENT;
+	}
+}

--- a/src/main/java/com/sagongsa/backend/notification/NoopFcmMessageSender.java
+++ b/src/main/java/com/sagongsa/backend/notification/NoopFcmMessageSender.java
@@ -1,0 +1,9 @@
+package com.sagongsa.backend.notification;
+
+public class NoopFcmMessageSender implements FcmMessageSender {
+
+	@Override
+	public FcmSendResult send(FcmSendRequest request) {
+		return FcmSendResult.failed();
+	}
+}

--- a/src/main/java/com/sagongsa/backend/notification/NotificationPushMessage.java
+++ b/src/main/java/com/sagongsa/backend/notification/NotificationPushMessage.java
@@ -1,0 +1,13 @@
+package com.sagongsa.backend.notification;
+
+import java.util.UUID;
+
+public record NotificationPushMessage(
+	UUID userId,
+	UUID notificationId,
+	String notificationType,
+	String title,
+	String body,
+	String targetPath
+) {
+}

--- a/src/main/java/com/sagongsa/backend/notification/PushNotificationService.java
+++ b/src/main/java/com/sagongsa/backend/notification/PushNotificationService.java
@@ -1,0 +1,108 @@
+package com.sagongsa.backend.notification;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PushNotificationService {
+
+	private final JdbcTemplate jdbcTemplate;
+	private final FcmMessageSender fcmMessageSender;
+
+	public PushNotificationService(JdbcTemplate jdbcTemplate, FcmMessageSender fcmMessageSender) {
+		this.jdbcTemplate = jdbcTemplate;
+		this.fcmMessageSender = fcmMessageSender;
+	}
+
+	@Transactional
+	public void send(NotificationPushMessage message) {
+		if (!pushEnabled(message.userId())) {
+			return;
+		}
+
+		List<PushTokenTarget> tokens = activeTokens(message.userId());
+		for (PushTokenTarget token : tokens) {
+			FcmSendResult result = fcmMessageSender.send(new FcmSendRequest(
+				token.pushToken(),
+				message.title(),
+				message.body(),
+				payload(message)
+			));
+			if (result.invalidToken()) {
+				deactivateToken(token.pushToken());
+			}
+		}
+	}
+
+	private boolean pushEnabled(UUID userId) {
+		Boolean enabled = jdbcTemplate.queryForObject(
+			"""
+			select coalesce(up.notification_enabled, true)
+			       and coalesce(uns.push_enabled, true) as enabled
+			from users u
+			left join user_profiles up on up.user_id = u.id
+			left join user_notification_settings uns on uns.user_id = u.id
+			where u.id = ?
+			""",
+			Boolean.class,
+			userId
+		);
+		return Boolean.TRUE.equals(enabled);
+	}
+
+	private List<PushTokenTarget> activeTokens(UUID userId) {
+		return jdbcTemplate.query(
+			"""
+			select push_token
+			from device_push_tokens
+			where user_id = ?
+			  and is_active = true
+			order by updated_at desc, id desc
+			""",
+			this::mapPushTokenTarget,
+			userId
+		);
+	}
+
+	private void deactivateToken(String pushToken) {
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			update device_push_tokens
+			set is_active = false,
+				disabled_at = coalesce(disabled_at, ?),
+				updated_at = ?
+			where push_token = ?
+			""",
+			now,
+			now,
+			pushToken
+		);
+	}
+
+	private Map<String, String> payload(NotificationPushMessage message) {
+		Map<String, String> data = new LinkedHashMap<>();
+		data.put("notificationId", message.notificationId().toString());
+		data.put("notificationType", message.notificationType());
+		if (message.targetPath() != null && !message.targetPath().isBlank()) {
+			data.put("targetPath", message.targetPath());
+		}
+		return data;
+	}
+
+	private PushTokenTarget mapPushTokenTarget(ResultSet rs, int rowNumber) throws SQLException {
+		return new PushTokenTarget(rs.getString("push_token"));
+	}
+
+	private record PushTokenTarget(String pushToken) {
+	}
+}

--- a/src/main/java/com/sagongsa/backend/notification/PushTokenController.java
+++ b/src/main/java/com/sagongsa/backend/notification/PushTokenController.java
@@ -1,0 +1,40 @@
+package com.sagongsa.backend.notification;
+
+import com.sagongsa.backend.auth.CurrentUserId;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/push-tokens")
+public class PushTokenController {
+
+	private final PushTokenService pushTokenService;
+
+	public PushTokenController(PushTokenService pushTokenService) {
+		this.pushTokenService = pushTokenService;
+	}
+
+	@PostMapping
+	public ResponseEntity<PushTokenResponse> register(
+		@CurrentUserId UUID userId,
+		@Valid @RequestBody PushTokenRegisterRequest request
+	) {
+		return ResponseEntity.status(HttpStatus.CREATED).body(pushTokenService.register(userId, request));
+	}
+
+	@DeleteMapping
+	public ResponseEntity<Void> deactivate(
+		@CurrentUserId UUID userId,
+		@Valid @RequestBody PushTokenDeleteRequest request
+	) {
+		pushTokenService.deactivate(userId, request);
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/src/main/java/com/sagongsa/backend/notification/PushTokenDeleteRequest.java
+++ b/src/main/java/com/sagongsa/backend/notification/PushTokenDeleteRequest.java
@@ -1,0 +1,11 @@
+package com.sagongsa.backend.notification;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PushTokenDeleteRequest(
+	@NotBlank
+	@Size(max = 512)
+	String token
+) {
+}

--- a/src/main/java/com/sagongsa/backend/notification/PushTokenRegisterRequest.java
+++ b/src/main/java/com/sagongsa/backend/notification/PushTokenRegisterRequest.java
@@ -1,0 +1,19 @@
+package com.sagongsa.backend.notification;
+
+import com.sagongsa.backend.domain.enums.PushPlatform;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record PushTokenRegisterRequest(
+	@NotBlank
+	@Size(max = 512)
+	String token,
+
+	@NotNull
+	PushPlatform platform,
+
+	@Size(max = 120)
+	String deviceId
+) {
+}

--- a/src/main/java/com/sagongsa/backend/notification/PushTokenResponse.java
+++ b/src/main/java/com/sagongsa/backend/notification/PushTokenResponse.java
@@ -1,0 +1,22 @@
+package com.sagongsa.backend.notification;
+
+import com.sagongsa.backend.domain.enums.PushPlatform;
+import com.sagongsa.backend.domain.notification.DevicePushToken;
+import java.util.UUID;
+
+public record PushTokenResponse(
+	UUID id,
+	PushPlatform platform,
+	String deviceId,
+	boolean active
+) {
+
+	static PushTokenResponse of(DevicePushToken token) {
+		return new PushTokenResponse(
+			token.getId(),
+			token.getPlatform(),
+			token.getDeviceId(),
+			token.isActive()
+		);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/notification/PushTokenService.java
+++ b/src/main/java/com/sagongsa/backend/notification/PushTokenService.java
@@ -1,0 +1,57 @@
+package com.sagongsa.backend.notification;
+
+import com.sagongsa.backend.domain.auth.UserAccount;
+import com.sagongsa.backend.domain.auth.UserAccountRepository;
+import com.sagongsa.backend.domain.enums.UserStatus;
+import com.sagongsa.backend.domain.notification.DevicePushToken;
+import com.sagongsa.backend.domain.notification.DevicePushTokenRepository;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class PushTokenService {
+
+	private final UserAccountRepository userAccountRepository;
+	private final DevicePushTokenRepository devicePushTokenRepository;
+
+	public PushTokenService(
+		UserAccountRepository userAccountRepository,
+		DevicePushTokenRepository devicePushTokenRepository
+	) {
+		this.userAccountRepository = userAccountRepository;
+		this.devicePushTokenRepository = devicePushTokenRepository;
+	}
+
+	@Transactional
+	public PushTokenResponse register(UUID userId, PushTokenRegisterRequest request) {
+		UserAccount user = findActiveUserOrThrow(userId);
+		DevicePushToken token = devicePushTokenRepository.findByPushToken(request.token())
+			.map(existing -> {
+				existing.activateFor(user, request.deviceId(), request.platform());
+				return existing;
+			})
+			.orElseGet(() -> devicePushTokenRepository.save(
+				DevicePushToken.create(user, request.deviceId(), request.platform(), request.token())));
+		return PushTokenResponse.of(token);
+	}
+
+	@Transactional
+	public void deactivate(UUID userId, PushTokenDeleteRequest request) {
+		findActiveUserOrThrow(userId);
+		devicePushTokenRepository.findByPushToken(request.token())
+			.filter(token -> token.getUser().getId().equals(userId))
+			.ifPresent(DevicePushToken::deactivate);
+	}
+
+	private UserAccount findActiveUserOrThrow(UUID userId) {
+		UserAccount user = userAccountRepository.findById(userId)
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User was not found."));
+		if (user.getStatus() != UserStatus.ACTIVE) {
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Push tokens can be used only by active users.");
+		}
+		return user;
+	}
+}

--- a/src/main/java/com/sagongsa/backend/notification/ReminderNotificationWorker.java
+++ b/src/main/java/com/sagongsa/backend/notification/ReminderNotificationWorker.java
@@ -21,10 +21,16 @@ public class ReminderNotificationWorker {
 
 	private final JdbcTemplate jdbcTemplate;
 	private final TransactionTemplate transactionTemplate;
+	private final PushNotificationService pushNotificationService;
 
-	public ReminderNotificationWorker(JdbcTemplate jdbcTemplate, TransactionTemplate transactionTemplate) {
+	public ReminderNotificationWorker(
+		JdbcTemplate jdbcTemplate,
+		TransactionTemplate transactionTemplate,
+		PushNotificationService pushNotificationService
+	) {
 		this.jdbcTemplate = jdbcTemplate;
 		this.transactionTemplate = transactionTemplate;
+		this.pushNotificationService = pushNotificationService;
 	}
 
 	public int processDueReminders() {
@@ -62,8 +68,14 @@ public class ReminderNotificationWorker {
 
 	private boolean processReminder(UUID reminderId) {
 		try {
-			Boolean processed = transactionTemplate.execute(status -> processReminderInTransaction(reminderId));
-			return Boolean.TRUE.equals(processed);
+			ReminderProcessResult result = transactionTemplate.execute(status -> processReminderInTransaction(reminderId));
+			if (result == null || !result.processed()) {
+				return false;
+			}
+			if (result.pushMessage() != null) {
+				pushNotificationService.send(result.pushMessage());
+			}
+			return true;
 		}
 		catch (RuntimeException exception) {
 			log.warn("Failed to process reminder {}", reminderId, exception);
@@ -71,16 +83,27 @@ public class ReminderNotificationWorker {
 		}
 	}
 
-	private boolean processReminderInTransaction(UUID reminderId) {
+	private ReminderProcessResult processReminderInTransaction(UUID reminderId) {
 		ReminderTarget target = lockReminderTarget(reminderId);
 		if (target == null || !"SCHEDULED".equals(target.status())) {
-			return false;
+			return ReminderProcessResult.skipped();
 		}
+		NotificationPushMessage pushMessage = null;
 		if (!notificationExists(target.reminderId())) {
-			insertNotification(target);
+			UUID notificationId = insertNotification(target);
+			if (notificationId != null) {
+				pushMessage = new NotificationPushMessage(
+					target.userId(),
+					notificationId,
+					"REGRET_CHECK_READY",
+					"구매 후 7일이 지났어요",
+					"[%s] 지금도 잘 샀다고 생각하나요?".formatted(target.itemTitle()),
+					"/reflections?decisionId=" + target.decisionId()
+				);
+			}
 		}
 		markSent(target.reminderId());
-		return true;
+		return ReminderProcessResult.processed(pushMessage);
 	}
 
 	private ReminderTarget lockReminderTarget(UUID reminderId) {
@@ -128,8 +151,9 @@ public class ReminderNotificationWorker {
 		return Boolean.TRUE.equals(exists);
 	}
 
-	private void insertNotification(ReminderTarget target) {
+	private UUID insertNotification(ReminderTarget target) {
 		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		UUID notificationId = UUID.randomUUID();
 		try {
 			jdbcTemplate.update(
 				"""
@@ -140,7 +164,7 @@ public class ReminderNotificationWorker {
 				)
 				values (?, ?, 'REGRET_CHECK_READY', ?, ?, ?, ?, ?, ?, false, ?, ?)
 				""",
-				UUID.randomUUID(),
+				notificationId,
 				target.userId(),
 				"구매 후 7일이 지났어요",
 				"[%s] 지금도 잘 샀다고 생각하나요?".formatted(target.itemTitle()),
@@ -151,9 +175,11 @@ public class ReminderNotificationWorker {
 				now,
 				now
 			);
+			return notificationId;
 		}
 		catch (DuplicateKeyException ignored) {
 			// Another worker inserted the reminder notification first.
+			return null;
 		}
 	}
 
@@ -193,5 +219,16 @@ public class ReminderNotificationWorker {
 		String status,
 		String itemTitle
 	) {
+	}
+
+	private record ReminderProcessResult(boolean processed, NotificationPushMessage pushMessage) {
+
+		static ReminderProcessResult skipped() {
+			return new ReminderProcessResult(false, null);
+		}
+
+		static ReminderProcessResult processed(NotificationPushMessage pushMessage) {
+			return new ReminderProcessResult(true, pushMessage);
+		}
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,3 +52,7 @@ app:
     access-token-ttl: ${APP_ACCESS_TOKEN_TTL:PT2H}
     refresh-token-ttl: ${APP_REFRESH_TOKEN_TTL:P30D}
     allowed-redirect-uri-prefixes: ${APP_ALLOWED_REDIRECT_URI_PREFIXES:sagongsa404://auth/callback,http://localhost/auth/callback,http://127.0.0.1/auth/callback,https://localhost/auth/callback,https://127.0.0.1/auth/callback}
+  push:
+    fcm:
+      enabled: ${APP_PUSH_FCM_ENABLED:false}
+      credentials-location: ${APP_PUSH_FCM_CREDENTIALS_LOCATION:}

--- a/src/test/java/com/sagongsa/backend/notification/PushNotificationServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/notification/PushNotificationServiceTest.java
@@ -1,0 +1,151 @@
+package com.sagongsa.backend.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@SpringBootTest
+class PushNotificationServiceTest extends PostgreSqlContainerTest {
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	private RecordingFcmMessageSender fcmMessageSender;
+	private PushNotificationService pushNotificationService;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.execute("truncate table users cascade");
+		fcmMessageSender = new RecordingFcmMessageSender();
+		pushNotificationService = new PushNotificationService(jdbcTemplate, fcmMessageSender);
+	}
+
+	@Test
+	void sendsActiveTokensWithNotificationIdPayload() {
+		UUID userId = insertUser();
+		insertPushToken(userId, "active-token");
+		UUID notificationId = UUID.randomUUID();
+
+		pushNotificationService.send(message(userId, notificationId));
+
+		assertThat(fcmMessageSender.requests).hasSize(1);
+		FcmSendRequest request = fcmMessageSender.requests.getFirst();
+		assertThat(request.token()).isEqualTo("active-token");
+		assertThat(request.data()).containsEntry("notificationId", notificationId.toString());
+		assertThat(request.data()).containsEntry("notificationType", "REGRET_CHECK_READY");
+	}
+
+	@Test
+	void skipsFcmWhenNotificationSettingDisabled() {
+		UUID userId = insertUser();
+		insertProfile(userId, false);
+		insertPushToken(userId, "disabled-user-token");
+
+		pushNotificationService.send(message(userId, UUID.randomUUID()));
+
+		assertThat(fcmMessageSender.requests).isEmpty();
+		assertTokenActive("disabled-user-token", true);
+	}
+
+	@Test
+	void deactivatesInvalidTokenAfterFcmFailure() {
+		UUID userId = insertUser();
+		insertPushToken(userId, "invalid-token");
+		fcmMessageSender.nextResult = FcmSendResult.invalid();
+
+		pushNotificationService.send(message(userId, UUID.randomUUID()));
+
+		assertThat(fcmMessageSender.requests).hasSize(1);
+		assertTokenActive("invalid-token", false);
+	}
+
+	private NotificationPushMessage message(UUID userId, UUID notificationId) {
+		return new NotificationPushMessage(
+			userId,
+			notificationId,
+			"REGRET_CHECK_READY",
+			"구매 후 7일이 지났어요",
+			"[상품] 지금도 잘 샀다고 생각하나요?",
+			"/reflections?decisionId=" + UUID.randomUUID()
+		);
+	}
+
+	private UUID insertUser() {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into users (id, status, onboarding_status, created_at, updated_at)
+			values (?, 'ACTIVE', 'COMPLETED', ?, ?)
+			""",
+			userId,
+			now,
+			now
+		);
+		return userId;
+	}
+
+	private void insertProfile(UUID userId, boolean notificationEnabled) {
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into user_profiles (
+				user_id, nickname, mascot_name, timezone, notification_enabled, created_at, updated_at
+			)
+			values (?, '너굴이', '너구리', 'Asia/Seoul', ?, ?, ?)
+			""",
+			userId,
+			notificationEnabled,
+			now,
+			now
+		);
+	}
+
+	private void insertPushToken(UUID userId, String token) {
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into device_push_tokens (
+				id, user_id, platform, push_token, is_active, created_at, updated_at
+			)
+			values (?, ?, 'ANDROID', ?, true, ?, ?)
+			""",
+			UUID.randomUUID(),
+			userId,
+			token,
+			now,
+			now
+		);
+	}
+
+	private void assertTokenActive(String token, boolean active) {
+		Boolean actual = jdbcTemplate.queryForObject(
+			"select is_active from device_push_tokens where push_token = ?",
+			Boolean.class,
+			token
+		);
+		assertThat(actual).isEqualTo(active);
+	}
+
+	private static class RecordingFcmMessageSender implements FcmMessageSender {
+
+		private final List<FcmSendRequest> requests = new ArrayList<>();
+		private FcmSendResult nextResult = FcmSendResult.success();
+
+		@Override
+		public FcmSendResult send(FcmSendRequest request) {
+			requests.add(request);
+			return nextResult;
+		}
+	}
+}

--- a/src/test/java/com/sagongsa/backend/notification/PushTokenApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/notification/PushTokenApiIntegrationTest.java
@@ -1,0 +1,114 @@
+package com.sagongsa.backend.notification;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PushTokenApiIntegrationTest extends PostgreSqlContainerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.execute("truncate table users cascade");
+	}
+
+	@Test
+	void registersAndroidPushToken() throws Exception {
+		UUID userId = insertUser();
+
+		mockMvc.perform(post("/api/v1/push-tokens")
+				.header("X-User-Id", userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "token": "fcm-token-1",
+					  "platform": "ANDROID",
+					  "deviceId": "android-device-1"
+					}
+					"""))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.platform").value("ANDROID"))
+			.andExpect(jsonPath("$.deviceId").value("android-device-1"))
+			.andExpect(jsonPath("$.active").value(true));
+
+		assertTokenActive("fcm-token-1", true);
+	}
+
+	@Test
+	void deactivatesPushToken() throws Exception {
+		UUID userId = insertUser();
+		insertPushToken(userId, "fcm-token-logout");
+
+		mockMvc.perform(delete("/api/v1/push-tokens")
+				.header("X-User-Id", userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"token": "fcm-token-logout"}
+					"""))
+			.andExpect(status().isNoContent());
+
+		assertTokenActive("fcm-token-logout", false);
+	}
+
+	private UUID insertUser() {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into users (id, status, onboarding_status, created_at, updated_at)
+			values (?, 'ACTIVE', 'COMPLETED', ?, ?)
+			""",
+			userId,
+			now,
+			now
+		);
+		return userId;
+	}
+
+	private void insertPushToken(UUID userId, String token) {
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into device_push_tokens (
+				id, user_id, platform, push_token, is_active, created_at, updated_at
+			)
+			values (?, ?, 'ANDROID', ?, true, ?, ?)
+			""",
+			UUID.randomUUID(),
+			userId,
+			token,
+			now,
+			now
+		);
+	}
+
+	private void assertTokenActive(String token, boolean active) {
+		Boolean actual = jdbcTemplate.queryForObject(
+			"select is_active from device_push_tokens where push_token = ?",
+			Boolean.class,
+			token
+		);
+		org.assertj.core.api.Assertions.assertThat(actual).isEqualTo(active);
+	}
+}

--- a/src/test/java/com/sagongsa/backend/notification/ReminderNotificationWorkerIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/notification/ReminderNotificationWorkerIntegrationTest.java
@@ -1,6 +1,9 @@
 package com.sagongsa.backend.notification;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import com.sagongsa.backend.support.PostgreSqlContainerTest;
 import java.time.OffsetDateTime;
@@ -9,6 +12,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 
@@ -20,6 +24,9 @@ class ReminderNotificationWorkerIntegrationTest extends PostgreSqlContainerTest 
 
 	@Autowired
 	private JdbcTemplate jdbcTemplate;
+
+	@MockBean
+	private PushNotificationService pushNotificationService;
 
 	@BeforeEach
 	void setUp() {
@@ -41,6 +48,13 @@ class ReminderNotificationWorkerIntegrationTest extends PostgreSqlContainerTest 
 		assertThat(queryString("select notification_type from notifications where reminder_id = ?", reminderId)).isEqualTo("REGRET_CHECK_READY");
 		assertThat(queryString("select target_path from notifications where reminder_id = ?", reminderId))
 			.isEqualTo("/reflections?decisionId=" + decisionId);
+		UUID notificationId = queryUuid("select id from notifications where reminder_id = ?", reminderId);
+		verify(pushNotificationService).send(argThat(message ->
+			message.userId().equals(userId)
+				&& message.notificationId().equals(notificationId)
+				&& message.notificationType().equals("REGRET_CHECK_READY")
+				&& message.targetPath().equals("/reflections?decisionId=" + decisionId)
+		));
 	}
 
 	@Test
@@ -56,6 +70,7 @@ class ReminderNotificationWorkerIntegrationTest extends PostgreSqlContainerTest 
 		assertThat(processedCount).isEqualTo(1);
 		assertThat(queryString("select status from reminder_schedules where id = ?", reminderId)).isEqualTo("SENT");
 		assertThat(queryInteger("select count(*) from notifications where reminder_id = ?", reminderId)).isEqualTo(1);
+		verify(pushNotificationService, never()).send(org.mockito.ArgumentMatchers.any());
 	}
 
 	@Test
@@ -260,5 +275,9 @@ class ReminderNotificationWorkerIntegrationTest extends PostgreSqlContainerTest 
 
 	private Integer queryInteger(String sql, Object... args) {
 		return jdbcTemplate.queryForObject(sql, Integer.class, args);
+	}
+
+	private UUID queryUuid(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(sql, UUID.class, args);
 	}
 }

--- a/src/test/java/com/sagongsa/backend/reflection/PurchaseReflectionControllerTest.java
+++ b/src/test/java/com/sagongsa/backend/reflection/PurchaseReflectionControllerTest.java
@@ -17,9 +17,10 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.MethodParameter;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -40,6 +41,7 @@ class PurchaseReflectionControllerTest {
 		mockMvc = MockMvcBuilders
 			.standaloneSetup(new PurchaseReflectionController(purchaseReflectionService))
 			.setCustomArgumentResolvers(new HeaderUserIdArgumentResolver())
+			.setMessageConverters(new MappingJackson2HttpMessageConverter())
 			.build();
 	}
 


### PR DESCRIPTION
## 작업 키 / 이슈
- NF-56
- Closes #113

## 변경 사항
- Firebase Admin SDK 기반 FCM 발송 설정을 추가했습니다.
- `POST /api/v1/push-tokens`로 Android FCM token을 등록/재활성화할 수 있게 했습니다.
- `DELETE /api/v1/push-tokens`로 로그아웃, 회원탈퇴, token 갱신 시 기존 token을 inactive 처리할 수 있게 했습니다.
- 리마인더 알림 DB 저장 후 확보한 `notificationId`를 FCM data payload에 포함해 발송하도록 연결했습니다.
- `notificationEnabled=false` 또는 `push_enabled=false`일 때 DB 알림 저장은 유지하고 FCM 발송만 차단했습니다.
- FCM 발송 결과가 invalid/unregistered token이면 해당 token을 inactive 처리하도록 했습니다.
- Firebase Admin SDK로 `gson`이 classpath에 추가되며 흔들리던 standalone MockMvc 테스트는 Jackson 컨버터를 명시해 고정했습니다.

## 테스트
```text
./gradlew test --tests "com.sagongsa.backend.notification.PushTokenApiIntegrationTest" --tests "com.sagongsa.backend.notification.PushNotificationServiceTest" --tests "com.sagongsa.backend.notification.ReminderNotificationWorkerIntegrationTest"
./gradlew test
```

## 설정
- 기본값은 `APP_PUSH_FCM_ENABLED=false`입니다.
- 운영 발송 활성화 시 `APP_PUSH_FCM_ENABLED=true`, `APP_PUSH_FCM_CREDENTIALS_LOCATION`에 Firebase service account credentials 위치를 설정해야 합니다.