### PR TITLE
[feat] NF-55 앱 심사용 고정 계정 토큰 발급 API 추가

### DIFF
--- a/src/main/java/com/sagongsa/backend/auth/AuthApiController.java
+++ b/src/main/java/com/sagongsa/backend/auth/AuthApiController.java
@@ -1,13 +1,17 @@
 package com.sagongsa.backend.auth;
 
+import com.sagongsa.backend.domain.auth.UserAccountRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -23,10 +27,18 @@ import org.springframework.web.server.ResponseStatusException;
 @Tag(name = "Auth", description = "OAuth login session and JWT refresh APIs")
 public class AuthApiController {
 
-	private final JwtTokenService jwtTokenService;
+	private static final UUID APP_REVIEWER_USER_ID = UUID.fromString("40400000-0000-0000-0000-000000000055");
+	private static final String APP_REVIEWER_PROVIDER = "kakao";
+	private static final String APP_REVIEWER_PROVIDER_USER_ID = "app-reviewer-fixed";
+	private static final String APP_REVIEWER_NAME = "앱 심사 계정";
+	private static final String APP_REVIEWER_EMAIL = "app-reviewer@sagongsa.dev";
 
-	public AuthApiController(JwtTokenService jwtTokenService) {
+	private final JwtTokenService jwtTokenService;
+	private final UserAccountRepository userAccountRepository;
+
+	public AuthApiController(JwtTokenService jwtTokenService, UserAccountRepository userAccountRepository) {
 		this.jwtTokenService = jwtTokenService;
+		this.userAccountRepository = userAccountRepository;
 	}
 
 	@GetMapping("/me")
@@ -70,16 +82,39 @@ public class AuthApiController {
 	public TokenRefreshResponse refresh(@RequestBody TokenRefreshRequest request) {
 		try {
 			JwtTokenService.TokenPair tokenPair = jwtTokenService.refresh(request.refreshToken());
-			return new TokenRefreshResponse(
-				tokenPair.tokenType(),
-				tokenPair.accessToken(),
-				tokenPair.accessTokenExpiresAt(),
-				tokenPair.refreshToken(),
-				tokenPair.refreshTokenExpiresAt()
-			);
+			return toTokenResponse(tokenPair);
 		} catch (RuntimeException exception) {
 			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid refresh token", exception);
 		}
+	}
+
+	@PostMapping("/reviewer-token")
+	@Operation(
+		summary = "Issue app reviewer token",
+		description = "Issues a regular user JWT token pair for the fixed app review account.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "Reviewer token pair issued"),
+			@ApiResponse(responseCode = "500", description = "Reviewer account seed data is missing")
+		}
+	)
+	public TokenRefreshResponse issueReviewerToken() {
+		if (!userAccountRepository.existsById(APP_REVIEWER_USER_ID)) {
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "App reviewer account is not configured.");
+		}
+
+		JwtTokenService.TokenPair tokenPair = jwtTokenService.issueTokenPair(
+			new SocialUserProfile(
+				APP_REVIEWER_PROVIDER,
+				APP_REVIEWER_PROVIDER_USER_ID,
+				APP_REVIEWER_NAME,
+				APP_REVIEWER_EMAIL,
+				null,
+				Map.of("purpose", "app-review"),
+				APP_REVIEWER_USER_ID
+			),
+			List.of(new SimpleGrantedAuthority("ROLE_USER"))
+		);
+		return toTokenResponse(tokenPair);
 	}
 
 	private SocialUserProfile extractProfile(Authentication authentication) {
@@ -94,6 +129,16 @@ public class AuthApiController {
 		}
 
 		throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Not authenticated");
+	}
+
+	private TokenRefreshResponse toTokenResponse(JwtTokenService.TokenPair tokenPair) {
+		return new TokenRefreshResponse(
+			tokenPair.tokenType(),
+			tokenPair.accessToken(),
+			tokenPair.accessTokenExpiresAt(),
+			tokenPair.refreshToken(),
+			tokenPair.refreshTokenExpiresAt()
+		);
 	}
 
 	public record AuthenticatedUserResponse(

--- a/src/main/java/com/sagongsa/backend/config/SecurityConfig.java
+++ b/src/main/java/com/sagongsa/backend/config/SecurityConfig.java
@@ -21,6 +21,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.Profiles;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.config.Customizer;
@@ -70,6 +71,7 @@ public class SecurityConfig {
 						"/deliberation.html", "/test-mypage.html", "/test-nickname.html", "/test-consumption.html", "/favicon.ico", "/error").permitAll()
 					.requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
 					.requestMatchers("/api/auth/token/refresh").permitAll()
+					.requestMatchers(HttpMethod.POST, "/api/auth/reviewer-token").permitAll()
 					.requestMatchers("/api/auth/me").authenticated();
 
 				if (nonProd) {

--- a/src/main/resources/db/migration/V13__seed_app_reviewer_user.sql
+++ b/src/main/resources/db/migration/V13__seed_app_reviewer_user.sql
@@ -1,0 +1,50 @@
+insert into users (id, status, onboarding_status, created_at, updated_at, withdrawn_at)
+values (
+    '40400000-0000-0000-0000-000000000055',
+    'ACTIVE',
+    'COMPLETED',
+    now(),
+    now(),
+    null
+)
+on conflict (id) do update
+set status = 'ACTIVE',
+    onboarding_status = 'COMPLETED',
+    updated_at = now(),
+    withdrawn_at = null;
+
+insert into social_accounts (id, user_id, provider, provider_user_id, email, profile_image_url, created_at, updated_at)
+values (
+    '40400000-0000-0000-0000-000000055001',
+    '40400000-0000-0000-0000-000000000055',
+    'KAKAO',
+    'app-reviewer-fixed',
+    'app-reviewer@sagongsa.dev',
+    null,
+    now(),
+    now()
+)
+on conflict on constraint uk_social_accounts_provider_user do update
+set user_id = excluded.user_id,
+    email = excluded.email,
+    profile_image_url = excluded.profile_image_url,
+    updated_at = now();
+
+insert into user_profiles (user_id, nickname, mascot_name, timezone, profile_image_url, notification_enabled, created_at, updated_at)
+values (
+    '40400000-0000-0000-0000-000000000055',
+    '심사너굴',
+    '너구리',
+    'Asia/Seoul',
+    null,
+    true,
+    now(),
+    now()
+)
+on conflict (user_id) do update
+set nickname = excluded.nickname,
+    mascot_name = excluded.mascot_name,
+    timezone = excluded.timezone,
+    profile_image_url = excluded.profile_image_url,
+    notification_enabled = excluded.notification_enabled,
+    updated_at = now();

--- a/src/test/java/com/sagongsa/backend/auth/AppReviewerAuthIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/auth/AppReviewerAuthIntegrationTest.java
@@ -1,0 +1,130 @@
+package com.sagongsa.backend.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest(properties = "app.auth.trusted-user-id-header.enabled=false")
+@ActiveProfiles("prod")
+@AutoConfigureMockMvc
+class AppReviewerAuthIntegrationTest extends PostgreSqlContainerTest {
+
+	private static final UUID REVIEWER_USER_ID = UUID.fromString("40400000-0000-0000-0000-000000000055");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void ensureReviewerAccount() {
+		jdbcTemplate.update(
+			"""
+			insert into users (id, status, onboarding_status, created_at, updated_at, withdrawn_at)
+			values (?, 'ACTIVE', 'COMPLETED', now(), now(), null)
+			on conflict (id) do update
+			set status = 'ACTIVE',
+			    onboarding_status = 'COMPLETED',
+			    updated_at = now(),
+			    withdrawn_at = null
+			""",
+			REVIEWER_USER_ID
+		);
+		jdbcTemplate.update(
+			"""
+			insert into social_accounts (id, user_id, provider, provider_user_id, email, profile_image_url, created_at, updated_at)
+			values (?, ?, 'KAKAO', 'app-reviewer-fixed', 'app-reviewer@sagongsa.dev', null, now(), now())
+			on conflict on constraint uk_social_accounts_provider_user do update
+			set user_id = excluded.user_id,
+			    email = excluded.email,
+			    profile_image_url = excluded.profile_image_url,
+			    updated_at = now()
+			""",
+			UUID.fromString("40400000-0000-0000-0000-000000055001"),
+			REVIEWER_USER_ID
+		);
+		jdbcTemplate.update(
+			"""
+			insert into user_profiles (user_id, nickname, mascot_name, timezone, profile_image_url, notification_enabled, created_at, updated_at)
+			values (?, '심사너굴', '너구리', 'Asia/Seoul', null, true, now(), now())
+			on conflict (user_id) do update
+			set nickname = excluded.nickname,
+			    mascot_name = excluded.mascot_name,
+			    timezone = excluded.timezone,
+			    profile_image_url = excluded.profile_image_url,
+			    notification_enabled = excluded.notification_enabled,
+			    updated_at = now()
+			""",
+			REVIEWER_USER_ID
+		);
+	}
+
+	@Test
+	void issuesReviewerTokenInProdProfileAndAuthenticatesAsReviewer() throws Exception {
+		MvcResult tokenResult = mockMvc.perform(post("/api/auth/reviewer-token"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.tokenType").value("Bearer"))
+			.andExpect(jsonPath("$.accessToken").isString())
+			.andExpect(jsonPath("$.refreshToken").isString())
+			.andReturn();
+
+		JsonNode tokenJson = objectMapper.readTree(tokenResult.getResponse().getContentAsString());
+		String accessToken = tokenJson.get("accessToken").asText();
+		String refreshToken = tokenJson.get("refreshToken").asText();
+
+		mockMvc.perform(get("/api/auth/me")
+			.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.authenticated").value(true))
+			.andExpect(jsonPath("$.userId").value(REVIEWER_USER_ID.toString()))
+			.andExpect(jsonPath("$.provider").value("kakao"))
+			.andExpect(jsonPath("$.providerUserId").value("app-reviewer-fixed"));
+
+		mockMvc.perform(get("/api/v1/users/me")
+			.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id").value(REVIEWER_USER_ID.toString()))
+			.andExpect(jsonPath("$.nickname").value("심사너굴"));
+
+		assertThat(countStoredRefreshTokens(refreshToken)).isEqualTo(1);
+	}
+
+	@Test
+	void keepsDevUserIdHeaderClosedInProdProfile() throws Exception {
+		mockMvc.perform(get("/api/v1/users/me")
+			.header("X-User-Id", REVIEWER_USER_ID.toString()))
+			.andExpect(status().isUnauthorized());
+	}
+
+	private int countStoredRefreshTokens(String refreshToken) {
+		String tokenHash = JwtTokenHash.sha256(refreshToken);
+		Integer count = jdbcTemplate.queryForObject(
+			"select count(*) from refresh_tokens where user_id = ? and token_hash = ? and revoked_at is null",
+			Integer.class,
+			REVIEWER_USER_ID,
+			tokenHash
+		);
+		return count == null ? 0 : count;
+	}
+}

--- a/src/test/java/com/sagongsa/backend/auth/JwtTokenHash.java
+++ b/src/test/java/com/sagongsa/backend/auth/JwtTokenHash.java
@@ -1,0 +1,21 @@
+package com.sagongsa.backend.auth;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+final class JwtTokenHash {
+
+	private JwtTokenHash() {
+	}
+
+	static String sha256(String token) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			return HexFormat.of().formatHex(digest.digest(token.getBytes(StandardCharsets.UTF_8)));
+		} catch (NoSuchAlgorithmException exception) {
+			throw new IllegalStateException("SHA-256 digest is not available", exception);
+		}
+	}
+}


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-55`
- GitHub: Related #114
- GitHub: Closes #114

> PR 제목: `NF-55 앱 심사용 고정 계정 토큰 발급 API 추가`
> 브랜치: `feat/NF-55-app-reviewer-auth-token`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #114의 단일 PR
- 선행 PR: 없음
- 후속 PR: FE 로고 N번 탭 호출 및 토큰 저장 작업

### 이 PR에서 변경한 것
- prod에서도 호출 가능한 앱 심사용 토큰 발급 API `POST /api/auth/reviewer-token`을 추가했습니다.
- reviewer 고정 계정을 Flyway migration으로 seed 합니다.
- reviewer 계정에 대해 기존 `JwtTokenService`로 일반 사용자 access/refresh token을 발급합니다.
- `SecurityConfig`에서 reviewer token API만 인증 없이 호출 가능하도록 허용했습니다.
- prod에서 `DevController`와 `X-User-Id` 정책은 변경하지 않았습니다.

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
- AC1: prod profile에서도 `POST /api/auth/reviewer-token`이 인증 없이 호출 가능하다.
- AC2: API는 요청 바디의 userId를 받지 않고, 서버 고정 reviewer UUID만 사용한다.
- AC3: 응답은 일반 사용자 access token과 refresh token을 반환한다.
- AC4: 발급된 access token으로 `@CurrentUserId` 기반 API가 reviewer userId를 인식한다.
- AC5: reviewer 계정은 Flyway migration으로 `users`, `social_accounts`, `user_profiles`에 생성된다.
- AC6: `DevController`와 `X-User-Id` prod 정책은 변경하지 않는다.

### Not covered (후속 작업)
- FE 로고 N번 탭 구현: 후속 FE 작업
- 앱 심사 안내 문구 또는 운영 문서 작성: 필요 시 후속 작업

---

## 🧪 테스트 결과 (필수)
### 로컬
```bash
./gradlew test --tests com.sagongsa.backend.auth.AppReviewerAuthIntegrationTest --tests com.sagongsa.backend.auth.AuthApiControllerTest
./gradlew test --tests com.sagongsa.backend.domain.DomainSchemaSmokeTest
git diff --check
```
- ✅ 결과: 통과

### CI
- 자동 첨부 예정

### Smoke 테스트
- 시나리오:
  - prod profile에서 `POST /api/auth/reviewer-token` 호출
  - 응답 access token을 `Authorization: Bearer ...`로 넣고 `GET /api/auth/me` 호출
  - 같은 access token으로 `GET /api/v1/users/me` 호출해 `@CurrentUserId` 기반 API 접근 확인
  - prod profile에서 `X-User-Id`만으로 `/api/v1/users/me` 호출 시 401 확인
- 결과: 통과

---

## 🧭 영향 범위 체크 (필수)
- [x] API 변경 (요약: `POST /api/auth/reviewer-token` 추가)
- [x] DB 변경 (마이그레이션: `V13__seed_app_reviewer_user.sql`로 reviewer 계정 seed 데이터 추가)
- [ ] 설정 변경
- [ ] Breaking change

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인:
  - `src/main/java/com/sagongsa/backend/auth/AuthApiController.java`
  - `src/main/java/com/sagongsa/backend/config/SecurityConfig.java`
  - `src/main/resources/db/migration/V13__seed_app_reviewer_user.sql`
  - `src/test/java/com/sagongsa/backend/auth/AppReviewerAuthIntegrationTest.java`
- 트레이드오프/대안:
  - `DevController`를 prod에서 여는 대신, 심사용 고정 계정 토큰 발급만 별도 API로 분리했습니다.
  - 로고 N번 탭은 노출을 줄이는 UX 장치로만 보고, 백엔드는 reviewer 계정 하나에 대한 일반 사용자 토큰 발급만 허용합니다.
  - API가 노출되어도 임의 계정 선택이나 개발용 데이터 생성으로 이어지지 않도록 요청 바디를 사용하지 않습니다.
