### PR TITLE
[bug] NF-58 회원 탈퇴 API 500 수정

### DIFF
--- a/src/main/resources/db/migration/V14__allow_self_check_history_delete.sql
+++ b/src/main/resources/db/migration/V14__allow_self_check_history_delete.sql
@@ -1,0 +1,2 @@
+drop trigger if exists trg_prevent_self_check_response_set_delete on self_check_response_sets;
+drop function if exists prevent_self_check_response_set_delete();

--- a/src/test/java/com/sagongsa/backend/domain/DomainSchemaSmokeTest.java
+++ b/src/test/java/com/sagongsa/backend/domain/DomainSchemaSmokeTest.java
@@ -127,7 +127,7 @@ class DomainSchemaSmokeTest extends PostgreSqlContainerTest {
 		assertPartialIndex("idx_post_comments_post_created_visible", "deleted_at is null");
 		assertTrigger("trg_post_votes_sync_feed_counts", "post_votes");
 		assertTrigger("trg_self_check_matches_decision", "self_check_response_sets");
-		assertTrigger("trg_prevent_self_check_response_set_delete", "self_check_response_sets");
+		assertNoTrigger("trg_prevent_self_check_response_set_delete", "self_check_response_sets");
 		assertTrigger("trg_decision_matches_self_check", "purchase_decisions");
 		assertConstraintComment("social_accounts", "uk_social_accounts_user_id", "MVP policy");
 		assertTableComment("share_tokens", "MVP policy");
@@ -316,15 +316,20 @@ class DomainSchemaSmokeTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
-	void preventsDeletingSelfCheckSetAfterDecisionSummaryWasStored() {
+	void allowsDeletingSelfCheckSetForAccountWithdrawalCleanup() {
 		UUID userId = insertUser();
 		UUID itemId = insertSavedItem(userId, "https://shop.example/self-check-delete");
 		UUID decisionId = insertPurchaseDecision(userId, itemId, (short) 1, "RATIONAL");
 		UUID responseSetId = insertSelfCheckResponseSet(decisionId, (short) 1, "RATIONAL");
 
-		assertThatThrownBy(() ->
-			jdbcTemplate.update("delete from self_check_response_sets where id = ?", responseSetId)
-		).isInstanceOf(DataIntegrityViolationException.class);
+		jdbcTemplate.update("delete from self_check_response_sets where id = ?", responseSetId);
+
+		Integer count = jdbcTemplate.queryForObject(
+			"select count(*) from self_check_response_sets where id = ?",
+			Integer.class,
+			responseSetId
+		);
+		assertThat(count).isZero();
 	}
 
 	@Test
@@ -407,6 +412,26 @@ class DomainSchemaSmokeTest extends PostgreSqlContainerTest {
 		);
 
 		assertThat(count).isNotNull().isGreaterThan(0);
+	}
+
+	private void assertNoTrigger(String triggerName, String tableName) {
+		Integer count = jdbcTemplate.queryForObject(
+			"""
+			select count(*)
+			from pg_trigger trg
+			join pg_class tbl on tbl.oid = trg.tgrelid
+			join pg_namespace n on n.oid = tbl.relnamespace
+			where n.nspname = current_schema()
+			  and lower(trg.tgname) = ?
+			  and lower(tbl.relname) = ?
+			  and not trg.tgisinternal
+			""",
+			Integer.class,
+			triggerName,
+			tableName
+		);
+
+		assertThat(count).isZero();
 	}
 
 	private void assertConstraintComment(String tableName, String constraintName, String expectedFragment) {

--- a/src/test/java/com/sagongsa/backend/mypage/MypageApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/mypage/MypageApiIntegrationTest.java
@@ -166,6 +166,24 @@ class MypageApiIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void 회원탈퇴_결정_셀프체크_이력이_있어도_204() throws Exception {
+		UUID userId = insertUser("너굴이", "너구리");
+		String yearMonth = YearMonth.now(KST).toString();
+		UUID decisionId = insertDecision(userId, "GO", 100_000, yearMonth);
+		UUID responseSetId = insertSelfCheckResponseSet(decisionId);
+
+		mockMvc.perform(delete(BASE).header("X-User-Id", userId))
+			.andExpect(status().isNoContent());
+
+		Integer responseSetCount = jdbcTemplate.queryForObject(
+			"SELECT COUNT(*) FROM self_check_response_sets WHERE id = ?", Integer.class, responseSetId);
+		Integer decisionCount = jdbcTemplate.queryForObject(
+			"SELECT COUNT(*) FROM purchase_decisions WHERE id = ?", Integer.class, decisionId);
+		org.assertj.core.api.Assertions.assertThat(responseSetCount).isZero();
+		org.assertj.core.api.Assertions.assertThat(decisionCount).isZero();
+	}
+
+	@Test
 	void 탈퇴_후_프로필_삭제_확인() throws Exception {
 		UUID userId = insertUser("너굴이", "너구리");
 		mockMvc.perform(delete(BASE).header("X-User-Id", userId))
@@ -335,6 +353,18 @@ class MypageApiIntegrationTest extends PostgreSqlContainerTest {
 			"INSERT INTO purchase_decisions (id, user_id, item_id, result, final_price, rationality_result, self_check_yes_count, is_changed, change_count, decided_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 'RATIONAL', 0, false, 0, ?, ?, ?)",
 			decisionId, userId, itemId, result, price, monthMid, now, now);
 		return decisionId;
+	}
+
+	private UUID insertSelfCheckResponseSet(UUID decisionId) {
+		UUID responseSetId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"INSERT INTO self_check_response_sets (id, decision_id, yes_count, rationality_result, submitted_at, created_at, updated_at) VALUES (?, ?, 0, 'RATIONAL', ?, ?, ?)",
+			responseSetId, decisionId, now, now, now);
+		jdbcTemplate.update(
+			"INSERT INTO self_check_answers (id, response_set_id, question_code, answer_boolean, created_at, updated_at) VALUES (?, ?, 'NEED', false, ?, ?)",
+			UUID.randomUUID(), responseSetId, now, now);
+		return responseSetId;
 	}
 
 	private void insertReflection(UUID userId, UUID decisionId, Integer satisfactionScore, String regretLevel,


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-58**
- Jira: https://parkjaehong.atlassian.net/browse/NF-58

> PR 제목: `[bug] NF-58 회원 탈퇴 API 500 수정`  
> 브랜치: `fix/NF-58-account-withdrawal-500`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #119

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- 구매 결정/self-check 이력이 있는 사용자가 `DELETE /api/v1/users/me`를 호출하면 500이 발생할 수 있었습니다.

### 왜 발생했나? (Root Cause)
- 탈퇴 로직은 `self_check_answers` → `self_check_response_sets` → `purchase_decisions` 순서로 의사결정 이력을 정리합니다.
- 하지만 DB의 `trg_prevent_self_check_response_set_delete` trigger가 `self_check_response_sets` 삭제를 항상 막고 있어, 실제 결정 이력이 있는 계정에서 `DataIntegrityViolationException`이 발생했습니다.

### 어떻게 고쳤나?
- `V14__allow_self_check_history_delete.sql` 마이그레이션으로 삭제 금지 trigger/function을 제거했습니다.
- schema smoke 테스트 기대값을 trigger 제거 정책에 맞게 수정했습니다.
- 결정 + self-check 이력이 있는 유저의 회원 탈퇴가 204로 완료되는 API 회귀 테스트를 추가했습니다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법(가능하면)
- Steps:
  1. 구매 결정과 self-check 응답 이력이 있는 유저를 준비합니다.
  2. `DELETE /api/v1/users/me`를 호출합니다.
- 기대 결과: `204 No Content`
- 실제 결과: 기존에는 `self_check_response_sets cannot be deleted...` 에러로 500 발생

### 재발 방지(있다면)
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [ ] 런북/문서 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] AC1: 구매 결정/self-check 이력이 있는 유저도 회원 탈퇴 API가 204를 반환한다.
- [x] AC2: 탈퇴 정리 과정에서 `self_check_response_sets`와 `purchase_decisions`가 정상 삭제된다.
- [x] AC3: DB schema smoke 테스트가 삭제 금지 trigger 제거 상태를 검증한다.

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew test --tests com.sagongsa.backend.mypage.MypageApiIntegrationTest --tests com.sagongsa.backend.domain.DomainSchemaSmokeTest`
- Result: PASS
- Command: `./gradlew test`
- Result: PASS

### CI
- 링크/결과: PR 생성 후 GitHub Actions 확인 예정

### Smoke / 수동 검증
- 시나리오: 결정 + self-check 이력이 있는 유저로 `DELETE /api/v1/users/me` 호출
- 결과: 통합 테스트에서 204와 관련 row 삭제 확인

### 테스트 공백(있다면 이유 필수)
- 없음

---

## 🧭 영향 범위 (필수)
- [x] API 스펙 변경 없음
- [ ] API 스펙 변경 있음 (요약: )
- [ ] DB 스키마 변경 없음
- [x] DB 스키마 변경 있음 (마이그레이션/락/시간: 삭제 금지 trigger/function 제거, DDL만 수행)
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음 (항목: )
- [x] 캐시/큐/외부 연동 영향 없음
- [ ] 캐시/큐/외부 연동 영향 있음 (요약: )

---

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음
- [ ] Breaking change 있음 → 무엇이 깨지는지 / 마이그레이션 / 롤아웃 전략:

---

## 🚀 배포/릴리즈 (해당 시 필수)
### Feature Flag
- [x] 사용 안함
- [ ] 사용함 → Flag/기본값/롤아웃:

### 모니터링/알림
- 확인할 대시보드/지표: 회원 탈퇴 API 5xx 비율
- 에러/로그 키워드: `self_check_response_sets cannot be deleted`, `DataIntegrityViolationException`

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- `self_check_response_sets` 단독 삭제를 금지하던 DB trigger를 제거하므로, 해당 invariant는 insert/update trigger와 애플리케이션 플로우 테스트로 관리합니다.

### 롤백
- [ ] 플래그/설정으로 우회 가능
- [x] 배포 롤백(이전 태그/이미지) 가능
- [x] 데이터 롤백/역마이그레이션 필요 (절차: 필요 시 trigger/function 재생성 마이그레이션 추가)

---

## 📸 증빙 (선택)
- 로컬 전체 테스트: `./gradlew test` PASS

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직:
  - `src/main/resources/db/migration/V14__allow_self_check_history_delete.sql`
  - `src/test/java/com/sagongsa/backend/mypage/MypageApiIntegrationTest.java`
  - `src/test/java/com/sagongsa/backend/domain/DomainSchemaSmokeTest.java`
- 트레이드오프/대안: 애플리케이션에서 trigger를 우회하기보다, 탈퇴 hard-delete 정책과 충돌하는 삭제 금지 trigger를 제거했습니다.
- 성능/보안/호환성 영향: 런타임 로직 변경 없음, DB trigger 제거만 포함합니다.
