### PR TITLE
[Bug] NF-60 온보딩 완료 시 사용자 입력 닉네임 저장

### DIFF
--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingCompleteRequest.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingCompleteRequest.java
@@ -1,6 +1,7 @@
 package com.sagongsa.backend.onboarding;
 
 public record OnboardingCompleteRequest(
+	String nickname,
 	String mascotName,
 	String timezone,
 	Integer monthlyBudgetAmount,

--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingService.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingService.java
@@ -234,13 +234,16 @@ public class OnboardingService {
 		return trimmed;
 	}
 
+	private static final java.util.regex.Pattern NICKNAME_PATTERN =
+		java.util.regex.Pattern.compile("^[가-힣a-zA-Z0-9]+$");
+
 	private String requireNicknameText(String value) {
 		String trimmed = value.trim();
-		if (trimmed.length() < 2) {
-			throw new OnboardingBadRequestException("nickname must be at least 2 characters.");
+		if (trimmed.length() < 1 || trimmed.length() > 10) {
+			throw new OnboardingBadRequestException("nickname must be between 1 and 10 characters.");
 		}
-		if (trimmed.length() > 8) {
-			throw new OnboardingBadRequestException("nickname must be 8 characters or less.");
+		if (!NICKNAME_PATTERN.matcher(trimmed).matches()) {
+			throw new OnboardingBadRequestException("닉네임은 한글, 영문, 숫자만 허용됩니다.");
 		}
 		return trimmed;
 	}

--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingService.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingService.java
@@ -205,7 +205,7 @@ public class OnboardingService {
 		}
 
 		String nickname = request.nickname() != null && !request.nickname().isBlank()
-			? requireText(request.nickname(), "nickname", 20)
+			? requireNicknameText(request.nickname())
 			: null;
 		String mascotName = requireText(request.mascotName(), "mascotName", 40);
 		String timezone = normalizeTimezone(request.timezone());
@@ -230,6 +230,17 @@ public class OnboardingService {
 		String trimmed = value.trim();
 		if (trimmed.length() > maxLength) {
 			throw new OnboardingBadRequestException(fieldName + " must be " + maxLength + " characters or less.");
+		}
+		return trimmed;
+	}
+
+	private String requireNicknameText(String value) {
+		String trimmed = value.trim();
+		if (trimmed.length() < 2) {
+			throw new OnboardingBadRequestException("nickname must be at least 2 characters.");
+		}
+		if (trimmed.length() > 8) {
+			throw new OnboardingBadRequestException("nickname must be 8 characters or less.");
 		}
 		return trimmed;
 	}

--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingService.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingService.java
@@ -115,7 +115,7 @@ public class OnboardingService {
 
 	private void insertUserProfile(UUID userId, NormalizedOnboardingRequest request, OffsetDateTime now) {
 		Long seq = jdbcTemplate.queryForObject("SELECT nextval('user_nickname_seq')", Long.class);
-		String autoNickname = "너굴" + seq;
+		String nickname = request.nickname() != null ? request.nickname() : "너굴" + seq;
 		jdbcTemplate.update(
 			"""
 				insert into user_profiles (
@@ -124,7 +124,7 @@ public class OnboardingService {
 				values (?, ?, ?, ?, null, ?, ?)
 				""",
 			userId,
-			autoNickname,
+			nickname,
 			request.mascotName(),
 			request.timezone(),
 			now,
@@ -204,12 +204,16 @@ public class OnboardingService {
 			throw new OnboardingBadRequestException("Request body is required.");
 		}
 
+		String nickname = request.nickname() != null && !request.nickname().isBlank()
+			? requireText(request.nickname(), "nickname", 20)
+			: null;
 		String mascotName = requireText(request.mascotName(), "mascotName", 40);
 		String timezone = normalizeTimezone(request.timezone());
 		int monthlyBudgetAmount = normalizeMonthlyBudgetAmount(request.monthlyBudgetAmount());
 		String regretFrequencyChoice = normalizeRegretFrequencyChoice(request.regretFrequencyChoice());
 
 		return new NormalizedOnboardingRequest(
+			nickname,
 			mascotName,
 			timezone,
 			ZoneId.of(timezone),
@@ -271,6 +275,7 @@ public class OnboardingService {
 	}
 
 	private record NormalizedOnboardingRequest(
+		String nickname,
 		String mascotName,
 		String timezone,
 		ZoneId zoneId,

--- a/src/test/java/com/sagongsa/backend/onboarding/OnboardingCompleteIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/onboarding/OnboardingCompleteIntegrationTest.java
@@ -137,6 +137,42 @@ class OnboardingCompleteIntegrationTest extends PostgreSqlContainerTest {
 		assertThat(countRows("user_profiles", userId)).isZero();
 	}
 
+	@Test
+	void completeWithNicknameSavesProvidedNickname() throws Exception {
+		UUID userId = insertUser("NOT_STARTED");
+
+		mockMvc.perform(post("/api/v1/onboarding/complete")
+				.header("X-User-Id", userId.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+						"nickname": "테스트닉네임",
+						"mascotName": "wigul",
+						"timezone": "Asia/Seoul",
+						"monthlyBudgetAmount": 300000,
+						"regretFrequencyChoice": "FOUR_OR_MORE"
+					}
+					"""))
+			.andExpect(status().isOk());
+
+		assertThat(queryString("select nickname from user_profiles where user_id = ?", userId))
+			.isEqualTo("테스트닉네임");
+	}
+
+	@Test
+	void completeWithoutNicknameFallsBackToAutoNickname() throws Exception {
+		UUID userId = insertUser("NOT_STARTED");
+
+		mockMvc.perform(post("/api/v1/onboarding/complete")
+				.header("X-User-Id", userId.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(onboardingRequestBody()))
+			.andExpect(status().isOk());
+
+		assertThat(queryString("select nickname from user_profiles where user_id = ?", userId))
+			.matches("너굴\\d+");
+	}
+
 	private UUID insertUser(String onboardingStatus) {
 		return insertUser("ACTIVE", onboardingStatus);
 	}

--- a/src/test/java/com/sagongsa/backend/onboarding/OnboardingCompleteIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/onboarding/OnboardingCompleteIntegrationTest.java
@@ -173,6 +173,44 @@ class OnboardingCompleteIntegrationTest extends PostgreSqlContainerTest {
 			.matches("너굴\\d+");
 	}
 
+	@Test
+	void completeWithTooShortNicknameReturns400() throws Exception {
+		UUID userId = insertUser("NOT_STARTED");
+
+		mockMvc.perform(post("/api/v1/onboarding/complete")
+				.header("X-User-Id", userId.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+						"nickname": "가",
+						"mascotName": "wigul",
+						"timezone": "Asia/Seoul",
+						"monthlyBudgetAmount": 300000,
+						"regretFrequencyChoice": "FOUR_OR_MORE"
+					}
+					"""))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void completeWithTooLongNicknameReturns400() throws Exception {
+		UUID userId = insertUser("NOT_STARTED");
+
+		mockMvc.perform(post("/api/v1/onboarding/complete")
+				.header("X-User-Id", userId.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+						"nickname": "아홉글자닉네임이야",
+						"mascotName": "wigul",
+						"timezone": "Asia/Seoul",
+						"monthlyBudgetAmount": 300000,
+						"regretFrequencyChoice": "FOUR_OR_MORE"
+					}
+					"""))
+			.andExpect(status().isBadRequest());
+	}
+
 	private UUID insertUser(String onboardingStatus) {
 		return insertUser("ACTIVE", onboardingStatus);
 	}

--- a/src/test/java/com/sagongsa/backend/onboarding/OnboardingCompleteIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/onboarding/OnboardingCompleteIntegrationTest.java
@@ -174,7 +174,7 @@ class OnboardingCompleteIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
-	void completeWithTooShortNicknameReturns400() throws Exception {
+	void completeWithTooLongNicknameReturns400() throws Exception {
 		UUID userId = insertUser("NOT_STARTED");
 
 		mockMvc.perform(post("/api/v1/onboarding/complete")
@@ -182,7 +182,7 @@ class OnboardingCompleteIntegrationTest extends PostgreSqlContainerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
-						"nickname": "가",
+						"nickname": "열한글자닉네임이야여기",
 						"mascotName": "wigul",
 						"timezone": "Asia/Seoul",
 						"monthlyBudgetAmount": 300000,
@@ -193,7 +193,7 @@ class OnboardingCompleteIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
-	void completeWithTooLongNicknameReturns400() throws Exception {
+	void completeWithSpecialCharNicknameReturns400() throws Exception {
 		UUID userId = insertUser("NOT_STARTED");
 
 		mockMvc.perform(post("/api/v1/onboarding/complete")
@@ -201,7 +201,7 @@ class OnboardingCompleteIntegrationTest extends PostgreSqlContainerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
-						"nickname": "아홉글자닉네임이야",
+						"nickname": "ab!",
 						"mascotName": "wigul",
 						"timezone": "Asia/Seoul",
 						"monthlyBudgetAmount": 300000,

--- a/src/test/java/com/sagongsa/backend/onboarding/OnboardingServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/onboarding/OnboardingServiceTest.java
@@ -219,7 +219,7 @@ class OnboardingServiceTest extends PostgreSqlContainerTest {
 	}
 
 	private OnboardingCompleteRequest request(String mascotName, String timezone, Integer monthlyBudgetAmount, String regretFrequencyChoice) {
-		return new OnboardingCompleteRequest(mascotName, timezone, monthlyBudgetAmount, regretFrequencyChoice);
+		return new OnboardingCompleteRequest(null, mascotName, timezone, monthlyBudgetAmount, regretFrequencyChoice);
 	}
 
 	private String queryString(String sql, UUID userId) {


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-60`
- GitHub: Related #123
- GitHub: Closes #123

> PR 제목: `NF-60 온보딩 완료 시 사용자 입력 닉네임 저장`
> 브랜치: `feat/NF-60-onboarding-nickname`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치
- 전체 이슈 #123의 1/1 단계 (Single PR)

### 이 PR에서 변경한 것
- `OnboardingCompleteRequest`에 `nickname` 선택 필드 추가
- `OnboardingService.normalize()`에서 닉네임 유효성 검사 (최대 20자) 및 빈값 처리
- `OnboardingService.insertUserProfile()`에서 요청 닉네임 우선 사용, 없으면 자동 닉네임("너굴N") fallback
- `OnboardingCompleteIntegrationTest`에 닉네임 저장 케이스 2개 추가

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers
- AC1: 온보딩 요청에 `nickname`을 포함하면 `user_profiles.nickname`에 해당 값이 저장된다
- AC2: `nickname`을 생략하면 자동 닉네임("너굴N")이 저장된다
- AC3: 마이페이지 조회 시 온보딩에서 설정한 닉네임이 반환된다 (마이페이지는 `user_profiles.nickname`을 그대로 읽으므로 별도 수정 없음)

---

## 🧪 테스트 결과 (필수)
### 추가된 테스트
- `completeWithNicknameSavesProvidedNickname` — nickname 포함 요청 시 해당 값 저장 확인
- `completeWithoutNicknameFallsBackToAutoNickname` — nickname 생략 시 자동 닉네임 저장 확인

---

## 🧭 영향 범위 체크 (필수)
- [x] API 변경 (`OnboardingCompleteRequest`에 선택 필드 `nickname` 추가 — 기존 클라이언트 하위 호환)
- [ ] DB 변경 없음

---

## 💬 리뷰 포인트 (필수)
- 닉네임 최대 길이를 20자로 설정했습니다. 기획 확정값과 다르다면 수정 부탁드립니다
- nickname이 공백 문자열(`"   "`)로 오면 null 처리해 자동 닉네임으로 fallback합니다