### PR TITLE
[feat] NF-57 마이페이지 소비 통계 및 위시 히스토리 응답 확장

### DIFF
--- a/src/main/java/com/sagongsa/backend/mypage/MypageService.java
+++ b/src/main/java/com/sagongsa/backend/mypage/MypageService.java
@@ -221,8 +221,47 @@ class MypageService {
 		Instant from = ym.atDay(1).atStartOfDay(KST).toInstant();
 		Instant to = ym.atEndOfMonth().plusDays(1).atStartOfDay(KST).toInstant();
 
-		String statusName = status != null ? status.name() : null;
-		List<WishSummaryResponse> wishes = jdbcTemplate.query(
+		List<WishSummaryResponse> wishes = getWishSummaries(userId, status, from, to, page, size);
+		long total = countWishSummaries(userId, status, from, to);
+		return new WishHistoryResponse(wishes, total, page, size);
+	}
+
+	private List<WishSummaryResponse> getWishSummaries(
+		UUID userId, ItemStatus status, Instant from, Instant to, int page, int size) {
+		if (status == null) {
+			return jdbcTemplate.query(
+				"""
+				SELECT si.id,
+				       pd.id AS decision_id,
+				       si.title,
+				       COALESCE(pd.final_price, si.listed_price) AS price,
+				       si.image_url,
+				       si.category,
+				       si.status,
+				       pr.satisfaction_score,
+				       pr.regret_level,
+				       pr.still_using,
+				       pr.reflection_note,
+				       pr.reflected_at
+				FROM purchase_decisions pd
+				JOIN saved_items si ON si.id = pd.item_id
+				LEFT JOIN purchase_reflections pr ON pr.decision_id = pd.id
+				WHERE pd.user_id = ?
+				  AND pd.decided_at >= ?
+				  AND pd.decided_at < ?
+				ORDER BY pd.decided_at DESC
+				LIMIT ? OFFSET ?
+				""",
+				this::mapWishSummary,
+				userId,
+				Timestamp.from(from),
+				Timestamp.from(to),
+				size,
+				page * size
+			);
+		}
+
+		return jdbcTemplate.query(
 			"""
 			SELECT si.id,
 			       pd.id AS decision_id,
@@ -240,7 +279,7 @@ class MypageService {
 			JOIN saved_items si ON si.id = pd.item_id
 			LEFT JOIN purchase_reflections pr ON pr.decision_id = pd.id
 			WHERE pd.user_id = ?
-			  AND (? IS NULL OR si.status = ?)
+			  AND si.status = ?
 			  AND pd.decided_at >= ?
 			  AND pd.decided_at < ?
 			ORDER BY pd.decided_at DESC
@@ -248,32 +287,48 @@ class MypageService {
 			""",
 			this::mapWishSummary,
 			userId,
-			statusName,
-			statusName,
-			from,
-			to,
+			status.name(),
+			Timestamp.from(from),
+			Timestamp.from(to),
 			size,
 			page * size
 		);
+	}
 
-		long total = jdbcTemplate.queryForObject(
+	private long countWishSummaries(UUID userId, ItemStatus status, Instant from, Instant to) {
+		if (status == null) {
+			return jdbcTemplate.queryForObject(
+				"""
+				SELECT COUNT(*)
+				FROM purchase_decisions pd
+				JOIN saved_items si ON si.id = pd.item_id
+				WHERE pd.user_id = ?
+				  AND pd.decided_at >= ?
+				  AND pd.decided_at < ?
+				""",
+				Long.class,
+				userId,
+				Timestamp.from(from),
+				Timestamp.from(to)
+			);
+		}
+
+		return jdbcTemplate.queryForObject(
 			"""
 			SELECT COUNT(*)
 			FROM purchase_decisions pd
 			JOIN saved_items si ON si.id = pd.item_id
 			WHERE pd.user_id = ?
-			  AND (? IS NULL OR si.status = ?)
+			  AND si.status = ?
 			  AND pd.decided_at >= ?
 			  AND pd.decided_at < ?
 			""",
 			Long.class,
 			userId,
-			statusName,
-			statusName,
-			from,
-			to
+			status.name(),
+			Timestamp.from(from),
+			Timestamp.from(to)
 		);
-		return new WishHistoryResponse(wishes, total, page, size);
 	}
 
 	private StatsAggregation getStatsAggregation(UUID userId, Instant from, Instant to) {
@@ -309,8 +364,8 @@ class MypageService {
 				);
 			},
 			userId,
-			from,
-			to
+			Timestamp.from(from),
+			Timestamp.from(to)
 		);
 	}
 
@@ -333,8 +388,8 @@ class MypageService {
 				rs.getInt("amount")
 			),
 			userId,
-			from,
-			to
+			Timestamp.from(from),
+			Timestamp.from(to)
 		);
 	}
 

--- a/src/main/java/com/sagongsa/backend/mypage/MypageService.java
+++ b/src/main/java/com/sagongsa/backend/mypage/MypageService.java
@@ -6,8 +6,8 @@ import com.sagongsa.backend.domain.auth.UserAccount;
 import com.sagongsa.backend.domain.auth.UserAccountRepository;
 import com.sagongsa.backend.domain.budget.BudgetCycle;
 import com.sagongsa.backend.domain.budget.BudgetCycleRepository;
+import com.sagongsa.backend.domain.enums.ItemCategory;
 import com.sagongsa.backend.domain.enums.ItemStatus;
-import com.sagongsa.backend.domain.item.SavedItem;
 import com.sagongsa.backend.domain.item.SavedItemRepository;
 import com.sagongsa.backend.domain.notification.DevicePushTokenRepository;
 import com.sagongsa.backend.domain.social.FeedPostRepository;
@@ -20,6 +20,9 @@ import com.sagongsa.backend.domain.user.UserProfileRepository;
 import com.sagongsa.backend.social.BlockService;
 import com.sagongsa.backend.social.PostListResponse;
 import com.sagongsa.backend.social.PostResponse;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.YearMonth;
 import java.time.ZoneId;
@@ -188,19 +191,26 @@ class MypageService {
 
 		BudgetCycle budget = budgetCycleRepository.findByUserIdAndYearMonth(userId, yearMonth).orElse(null);
 		Integer budgetAmount = budget != null ? budget.getMonthlyBudgetAmount() : null;
-		Integer spent = savedItemRepository.sumPriceByUserIdAndStatusBetween(userId, ItemStatus.GO, from, to);
-		Integer restrained = savedItemRepository.sumPriceByUserIdAndStatusBetween(userId, ItemStatus.STOP, from, to);
-		long boughtCount = savedItemRepository.countByUserIdAndStatusBetween(userId, ItemStatus.GO, from, to);
-		long restrainedCount = savedItemRepository.countByUserIdAndStatusBetween(userId, ItemStatus.STOP, from, to);
+		StatsAggregation stats = getStatsAggregation(userId, from, to);
+		List<CategorySpendAmountResponse> categorySpendAmounts = getCategorySpendAmounts(userId, from, to);
 
 		Double usageRate = null;
-		int spentVal = spent != null ? spent : 0;
 		if (budgetAmount != null && budgetAmount > 0) {
-			usageRate = Math.round((double) spentVal / budgetAmount * 1000.0) / 10.0;
+			usageRate = roundRate((double) stats.spentAmount() / budgetAmount * 100.0);
 		}
 
-		return new StatsResponse(yearMonth, budgetAmount, spentVal,
-			restrained != null ? restrained : 0, usageRate, boughtCount, restrainedCount);
+		return new StatsResponse(
+			yearMonth,
+			budgetAmount,
+			stats.spentAmount(),
+			stats.restrainedAmount(),
+			usageRate,
+			stats.boughtCount(),
+			stats.restrainedCount(),
+			categorySpendAmounts,
+			stats.rationalChoiceRate(),
+			stats.irrationalChoiceCount()
+		);
 	}
 
 	WishHistoryResponse getWishHistory(UUID userId, ItemStatus status, String yearMonth, int page, int size) {
@@ -211,17 +221,177 @@ class MypageService {
 		Instant from = ym.atDay(1).atStartOfDay(KST).toInstant();
 		Instant to = ym.atEndOfMonth().plusDays(1).atStartOfDay(KST).toInstant();
 
-		List<SavedItem> items = savedItemRepository.findByUserIdAndStatusBetween(
-			userId, status, from, to, PageRequest.of(page, size));
+		String statusName = status != null ? status.name() : null;
+		List<WishSummaryResponse> wishes = jdbcTemplate.query(
+			"""
+			SELECT si.id,
+			       pd.id AS decision_id,
+			       si.title,
+			       COALESCE(pd.final_price, si.listed_price) AS price,
+			       si.image_url,
+			       si.category,
+			       si.status,
+			       pr.satisfaction_score,
+			       pr.regret_level,
+			       pr.still_using,
+			       pr.reflection_note,
+			       pr.reflected_at
+			FROM purchase_decisions pd
+			JOIN saved_items si ON si.id = pd.item_id
+			LEFT JOIN purchase_reflections pr ON pr.decision_id = pd.id
+			WHERE pd.user_id = ?
+			  AND (? IS NULL OR si.status = ?)
+			  AND pd.decided_at >= ?
+			  AND pd.decided_at < ?
+			ORDER BY pd.decided_at DESC
+			LIMIT ? OFFSET ?
+			""",
+			this::mapWishSummary,
+			userId,
+			statusName,
+			statusName,
+			from,
+			to,
+			size,
+			page * size
+		);
 
-		long total = (status != null)
-			? savedItemRepository.countByUserIdAndStatusBetween(userId, status, from, to)
-			: savedItemRepository.countByUserIdAndStatusBetween(userId, ItemStatus.GO, from, to)
-			+ savedItemRepository.countByUserIdAndStatusBetween(userId, ItemStatus.STOP, from, to);
-
-		List<WishSummaryResponse> wishes = items.stream().map(WishSummaryResponse::of).toList();
+		long total = jdbcTemplate.queryForObject(
+			"""
+			SELECT COUNT(*)
+			FROM purchase_decisions pd
+			JOIN saved_items si ON si.id = pd.item_id
+			WHERE pd.user_id = ?
+			  AND (? IS NULL OR si.status = ?)
+			  AND pd.decided_at >= ?
+			  AND pd.decided_at < ?
+			""",
+			Long.class,
+			userId,
+			statusName,
+			statusName,
+			from,
+			to
+		);
 		return new WishHistoryResponse(wishes, total, page, size);
 	}
+
+	private StatsAggregation getStatsAggregation(UUID userId, Instant from, Instant to) {
+		return jdbcTemplate.queryForObject(
+			"""
+			SELECT COALESCE(SUM(CASE WHEN pd.result = 'GO'
+			           THEN COALESCE(pd.final_price, si.listed_price, 0) ELSE 0 END), 0)::integer AS spent_amount,
+			       COALESCE(SUM(CASE WHEN pd.result = 'STOP'
+			           THEN COALESCE(si.listed_price, 0) ELSE 0 END), 0)::integer AS restrained_amount,
+			       COUNT(*) FILTER (WHERE pd.result = 'GO') AS bought_count,
+			       COUNT(*) FILTER (WHERE pd.result = 'STOP') AS restrained_count,
+			       COUNT(*) AS decision_count,
+			       COUNT(*) FILTER (WHERE pd.rationality_result = 'RATIONAL') AS rational_count,
+			       COUNT(*) FILTER (WHERE pd.rationality_result = 'IRRATIONAL') AS irrational_count
+			FROM purchase_decisions pd
+			JOIN saved_items si ON si.id = pd.item_id
+			WHERE pd.user_id = ?
+			  AND pd.decided_at >= ?
+			  AND pd.decided_at < ?
+			""",
+			(rs, rowNum) -> {
+				long decisionCount = rs.getLong("decision_count");
+				Double rationalChoiceRate = decisionCount == 0
+					? null
+					: roundRate((double) rs.getLong("rational_count") / decisionCount * 100.0);
+				return new StatsAggregation(
+					rs.getInt("spent_amount"),
+					rs.getInt("restrained_amount"),
+					rs.getLong("bought_count"),
+					rs.getLong("restrained_count"),
+					rationalChoiceRate,
+					rs.getLong("irrational_count")
+				);
+			},
+			userId,
+			from,
+			to
+		);
+	}
+
+	private List<CategorySpendAmountResponse> getCategorySpendAmounts(UUID userId, Instant from, Instant to) {
+		return jdbcTemplate.query(
+			"""
+			SELECT si.category,
+			       COALESCE(SUM(COALESCE(pd.final_price, si.listed_price, 0)), 0)::integer AS amount
+			FROM purchase_decisions pd
+			JOIN saved_items si ON si.id = pd.item_id
+			WHERE pd.user_id = ?
+			  AND pd.result = 'GO'
+			  AND pd.decided_at >= ?
+			  AND pd.decided_at < ?
+			GROUP BY si.category
+			ORDER BY amount DESC, si.category ASC
+			""",
+			(rs, rowNum) -> new CategorySpendAmountResponse(
+				ItemCategory.valueOf(rs.getString("category")),
+				rs.getInt("amount")
+			),
+			userId,
+			from,
+			to
+		);
+	}
+
+	private WishSummaryResponse mapWishSummary(ResultSet rs, int rowNum) throws SQLException {
+		return new WishSummaryResponse(
+			rs.getObject("id", UUID.class),
+			rs.getObject("decision_id", UUID.class),
+			rs.getString("title"),
+			nullableInt(rs, "price"),
+			rs.getString("image_url"),
+			ItemCategory.valueOf(rs.getString("category")),
+			ItemStatus.valueOf(rs.getString("status")),
+			mapWishReflection(rs)
+		);
+	}
+
+	private WishReflectionResponse mapWishReflection(ResultSet rs) throws SQLException {
+		String regretLevel = rs.getString("regret_level");
+		if (regretLevel == null) {
+			return null;
+		}
+		return new WishReflectionResponse(
+			nullableInt(rs, "satisfaction_score"),
+			regretLevel,
+			nullableBoolean(rs, "still_using"),
+			rs.getString("reflection_note"),
+			toInstant(rs, "reflected_at")
+		);
+	}
+
+	private Integer nullableInt(ResultSet rs, String column) throws SQLException {
+		int value = rs.getInt(column);
+		return rs.wasNull() ? null : value;
+	}
+
+	private Boolean nullableBoolean(ResultSet rs, String column) throws SQLException {
+		boolean value = rs.getBoolean(column);
+		return rs.wasNull() ? null : value;
+	}
+
+	private Instant toInstant(ResultSet rs, String column) throws SQLException {
+		Timestamp timestamp = rs.getTimestamp(column);
+		return timestamp == null ? null : timestamp.toInstant();
+	}
+
+	private Double roundRate(double rate) {
+		return Math.round(rate * 10.0) / 10.0;
+	}
+
+	private record StatsAggregation(
+		int spentAmount,
+		int restrainedAmount,
+		long boughtCount,
+		long restrainedCount,
+		Double rationalChoiceRate,
+		long irrationalChoiceCount
+	) {}
 
 	PostListResponse getMyPosts(UUID userId, Instant cursor, int size) {
 		PageRequest pageable = PageRequest.of(0, size + 1);

--- a/src/main/java/com/sagongsa/backend/mypage/StatsResponse.java
+++ b/src/main/java/com/sagongsa/backend/mypage/StatsResponse.java
@@ -1,5 +1,8 @@
 package com.sagongsa.backend.mypage;
 
+import com.sagongsa.backend.domain.enums.ItemCategory;
+import java.util.List;
+
 record StatsResponse(
 	String yearMonth,
 	Integer budgetAmount,
@@ -7,5 +10,13 @@ record StatsResponse(
 	int restrainedAmount,
 	Double usageRate,
 	long boughtCount,
-	long restrainedCount
+	long restrainedCount,
+	List<CategorySpendAmountResponse> categorySpendAmounts,
+	Double rationalChoiceRate,
+	long irrationalChoiceCount
+) {}
+
+record CategorySpendAmountResponse(
+	ItemCategory category,
+	int amount
 ) {}

--- a/src/main/java/com/sagongsa/backend/mypage/WishSummaryResponse.java
+++ b/src/main/java/com/sagongsa/backend/mypage/WishSummaryResponse.java
@@ -3,24 +3,37 @@ package com.sagongsa.backend.mypage;
 import com.sagongsa.backend.domain.enums.ItemCategory;
 import com.sagongsa.backend.domain.enums.ItemStatus;
 import com.sagongsa.backend.domain.item.SavedItem;
+import java.time.Instant;
 import java.util.UUID;
 
 record WishSummaryResponse(
 	UUID id,
+	UUID decisionId,
 	String title,
 	Integer price,
 	String imageUrl,
 	ItemCategory category,
-	ItemStatus status
+	ItemStatus status,
+	WishReflectionResponse reflection
 ) {
 	static WishSummaryResponse of(SavedItem item) {
 		return new WishSummaryResponse(
 			item.getId(),
+			null,
 			item.getTitle(),
 			item.getListedPrice(),
 			item.getImageUrl(),
 			item.getCategory(),
-			item.getStatus()
+			item.getStatus(),
+			null
 		);
 	}
 }
+
+record WishReflectionResponse(
+	Integer satisfactionScore,
+	String regretLevel,
+	Boolean stillUsing,
+	String reflectionNote,
+	Instant reflectedAt
+) {}

--- a/src/test/java/com/sagongsa/backend/mypage/MypageApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/mypage/MypageApiIntegrationTest.java
@@ -209,7 +209,11 @@ class MypageApiIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(jsonPath("$.restrainedAmount").value(50_000))
 			.andExpect(jsonPath("$.boughtCount").value(1))
 			.andExpect(jsonPath("$.restrainedCount").value(1))
-			.andExpect(jsonPath("$.usageRate").value(33.3));
+			.andExpect(jsonPath("$.usageRate").value(33.3))
+			.andExpect(jsonPath("$.categorySpendAmounts[0].category").value("DIGITAL"))
+			.andExpect(jsonPath("$.categorySpendAmounts[0].amount").value(100_000))
+			.andExpect(jsonPath("$.rationalChoiceRate").value(100.0))
+			.andExpect(jsonPath("$.irrationalChoiceCount").value(0));
 	}
 
 	// ── GET /api/v1/users/me/wishes/history ──────────────────────────────────
@@ -221,6 +225,24 @@ class MypageApiIntegrationTest extends PostgreSqlContainerTest {
 		mockMvc.perform(get(BASE + "/wishes/history").header("X-User-Id", userId))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.wishes").isArray());
+	}
+
+	@Test
+	void 위시_히스토리_평가_결과_조회_200() throws Exception {
+		UUID userId = insertUser("너굴이", "너구리");
+		String yearMonth = YearMonth.now(KST).toString();
+		UUID decisionId = insertDecision(userId, "GO", 100_000, yearMonth);
+		insertReflection(userId, decisionId, 5, "NONE", true, "잘 쓰고 있어요");
+
+		mockMvc.perform(get(BASE + "/wishes/history")
+				.header("X-User-Id", userId)
+				.param("status", "GO")
+				.param("yearMonth", yearMonth))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.wishes[0].decisionId").value(decisionId.toString()))
+			.andExpect(jsonPath("$.wishes[0].reflection.satisfactionScore").value(5))
+			.andExpect(jsonPath("$.wishes[0].reflection.regretLevel").value("NONE"))
+			.andExpect(jsonPath("$.wishes[0].reflection.stillUsing").value(true));
 	}
 
 	@Test
@@ -298,8 +320,9 @@ class MypageApiIntegrationTest extends PostgreSqlContainerTest {
 			UUID.randomUUID(), postId, userId, voteType, now, now);
 	}
 
-	private void insertDecision(UUID userId, String result, int price, String yearMonth) {
+	private UUID insertDecision(UUID userId, String result, int price, String yearMonth) {
 		UUID itemId = UUID.randomUUID();
+		UUID decisionId = UUID.randomUUID();
 		ZoneId kst = ZoneId.of("Asia/Seoul");
 		java.time.YearMonth ym = java.time.YearMonth.parse(yearMonth);
 		OffsetDateTime monthMid = OffsetDateTime.ofInstant(
@@ -310,6 +333,18 @@ class MypageApiIntegrationTest extends PostgreSqlContainerTest {
 			itemId, userId, price, result, monthMid, monthMid);
 		jdbcTemplate.update(
 			"INSERT INTO purchase_decisions (id, user_id, item_id, result, final_price, rationality_result, self_check_yes_count, is_changed, change_count, decided_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 'RATIONAL', 0, false, 0, ?, ?, ?)",
-			UUID.randomUUID(), userId, itemId, result, price, monthMid, now, now);
+			decisionId, userId, itemId, result, price, monthMid, now, now);
+		return decisionId;
+	}
+
+	private void insertReflection(UUID userId, UUID decisionId, Integer satisfactionScore, String regretLevel,
+		Boolean stillUsing, String reflectionNote) {
+		UUID itemId = jdbcTemplate.queryForObject(
+			"SELECT item_id FROM purchase_decisions WHERE id = ?", UUID.class, decisionId);
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"INSERT INTO purchase_reflections (id, user_id, item_id, decision_id, satisfaction_score, regret_level, still_using, reflection_note, reflected_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+			UUID.randomUUID(), userId, itemId, decisionId, satisfactionScore, regretLevel, stillUsing, reflectionNote,
+			now, now, now);
 	}
 }

--- a/src/test/java/com/sagongsa/backend/mypage/MypageServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/mypage/MypageServiceTest.java
@@ -3,6 +3,8 @@ package com.sagongsa.backend.mypage;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.sagongsa.backend.domain.enums.ItemCategory;
+import com.sagongsa.backend.domain.enums.ItemStatus;
 import com.sagongsa.backend.support.PostgreSqlContainerTest;
 import java.time.OffsetDateTime;
 import java.time.YearMonth;
@@ -186,6 +188,25 @@ class MypageServiceTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void 통계_카테고리별_소비와_합리성_집계() {
+		UUID userId = insertUser("너굴이", "너구리");
+		String yearMonth = YearMonth.now(KST).toString();
+		insertBudgetCycle(userId, yearMonth, 500_000, 100_000);
+		insertDecision(userId, "GO", 45_000, yearMonth, "FASHION", "RATIONAL");
+		insertDecision(userId, "GO", 15_000, yearMonth, "BEAUTY", "IRRATIONAL");
+		insertDecision(userId, "STOP", 27_000, yearMonth, "ETC", "IRRATIONAL");
+
+		StatsResponse response = mypageService.getStats(userId, yearMonth);
+
+		assertThat(response.categorySpendAmounts()).containsExactly(
+			new CategorySpendAmountResponse(ItemCategory.FASHION, 45_000),
+			new CategorySpendAmountResponse(ItemCategory.BEAUTY, 15_000)
+		);
+		assertThat(response.rationalChoiceRate()).isEqualTo(33.3);
+		assertThat(response.irrationalChoiceCount()).isEqualTo(2);
+	}
+
+	@Test
 	void 통계_예산_사용률_계산() {
 		UUID userId = insertUser("너굴이", "너구리");
 		String yearMonth = YearMonth.now(KST).toString();
@@ -252,10 +273,27 @@ class MypageServiceTest extends PostgreSqlContainerTest {
 		insertDecision(userId, "STOP", 30_000, yearMonth);
 
 		WishHistoryResponse response = mypageService.getWishHistory(
-			userId, com.sagongsa.backend.domain.enums.ItemStatus.GO, yearMonth, 0, 20);
+			userId, ItemStatus.GO, yearMonth, 0, 20);
 
 		assertThat(response.wishes()).hasSize(1);
-		assertThat(response.wishes().get(0).status()).isEqualTo(com.sagongsa.backend.domain.enums.ItemStatus.GO);
+		assertThat(response.wishes().get(0).status()).isEqualTo(ItemStatus.GO);
+	}
+
+	@Test
+	void 위시_히스토리_평가_결과_포함() {
+		UUID userId = insertUser("너굴이", "너구리");
+		String yearMonth = YearMonth.now(KST).toString();
+		UUID decisionId = insertDecision(userId, "GO", 50_000, yearMonth);
+		insertReflection(userId, decisionId, 5, "NONE", true, "잘 쓰고 있어요");
+
+		WishHistoryResponse response = mypageService.getWishHistory(userId, ItemStatus.GO, yearMonth, 0, 20);
+
+		WishSummaryResponse wish = response.wishes().get(0);
+		assertThat(wish.decisionId()).isEqualTo(decisionId);
+		assertThat(wish.reflection()).isNotNull();
+		assertThat(wish.reflection().satisfactionScore()).isEqualTo(5);
+		assertThat(wish.reflection().regretLevel()).isEqualTo("NONE");
+		assertThat(wish.reflection().stillUsing()).isTrue();
 	}
 
 	// ── 회원 탈퇴 ────────────────────────────────────────────────────────────
@@ -336,6 +374,11 @@ class MypageServiceTest extends PostgreSqlContainerTest {
 	}
 
 	private UUID insertDecision(UUID userId, String result, int price, String yearMonth) {
+		return insertDecision(userId, result, price, yearMonth, "DIGITAL", "RATIONAL");
+	}
+
+	private UUID insertDecision(UUID userId, String result, int price, String yearMonth, String category,
+		String rationalityResult) {
 		UUID itemId = UUID.randomUUID();
 		UUID decisionId = UUID.randomUUID();
 		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
@@ -345,11 +388,23 @@ class MypageServiceTest extends PostgreSqlContainerTest {
 			ym.atDay(15).atStartOfDay(kst).toInstant(), ZoneOffset.UTC);
 
 		jdbcTemplate.update(
-			"INSERT INTO saved_items (id, user_id, input_source, title, listed_price, currency_code, category, category_locked_by_user, status, created_at, updated_at) VALUES (?, ?, 'DIRECT_INPUT', '테스트 상품', ?, 'KRW', 'DIGITAL', false, ?, ?, ?)",
-			itemId, userId, price, result, monthMid, monthMid);
+			"INSERT INTO saved_items (id, user_id, input_source, title, listed_price, currency_code, category, category_locked_by_user, status, created_at, updated_at) VALUES (?, ?, 'DIRECT_INPUT', '테스트 상품', ?, 'KRW', ?, false, ?, ?, ?)",
+			itemId, userId, price, category, result, monthMid, monthMid);
+		short yesCount = "IRRATIONAL".equals(rationalityResult) ? (short) 2 : (short) 0;
 		jdbcTemplate.update(
-			"INSERT INTO purchase_decisions (id, user_id, item_id, result, final_price, rationality_result, self_check_yes_count, is_changed, change_count, decided_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 'RATIONAL', 0, false, 0, ?, ?, ?)",
-			decisionId, userId, itemId, result, price, monthMid, now, now);
+			"INSERT INTO purchase_decisions (id, user_id, item_id, result, final_price, rationality_result, self_check_yes_count, is_changed, change_count, decided_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, false, 0, ?, ?, ?)",
+			decisionId, userId, itemId, result, price, rationalityResult, yesCount, monthMid, now, now);
 		return decisionId;
+	}
+
+	private void insertReflection(UUID userId, UUID decisionId, Integer satisfactionScore, String regretLevel,
+		Boolean stillUsing, String reflectionNote) {
+		UUID itemId = jdbcTemplate.queryForObject(
+			"SELECT item_id FROM purchase_decisions WHERE id = ?", UUID.class, decisionId);
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"INSERT INTO purchase_reflections (id, user_id, item_id, decision_id, satisfaction_score, regret_level, still_using, reflection_note, reflected_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+			UUID.randomUUID(), userId, itemId, decisionId, satisfactionScore, regretLevel, stillUsing, reflectionNote,
+			now, now, now);
 	}
 }


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-57`
- Jira: https://parkjaehong.atlassian.net/browse/NF-57
- GitHub: Related #117
- GitHub: Closes #117

> PR 제목: `[feat] NF-57 마이페이지 소비 통계 및 위시 히스토리 응답 확장`
> 브랜치: `feat/NF-57-mypage-consumption-history`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #117의 1/1 단계
- 선행 PR: 없음
- 후속 PR: 없음

### 이 PR에서 변경한 것
- `GET /api/v1/users/me/stats` 응답에 카테고리별 소비 금액을 추가했습니다.
- `GET /api/v1/users/me/stats` 응답에 합리적 선택률과 비합리적 선택 횟수를 추가했습니다.
- `GET /api/v1/users/me/wishes/history` 응답에 결정 ID와 7일 후 평가 결과를 추가했습니다.
- 마이페이지 서비스/통합 테스트에 신규 응답 필드 검증을 추가했습니다.

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
- AC1: 월별 소비 통계에서 카테고리별 총 소비 금액을 조회할 수 있습니다.
- AC2: 월별 소비 통계에서 합리적 선택률과 비합리적 선택 횟수를 조회할 수 있습니다.
- AC3: 위시 히스토리에서 7일 후 평가가 완료된 구매 건의 평가 결과를 조회할 수 있습니다.

### Not covered (후속 작업)
- 없음

---

## 🧪 테스트 결과 (필수)
### 로컬
```
./gradlew test jacocoTestReport
```
- ✅ 결과: 성공 (`/tmp/404_BE_NF57_verify`, 원격 head `f8604ea` 기준)

### CI
- ✅ Gradle Test 성공

### Smoke 테스트
- 시나리오: `GET /api/v1/users/me/stats` 응답에 신규 통계 필드가 포함되는지 검증
- 결과: ✅ `MypageApiIntegrationTest.통계_조회_200`에서 확인
- 시나리오: `GET /api/v1/users/me/wishes/history` 응답에 7일 후 평가 결과가 포함되는지 검증
- 결과: ✅ `MypageApiIntegrationTest.위시_히스토리_평가_결과_조회_200`에서 확인

---

## 🧭 영향 범위 체크 (필수)
- [x] API 변경 (요약: 마이페이지 통계/위시 히스토리 응답 필드 추가)
- [ ] DB 변경 (마이그레이션: 없음)
- [ ] 설정 변경 (항목: 없음)
- [ ] Breaking change (무엇: 없음. 기존 응답 필드는 유지하고 필드만 추가)

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인: `MypageService`의 stats/history 조회 SQL과 응답 매핑
- 트레이드오프/대안: 기존 `SavedItemRepository` 기반 집계 대신 `purchase_decisions`/`purchase_reflections` 조인 SQL로 UI에 필요한 월별 결정 기준 데이터를 직접 조회합니다.