### PR TITLE
[feat] NF-61 위시 상품 수정 API 추가

### DIFF
--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistController.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistController.java
@@ -88,7 +88,7 @@ public class WishlistController {
 	@PatchMapping("/{itemId}")
 	@Operation(
 		summary = "Update wishlist item",
-		description = "Updates editable wishlist item fields. Direct input items can update URL, title, price, and category; shared-link items can update title, price, and category.",
+		description = "Replaces the editable wishlist item fields. title and category are required. listedPrice is optional and null clears the saved price. Direct input items can update URL fields, and blank or null URL fields clear the saved URL. Shared-link item URLs cannot be changed.",
 		responses = {
 			@ApiResponse(responseCode = "200", description = "Wishlist item updated"),
 			@ApiResponse(responseCode = "400", description = "Invalid wishlist update payload"),

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistController.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/wishlist/items")
-@Tag(name = "Wishlist", description = "Saved wishlist item create, list, detail, category update, and delete APIs")
+@Tag(name = "Wishlist", description = "Saved wishlist item create, list, detail, update, category update, and delete APIs")
 public class WishlistController {
 
 	private final WishlistService wishlistService;
@@ -83,6 +83,27 @@ public class WishlistController {
 		@PathVariable UUID itemId
 	) {
 		return wishlistService.get(userId, itemId);
+	}
+
+	@PatchMapping("/{itemId}")
+	@Operation(
+		summary = "Update wishlist item",
+		description = "Updates editable wishlist item fields. Direct input items can update URL, title, price, and category; shared-link items can update title, price, and category.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "Wishlist item updated"),
+			@ApiResponse(responseCode = "400", description = "Invalid wishlist update payload"),
+			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication"),
+			@ApiResponse(responseCode = "403", description = "Item belongs to another user"),
+			@ApiResponse(responseCode = "404", description = "Wishlist item does not exist"),
+			@ApiResponse(responseCode = "409", description = "Same normalized URL is already saved")
+		}
+	)
+	public WishlistItemResponse update(
+		@Parameter(hidden = true) @CurrentUserId UUID userId,
+		@PathVariable UUID itemId,
+		@RequestBody WishlistItemUpdateRequest request
+	) {
+		return wishlistService.update(userId, itemId, request);
 	}
 
 	@PatchMapping("/{itemId}/category")

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistItemUpdateRequest.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistItemUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.sagongsa.backend.wishlist;
+
+public record WishlistItemUpdateRequest(
+	String originalUrl,
+	String normalizedUrl,
+	String title,
+	Integer listedPrice,
+	String category
+) {
+}

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistItemUpdateRequest.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistItemUpdateRequest.java
@@ -1,10 +1,21 @@
 package com.sagongsa.backend.wishlist;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record WishlistItemUpdateRequest(
+	@Schema(description = "Original item URL. Optional. For DIRECT_INPUT items, blank or null clears the saved URL. For SHARE items, omit this field because URL changes are rejected.")
 	String originalUrl,
+	@Schema(description = "Canonical item URL. Optional. If omitted, originalUrl is normalized. For DIRECT_INPUT items, blank or null clears the saved normalized URL. For SHARE items, omit this field because URL changes are rejected.")
 	String normalizedUrl,
+	@Schema(description = "Item title. Required; null or blank returns 400.", requiredMode = Schema.RequiredMode.REQUIRED, maxLength = 255)
 	String title,
+	@Schema(description = "Listed price. Optional; null clears the saved price.", minimum = "0")
 	Integer listedPrice,
+	@Schema(
+		description = "Wishlist category. Required; null, blank, or unsupported values return 400.",
+		requiredMode = Schema.RequiredMode.REQUIRED,
+		allowableValues = {"FASHION", "BEAUTY", "DIGITAL", "LIVING", "FOOD", "HOBBY", "SUBSCRIPTION", "ETC"}
+	)
 	String category
 ) {
 }

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
@@ -217,6 +217,78 @@ public class WishlistService {
 	}
 
 	@Transactional
+	public WishlistItemResponse update(UUID userId, UUID itemId, WishlistItemUpdateRequest request) {
+		ensureWishlistUserAllowed(userId);
+		if (request == null) {
+			throw new BadRequestException("Request body is required.");
+		}
+
+		WishlistItemResponse current = findSavedByUserAndId(userId, itemId);
+		ItemInputSource inputSource = parseRequiredEnum(current.inputSource(), ItemInputSource.class, "inputSource");
+		ItemCategory category = parseRequiredEnum(request.category(), ItemCategory.class, "category");
+		String title = cleanRequired(request.title(), "title", 255);
+		Integer listedPrice = validateListedPrice(request.listedPrice());
+		String originalUrl = cleanOptional(request.originalUrl(), "originalUrl");
+		String normalizedUrl = cleanOptional(request.normalizedUrl(), "normalizedUrl");
+
+		if (inputSource == ItemInputSource.SHARE) {
+			if (StringUtils.hasText(originalUrl) || StringUtils.hasText(normalizedUrl)) {
+				throw new BadRequestException("SHARE wishlist item URL cannot be updated.");
+			}
+			originalUrl = current.originalUrl();
+			normalizedUrl = current.normalizedUrl();
+		} else {
+			normalizedUrl = normalizeSavedUrl(inputSource, originalUrl, normalizedUrl);
+			findExistingSavedNormalizedUrl(userId, normalizedUrl, itemId)
+				.ifPresent(existingItem -> {
+					throw new DuplicateSavedItemException(
+						"Saved wishlist item already exists for the normalized URL.",
+						existingItem
+					);
+				});
+		}
+
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		try {
+			int updated = jdbcTemplate.update(
+				"""
+				update saved_items
+				set original_url = ?,
+					normalized_url = ?,
+					title = ?,
+					listed_price = ?,
+					category = ?,
+					category_locked_by_user = true,
+					updated_at = ?
+				where user_id = ?
+				  and id = ?
+				  and status = 'SAVED'
+				""",
+				originalUrl,
+				normalizedUrl,
+				title,
+				listedPrice,
+				category.name(),
+				now,
+				userId,
+				itemId
+			);
+
+			if (updated == 0) {
+				throw new WishlistItemNotFoundException("Saved wishlist item was not found.");
+			}
+		}
+		catch (DuplicateKeyException exception) {
+			throw new DuplicateSavedItemException(
+				"Saved wishlist item already exists for the normalized URL.",
+				findExistingSavedNormalizedUrl(userId, normalizedUrl, itemId).orElse(null)
+			);
+		}
+
+		return findByUserAndId(userId, itemId);
+	}
+
+	@Transactional
 	public void drop(UUID userId, UUID itemId) {
 		ensureWishlistUserAllowed(userId);
 		int updated = jdbcTemplate.update(
@@ -304,16 +376,31 @@ public class WishlistService {
 	}
 
 	private Optional<WishlistItemResponse> findExistingSavedNormalizedUrl(UUID userId, String normalizedUrl) {
-		List<WishlistItemResponse> items = jdbcTemplate.query(
-			baseSelect() + """
+		return findExistingSavedNormalizedUrl(userId, normalizedUrl, null);
+	}
+
+	private Optional<WishlistItemResponse> findExistingSavedNormalizedUrl(UUID userId, String normalizedUrl, UUID excludedItemId) {
+		if (!StringUtils.hasText(normalizedUrl)) {
+			return Optional.empty();
+		}
+		List<Object> parameters = new ArrayList<>();
+		parameters.add(userId);
+		parameters.add(normalizedUrl);
+		StringBuilder query = new StringBuilder(baseSelect());
+		query.append("""
 			where si.user_id = ?
 			  and si.normalized_url = ?
 			  and si.status = 'SAVED'
-			limit 1
-			""",
+			""");
+		if (excludedItemId != null) {
+			query.append("  and si.id <> ?\n");
+			parameters.add(excludedItemId);
+		}
+		query.append("limit 1\n");
+		List<WishlistItemResponse> items = jdbcTemplate.query(
+			query.toString(),
 			this::mapRow,
-			userId,
-			normalizedUrl
+			parameters.toArray()
 		);
 		return items.stream().findFirst();
 	}

--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistApiIntegrationTest.java
@@ -129,6 +129,22 @@ class WishlistApiIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void serializesDuplicateSavedItemResponseWhenExistingItemIsNull() throws Exception {
+		DuplicateSavedItemResponse response = new DuplicateSavedItemResponse(
+			"DUPLICATE_SAVED_ITEM",
+			"Saved wishlist item already exists for the normalized URL.",
+			null
+		);
+
+		JsonNode body = objectMapper.readTree(objectMapper.writeValueAsString(response));
+
+		assertThat(body.get("code").asText()).isEqualTo("DUPLICATE_SAVED_ITEM");
+		assertThat(body.get("message").asText()).isEqualTo("Saved wishlist item already exists for the normalized URL.");
+		assertThat(body.has("existingItem")).isTrue();
+		assertThat(body.get("existingItem").isNull()).isTrue();
+	}
+
+	@Test
 	void createsItemByNormalizingOriginalUrlWhenNormalizedUrlIsMissing() throws Exception {
 		UUID userId = createUser();
 

--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistApiIntegrationTest.java
@@ -381,6 +381,104 @@ class WishlistApiIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void updatesDirectInputItemFieldsIncludingUrl() throws Exception {
+		UUID userId = createUser();
+		UUID itemId = insertItem(userId, "Manual update target", "ETC", "SAVED", OffsetDateTime.now(ZoneOffset.UTC));
+
+		mockMvc.perform(patch(WISHLIST_ITEMS_PATH + "/{itemId}", itemId)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"originalUrl": "https://shop.example.com/product?id=100&utm_source=social",
+					"title": "Updated manual item",
+					"listedPrice": 99000,
+					"category": "DIGITAL"
+				}
+				"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.inputSource").value("DIRECT_INPUT"))
+			.andExpect(jsonPath("$.originalUrl").value("https://shop.example.com/product?id=100&utm_source=social"))
+			.andExpect(jsonPath("$.normalizedUrl").value("https://shop.example.com/product?id=100"))
+			.andExpect(jsonPath("$.title").value("Updated manual item"))
+			.andExpect(jsonPath("$.listedPrice").value(99000))
+			.andExpect(jsonPath("$.category").value("DIGITAL"))
+			.andExpect(jsonPath("$.categoryLockedByUser").value(true));
+	}
+
+	@Test
+	void updatesShareItemFieldsWithoutChangingUrl() throws Exception {
+		UUID userId = createUser();
+		UUID itemId = insertShareItem(
+			userId,
+			"Share update target",
+			"https://shop.example.com/product?id=100",
+			"DIGITAL",
+			"SAVED",
+			OffsetDateTime.now(ZoneOffset.UTC)
+		);
+
+		mockMvc.perform(patch(WISHLIST_ITEMS_PATH + "/{itemId}", itemId)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"title": "Updated share item",
+					"listedPrice": 88000,
+					"category": "LIVING"
+				}
+				"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.inputSource").value("SHARE"))
+			.andExpect(jsonPath("$.originalUrl").value("https://shop.example.com/product?id=100"))
+			.andExpect(jsonPath("$.normalizedUrl").value("https://shop.example.com/product?id=100"))
+			.andExpect(jsonPath("$.title").value("Updated share item"))
+			.andExpect(jsonPath("$.listedPrice").value(88000))
+			.andExpect(jsonPath("$.category").value("LIVING"))
+			.andExpect(jsonPath("$.categoryLockedByUser").value(true));
+	}
+
+	@Test
+	void rejectsShareItemUrlUpdate() throws Exception {
+		UUID userId = createUser();
+		UUID itemId = insertShareItem(
+			userId,
+			"Share update target",
+			"https://shop.example.com/product?id=100",
+			"DIGITAL",
+			"SAVED",
+			OffsetDateTime.now(ZoneOffset.UTC)
+		);
+
+		mockMvc.perform(patch(WISHLIST_ITEMS_PATH + "/{itemId}", itemId)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"originalUrl": "https://shop.example.com/changed",
+					"title": "Updated share item",
+					"listedPrice": 88000,
+					"category": "LIVING"
+				}
+				"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("BAD_REQUEST"));
+	}
+
+	@Test
+	void rejectsNullBodyForItemUpdate() throws Exception {
+		UUID userId = createUser();
+		UUID itemId = insertItem(userId, "Manual update target", "ETC", "SAVED", OffsetDateTime.now(ZoneOffset.UTC));
+
+		mockMvc.perform(patch(WISHLIST_ITEMS_PATH + "/{itemId}", itemId)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("null"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("BAD_REQUEST"));
+	}
+
+	@Test
 	void rejectsNullBodyForCategoryUpdate() throws Exception {
 		UUID userId = createUser();
 		UUID itemId = insertItem(userId, "Category update target", "ETC", "SAVED", OffsetDateTime.now(ZoneOffset.UTC));
@@ -456,6 +554,29 @@ class WishlistApiIntegrationTest extends PostgreSqlContainerTest {
 			""",
 			itemId,
 			userId,
+			title,
+			category,
+			status,
+			createdAt,
+			createdAt
+		);
+		return itemId;
+	}
+
+	private UUID insertShareItem(UUID userId, String title, String url, String category, String status, OffsetDateTime createdAt) {
+		UUID itemId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into saved_items (
+				id, user_id, input_source, original_url, normalized_url, title, category,
+				category_locked_by_user, status, created_at, updated_at
+			)
+			values (?, ?, 'SHARE', ?, ?, ?, ?, false, ?, ?, ?)
+			""",
+			itemId,
+			userId,
+			url,
+			url,
 			title,
 			category,
 			status,

--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistServiceTest.java
@@ -310,6 +310,118 @@ class WishlistServiceTest extends PostgreSqlContainerTest {
 			.isInstanceOf(WishlistItemNotFoundException.class);
 	}
 
+	// ── TC7: 상품 정보 수정 ────────────────────────────────────────────────
+
+	@Test
+	void updatesDirectInputItemEditableFieldsIncludingUrl() {
+		UUID userId = createActiveUser();
+		WishlistItemResponse created = wishlistService.create(userId, new WishlistItemCreateRequest(
+			"DIRECT_INPUT", null, null, "직접 입력 상품", null,
+			29000, "KRW", "FASHION", null, false,
+			null, null, null, null, null
+		));
+
+		WishlistItemResponse updated = wishlistService.update(userId, created.id(), new WishlistItemUpdateRequest(
+			"https://shop.example.com/item?id=100&utm_source=kakao",
+			null,
+			"수정된 상품",
+			39000,
+			"DIGITAL"
+		));
+
+		assertThat(updated.inputSource()).isEqualTo("DIRECT_INPUT");
+		assertThat(updated.originalUrl()).isEqualTo("https://shop.example.com/item?id=100&utm_source=kakao");
+		assertThat(updated.normalizedUrl()).isEqualTo("https://shop.example.com/item?id=100");
+		assertThat(updated.title()).isEqualTo("수정된 상품");
+		assertThat(updated.listedPrice()).isEqualTo(39000);
+		assertThat(updated.category()).isEqualTo("DIGITAL");
+		assertThat(updated.categoryLockedByUser()).isTrue();
+	}
+
+	@Test
+	void clearsDirectInputItemUrlWhenUrlIsBlank() {
+		UUID userId = createActiveUser();
+		WishlistItemResponse created = wishlistService.create(userId, new WishlistItemCreateRequest(
+			"DIRECT_INPUT", "https://shop.example.com/item", null, "직접 입력 상품", null,
+			29000, "KRW", "FASHION", null, false,
+			null, null, null, null, null
+		));
+
+		WishlistItemResponse updated = wishlistService.update(userId, created.id(), new WishlistItemUpdateRequest(
+			"   ",
+			null,
+			"URL 없는 상품",
+			19000,
+			"FASHION"
+		));
+
+		assertThat(updated.originalUrl()).isNull();
+		assertThat(updated.normalizedUrl()).isNull();
+	}
+
+	@Test
+	void updatesShareItemEditableFieldsButKeepsUrl() {
+		UUID userId = createActiveUser();
+		WishlistItemResponse created = wishlistService.create(userId,
+			shareRequest("https://shop.example.com/product?id=1", "상품"));
+
+		WishlistItemResponse updated = wishlistService.update(userId, created.id(), new WishlistItemUpdateRequest(
+			null,
+			null,
+			"공유 상품 수정",
+			45000,
+			"LIVING"
+		));
+
+		assertThat(updated.inputSource()).isEqualTo("SHARE");
+		assertThat(updated.originalUrl()).isEqualTo("https://shop.example.com/product?id=1");
+		assertThat(updated.normalizedUrl()).isEqualTo("https://shop.example.com/product?id=1");
+		assertThat(updated.title()).isEqualTo("공유 상품 수정");
+		assertThat(updated.listedPrice()).isEqualTo(45000);
+		assertThat(updated.category()).isEqualTo("LIVING");
+		assertThat(updated.categoryLockedByUser()).isTrue();
+	}
+
+	@Test
+	void rejectsShareItemUrlUpdate() {
+		UUID userId = createActiveUser();
+		WishlistItemResponse created = wishlistService.create(userId,
+			shareRequest("https://shop.example.com/product?id=1", "상품"));
+
+		assertThatThrownBy(() -> wishlistService.update(userId, created.id(), new WishlistItemUpdateRequest(
+			"https://shop.example.com/changed",
+			null,
+			"공유 상품 수정",
+			45000,
+			"LIVING"
+		)))
+			.isInstanceOf(BadRequestException.class);
+	}
+
+	@Test
+	void rejectsDuplicateDirectInputUrlOnUpdate() {
+		UUID userId = createActiveUser();
+		wishlistService.create(userId, new WishlistItemCreateRequest(
+			"DIRECT_INPUT", "https://shop.example.com/duplicated", null, "기존 상품", null,
+			29000, "KRW", "FASHION", null, false,
+			null, null, null, null, null
+		));
+		WishlistItemResponse target = wishlistService.create(userId, new WishlistItemCreateRequest(
+			"DIRECT_INPUT", null, null, "수정 대상", null,
+			19000, "KRW", "FASHION", null, false,
+			null, null, null, null, null
+		));
+
+		assertThatThrownBy(() -> wishlistService.update(userId, target.id(), new WishlistItemUpdateRequest(
+			"https://shop.example.com/duplicated?utm_source=kakao",
+			null,
+			"수정 대상",
+			19000,
+			"FASHION"
+		)))
+			.isInstanceOf(DuplicateSavedItemException.class);
+	}
+
 	// ── 헬퍼 ───────────────────────────────────────────────────────────────
 
 	private UUID createActiveUser() {


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-61`
- Jira: https://parkjaehong.atlassian.net/browse/NF-61
- GitHub: Related #125
- GitHub: Closes #125

> PR 제목: `[feat] NF-61 위시 상품 수정 API 추가`
> 브랜치: `feat/NF-61-wishlist-item-update-api`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치
- 전체 이슈 #125의 1/1 단계 (Single PR)

### 이 PR에서 변경한 것
- `PATCH /api/v1/wishlist/items/{itemId}` 위시 상품 수정 API 추가
- `DIRECT_INPUT` 위시는 링크, 상품명, 가격, 카테고리 수정 허용
- `SHARE` 위시는 상품명, 가격, 카테고리 수정 허용 및 URL 수정 요청 400 처리
- 직접 등록 위시 URL 수정 시 기존 URL 정규화/중복 URL 정책 재사용
- 위시 수정 서비스/통합 테스트 추가

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers
- AC1: `DIRECT_INPUT` 위시는 링크, 상품명, 가격, 카테고리를 수정할 수 있다.
- AC2: `SHARE` 위시는 상품명, 가격, 카테고리를 수정할 수 있다.
- AC3: `SHARE` 위시에 URL 수정 요청이 오면 400으로 거절한다.
- AC4: `DIRECT_INPUT` URL 수정 시 기존 정규화/중복 URL 정책이 유지된다.
- AC5: 관련 서비스/통합 테스트가 통과한다.

### Not covered
- 상품 이미지/브랜드/요약/source metadata 수정: 이번 FE 요청 범위가 아니어서 제외

---

## 🧪 테스트 결과 (필수)
### 로컬
```
./gradlew test --tests 'com.sagongsa.backend.wishlist.*'
./gradlew test
```
- ✅ 결과: 성공

### CI
- 자동 첨부

### Smoke 테스트
- 시나리오: `DIRECT_INPUT` 위시를 PATCH로 수정하면 URL 정규화, 상품명, 가격, 카테고리가 반영된다.
- 결과: ✅ `WishlistApiIntegrationTest.updatesDirectInputItemFieldsIncludingUrl`에서 확인
- 시나리오: `SHARE` 위시를 PATCH로 수정하면 기존 URL은 유지하고 상품명, 가격, 카테고리만 반영된다.
- 결과: ✅ `WishlistApiIntegrationTest.updatesShareItemFieldsWithoutChangingUrl`에서 확인
- 시나리오: `SHARE` 위시에 URL 변경 요청을 보내면 400이 반환된다.
- 결과: ✅ `WishlistApiIntegrationTest.rejectsShareItemUrlUpdate`에서 확인

---

## 🧭 영향 범위 체크 (필수)
- [x] API 변경 (요약: `PATCH /api/v1/wishlist/items/{itemId}` 추가)
- [ ] DB 변경 (마이그레이션: 없음)
- [ ] 설정 변경 (항목: 없음)
- [ ] Breaking change (무엇: 없음. 기존 API는 유지)

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인: `WishlistService.update()`의 `DIRECT_INPUT`/`SHARE` 분기와 중복 URL 검사
- 트레이드오프/대안: 기존 카테고리 단독 수정 API는 유지하고, FE 수정 화면용 전체 수정 API를 별도 추가했습니다.
