### PR TITLE
[bug] NF-59 올리브영 링크 상품명 오추출 방지

### DIFF
--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
@@ -37,6 +37,7 @@ public class ShoppingLinkImportService {
 	private static final Set<String> TRACKING_QUERY_KEYS = Set.of(
 		"fbclid", "gclid", "igshid", "mc_cid", "mc_eid", "n_media", "n_query", "n_rank", "n_ad_group"
 	);
+	private static final Set<String> OLIVE_YOUNG_HOSTS = Set.of("oliveyoung.co.kr", "m.oliveyoung.co.kr");
 	private static final double DEFAULT_CATEGORY_CONFIDENCE = 0.35d;
 
 	private final PageFetcher pageFetcher;
@@ -74,6 +75,9 @@ public class ShoppingLinkImportService {
 		}
 
 		Document document = Jsoup.parse(page.body(), page.finalUri().toString());
+		if (isBlockedShoppingPage(document, page)) {
+			throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Shopping page access was challenged");
+		}
 		ExtractionResult extracted = extractFromPage(document, page);
 		List<String> warnings = new ArrayList<>(normalized.warnings());
 
@@ -81,7 +85,10 @@ public class ShoppingLinkImportService {
 			warnings.add("상품 메타데이터가 일부만 추출되었습니다.");
 		}
 
-		if (isBlank(extracted.title()) && extracted.price() == null && isBlank(extracted.imageUrl())) {
+		if (isBlank(extracted.title())) {
+			throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Unable to extract shopping item title");
+		}
+		if (extracted.price() == null && isBlank(extracted.imageUrl())) {
 			throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Unable to extract shopping metadata");
 		}
 
@@ -208,13 +215,15 @@ public class ShoppingLinkImportService {
 
 	private ExtractionResult extractFromPage(Document document, FetchedPage page) {
 		String html = page.body();
+		String sourceDomain = sourceDomain(page.finalUri());
 		String summary = firstNonBlank(
 			metaContent(document, "meta[property=og:description]"),
 			metaContent(document, "meta[name=description]"),
 			metaContent(document, "meta[name=twitter:description]"),
 			jsonLdText(document, "description")
 		);
-		String title = firstNonBlank(
+		String title = firstProductTitle(
+			sourceDomain,
 			metaContent(document, "meta[property=og:title]"),
 			metaContent(document, "meta[name=twitter:title]"),
 			jsonLdText(document, "name"),
@@ -416,6 +425,27 @@ public class ShoppingLinkImportService {
 		return matcher.find() ? matcher.group(1) : null;
 	}
 
+	private boolean isBlockedShoppingPage(Document document, FetchedPage page) {
+		String title = normalizeWhitespace(document.title());
+		String bodyText = normalizeWhitespace(document.body() == null ? null : document.body().text());
+		String html = page.body() == null ? "" : page.body().toLowerCase(Locale.ROOT);
+		return isBlockedPageText(title)
+			|| isBlockedPageText(bodyText)
+			|| html.contains("cf-mitigated")
+			|| html.contains("cf_chl")
+			|| html.contains("/cdn-cgi/challenge-platform");
+	}
+
+	private boolean isBlockedPageText(String text) {
+		if (isBlank(text)) {
+			return false;
+		}
+		String normalized = text.toLowerCase(Locale.ROOT);
+		return normalized.contains("잠시만 기다")
+			|| normalized.contains("접속 정보를 확인")
+			|| normalized.contains("enable javascript and cookies");
+	}
+
 	private Integer parsePrice(String rawPrice) {
 		if (isBlank(rawPrice)) {
 			return null;
@@ -457,6 +487,46 @@ public class ShoppingLinkImportService {
 	private String sourceDomain(URI uri) {
 		String host = Optional.ofNullable(uri.getHost()).orElse("");
 		return host.toLowerCase(Locale.ROOT).replaceFirst("^www\\.", "");
+	}
+
+	private String firstProductTitle(String sourceDomain, String... values) {
+		for (String value : values) {
+			String title = cleanProductTitle(sourceDomain, value);
+			if (!isBlank(title)) {
+				return title;
+			}
+		}
+		return null;
+	}
+
+	private String cleanProductTitle(String sourceDomain, String value) {
+		String title = normalizeWhitespace(value);
+		if (isBlank(title) || isBlockedPageText(title)) {
+			return null;
+		}
+		if (isOliveYoungDomain(sourceDomain)) {
+			title = normalizeWhitespace(title.replaceFirst("\\s*/\\s*올리브영$", ""));
+			if (isOliveYoungSiteTitle(title)) {
+				return null;
+			}
+		}
+		return title;
+	}
+
+	private boolean isOliveYoungDomain(String sourceDomain) {
+		return OLIVE_YOUNG_HOSTS.contains(sourceDomain);
+	}
+
+	private boolean isOliveYoungSiteTitle(String title) {
+		if (isBlank(title)) {
+			return true;
+		}
+		String normalized = title.replace("[", "")
+			.replace("]", "")
+			.replace("/", "")
+			.trim()
+			.toLowerCase(Locale.ROOT);
+		return normalized.equals("올리브영") || normalized.equals("oliveyoung");
 	}
 
 	private boolean containsAny(String value, String... keywords) {

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
@@ -115,6 +115,74 @@ class ShoppingLinkImportServiceTest {
 	}
 
 	@Test
+	void skipsOliveYoungSiteTitleAndUsesProductTitleFallback() {
+		pageFetcher.stub(
+			"https://www.oliveyoung.co.kr/store/goods/getGoodsDetail.do?goodsNo=A000000230109",
+			"""
+				<html>
+				<head>
+				  <title>[올리브영]</title>
+				  <meta property="og:title" content="/ 올리브영" />
+				  <meta property="og:image" content="https://image.oliveyoung.co.kr/item.jpg" />
+				  <meta property="product:price:amount" content="12900" />
+				</head>
+				<body>
+				  <h1>[포켓몬 에디션] 힐링버드 헤어에센스 150ml / 올리브영</h1>
+				</body>
+				</html>
+				"""
+		);
+
+		ShoppingLinkImportResponse response = service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.SHARE,
+				"https://www.oliveyoung.co.kr/store/goods/getGoodsDetail.do?goodsNo=A000000230109",
+				null,
+				null,
+				null,
+				null
+			)
+		);
+
+		assertThat(response.item().title()).isEqualTo("[포켓몬 에디션] 힐링버드 헤어에센스 150ml");
+		assertThat(response.saveRequest().title()).isEqualTo("[포켓몬 에디션] 힐링버드 헤어에센스 150ml");
+		assertThat(response.item().category()).isEqualTo(ItemCategory.BEAUTY);
+	}
+
+	@Test
+	void rejectsOliveYoungChallengePageInsteadOfUsingChallengeTitle() {
+		pageFetcher.stub(
+			"https://www.oliveyoung.co.kr/store/goods/getGoodsDetail.do?goodsNo=A000000230109",
+			"""
+				<html>
+				<head>
+				  <title>잠시만 기다려 주세요 - 올리브영</title>
+				  <meta property="og:image" content="https://image.oliveyoung.co.kr/item.jpg" />
+				  <meta property="product:price:amount" content="12900" />
+				</head>
+				<body>안전하고 원활한 올리브영 이용을 위해 접속 정보를 확인 중이에요</body>
+				</html>
+				"""
+		);
+
+		assertThatThrownBy(() -> service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.SHARE,
+				"https://www.oliveyoung.co.kr/store/goods/getGoodsDetail.do?goodsNo=A000000230109",
+				null,
+				null,
+				null,
+				null
+			)
+		))
+			.isInstanceOf(ResponseStatusException.class)
+			.satisfies(exception -> {
+				ResponseStatusException responseStatusException = (ResponseStatusException) exception;
+				assertThat(responseStatusException.getStatusCode()).isEqualTo(HttpStatus.BAD_GATEWAY);
+			});
+	}
+
+	@Test
 	void acceptsDirectInputWithoutRemoteFetch() {
 		ShoppingLinkImportResponse response = service.importLink(
 			new ShoppingLinkImportRequest(


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-59**
- Jira: https://parkjaehong.atlassian.net/browse/NF-59

> PR 제목: `[bug] NF-59 올리브영 링크 상품명 오추출 방지`  
> 브랜치: `fix/NF-59-oliveyoung-title-filter`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #121

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- 올리브영 링크 import 시 실제 상품명 대신 `[올리브영]`, `/ 올리브영`, 대기/차단 페이지 제목이 상품명으로 선택될 수 있었습니다.

### 왜 발생했나? (Root Cause)
- 상품명 후보를 `og:title` → `twitter:title` → JSON-LD → `<title>` → 본문 셀렉터 순서로 고를 때, 사이트명성 title과 차단 페이지 title을 걸러내지 않았습니다.
- 상품명 없이 가격/이미지만 잡힌 경우에도 부분 성공 응답을 만들 수 있어 잘못된 저장 후보가 내려갈 수 있었습니다.

### 어떻게 고쳤나?
- 공통 노이즈 제거: 차단/대기 페이지성 문구와 Cloudflare challenge HTML은 상품 정보로 사용하지 않도록 필터링했습니다.
- 올리브영 전용 노이즈 제거: `[올리브영]`, `/ 올리브영` 같은 사이트명성 title 후보를 제외했습니다.
- 정상 상품명 뒤의 ` / 올리브영` suffix는 제거합니다.
- Cloudflare/대기 페이지성 HTML은 상품 import 성공으로 처리하지 않고 `502`로 실패시킵니다.
- SHARE import에서 상품명이 비어 있으면 성공 응답 대신 `422`로 실패시킵니다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법(가능하면)
- Steps:
  1. 올리브영 상품 링크를 `/api/v1/items/import-link`에 SHARE로 전달합니다.
  2. 응답 HTML title/meta가 `[올리브영]` 또는 `/ 올리브영`만 제공합니다.
- 기대 결과: 사이트명은 상품명으로 선택되지 않고, 실제 상품명 후보가 있으면 해당 값을 사용합니다.
- 실제 결과: 기존에는 사이트명성 title이 `item.title`/`saveRequest.title`로 반환될 수 있었습니다.

### 재발 방지(있다면)
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [ ] 런북/문서 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] AC1: 올리브영 사이트명성 title 후보는 상품명으로 선택하지 않는다.
- [x] AC2: 올리브영 상품명 뒤의 ` / 올리브영` suffix는 제거한다.
- [x] AC3: 올리브영 대기/차단 페이지는 상품 import 성공 응답으로 처리하지 않는다.

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew --no-daemon test --tests com.sagongsa.backend.itemimport.item.ShoppingLinkImportServiceTest`
- Result: PASS
- Command: `./gradlew --no-daemon test --tests com.sagongsa.backend.itemimport.ItemImportApiIntegrationTest`
- Result: PASS

### CI
- 링크/결과: PR 생성 후 GitHub Actions 확인 예정

### Smoke / 수동 검증
- 시나리오: 올리브영 mock HTML에서 `[올리브영]`/`/ 올리브영` 후보와 실제 h1 상품명이 함께 들어오는 케이스
- 결과: 실제 상품명만 `item.title`/`saveRequest.title`로 반환됨

### 테스트 공백(있다면 이유 필수)
- 실제 올리브영 라이브 호출은 현재 Cloudflare challenge 403이 내려올 수 있어 mock 기반 회귀 테스트로 검증했습니다.

---

## 🧭 영향 범위 (필수)
- [x] API 스펙 변경 없음
- [ ] API 스펙 변경 있음 (요약: )
- [x] DB 스키마 변경 없음
- [ ] DB 스키마 변경 있음 (마이그레이션/락/시간: )
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음 (항목: )
- [x] 캐시/큐/외부 연동 영향 없음
- [ ] 캐시/큐/외부 연동 영향 있음 (요약: )

---

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음
- [ ] Breaking change 있음 → 무엇이 깨지는지 / 마이그레이션 / 롤아웃 전략:

---

## 🚀 배포/릴리즈 (해당 시 필수)
### Feature Flag
- [x] 사용 안함
- [ ] 사용함 → Flag/기본값/롤아웃:

### 모니터링/알림
- 확인할 대시보드/지표: `/api/v1/items/import-link` 422/502 비율
- 에러/로그 키워드: `Shopping page access was challenged`, `Unable to extract shopping item title`

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 상품명 없이 가격/이미지만 추출되던 일부 링크는 더 이상 부분 성공으로 내려가지 않고 422가 될 수 있습니다. 저장용 상품명 품질을 우선한 선택입니다.

### 롤백
- [ ] 플래그/설정으로 우회 가능
- [x] 배포 롤백(이전 태그/이미지) 가능
- [ ] 데이터 롤백/역마이그레이션 필요 (절차: )

---

## 📸 증빙 (선택)
- 로컬 서비스 테스트와 import-link API 통합 테스트 PASS

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직:
  - `src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java`
  - `src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java`
- 트레이드오프/대안: 사이트별 브라우저 렌더링 보강보다 먼저, 현재 HTML 추출 경로에서 명확한 노이즈 title을 제거하는 최소 수정으로 잡았습니다.
- 성능/보안/호환성 영향: 추가 네트워크 호출 없음, 기존 응답 HTML 내 문자열 필터만 수행합니다.
