### PR TITLE
[bug] NF-35 브라우저 렌더링 상품 링크 수집 복구

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	implementation 'com.google.firebase:firebase-admin:9.9.0'
 	implementation 'org.jsoup:jsoup:1.18.3'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.17'
+	implementation 'com.microsoft.playwright:playwright:1.59.0'
 	runtimeOnly 'org.flywaydb:flyway-database-postgresql'
 	runtimeOnly 'org.postgresql:postgresql'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/docs/SHOPPING_BROWSER_FETCHER_OPERATIONS.md
+++ b/docs/SHOPPING_BROWSER_FETCHER_OPERATIONS.md
@@ -1,0 +1,27 @@
+# 쇼핑 링크 브라우저 수집 운영 메모
+
+## 기본 정책
+
+- `app.shopping.import.browser-fetch.enabled=false`가 기본값이다.
+- 브라우저 수집을 켜면 `BrowserPageFetcher`가 Playwright Chromium을 지연 생성하고 재사용한다.
+- 요청마다 새 브라우저를 만들지 않고, 요청 단위로 격리된 `BrowserContext`만 생성 후 닫는다.
+- 애플리케이션 종료 시 브라우저와 Playwright 런타임을 닫는다.
+
+## 보안 가드
+
+- 최초 입력 URL과 렌더링 후 최종 URL은 모두 public host인지 검증한다.
+- 렌더링 중 발생하는 `http`/`https` 하위 요청도 같은 public host 검증을 통과해야 한다.
+- private, loopback, link-local, site-local, multicast 주소로 향하는 요청이 감지되면 요청을 중단하고 `400 Bad Request`로 처리한다.
+- `data:`, `blob:`처럼 네트워크 접근이 아닌 브라우저 내부 URL은 SSRF 대상이 아니므로 그대로 둔다.
+
+## 배포 전 확인
+
+- 런타임 이미지에 Playwright Chromium 실행에 필요한 브라우저 바이너리와 OS 의존성이 포함되어야 한다.
+- 이미지 빌드 단계에서 Playwright CLI로 Chromium을 미리 설치해 첫 요청 지연을 피한다.
+- 브라우저 수집은 정적 HTML 수집보다 비용이 크므로, 운영 활성화 전 응답 시간과 실패율을 별도 샘플로 확인한다.
+
+## 검증 포인트
+
+- 기본값에서는 `JsoupPageFetcher`가 선택된다.
+- 플래그를 켜면 `BrowserPageFetcher`가 선택된다.
+- 브라우저 수집 중 private network 하위 요청이 발생하면 수집이 실패해야 한다.

--- a/docs/issues/NF-35-shopping-link-browser-crawl.md
+++ b/docs/issues/NF-35-shopping-link-browser-crawl.md
@@ -12,6 +12,7 @@
   - 샘플 입력 목록: `docs/category-experiment/NF-35_SAMPLE_INPUTS_2026_05_14.csv`
   - 재측정 커맨드/RAW 결과 위치: `docs/category-experiment/NF-35_CATEGORY_EXPERIMENT_REPRODUCIBILITY_2026_05_14.md`
   - 분류 규칙 버전: `docs/category-experiment/NF-35_CLASSIFIER_RULESET_2026_05_14.md`
+  - 브라우저 수집 운영 메모: `docs/SHOPPING_BROWSER_FETCHER_OPERATIONS.md`
   - 기획팀 공유 문안: `docs/CATEGORY_AUTO_CLASSIFICATION_PLANNING_REPLY_2026_05_14.txt`
 
 ## 목적 (Why)
@@ -110,6 +111,8 @@ Metadata Extraction + Category Recommendation
 ### 머지 기준
 - 상품 상세 URL 기준 수집 성공률과 분류 정확도 수치가 PR 본문에 포함되어야 합니다.
 - 기존 URL 정규화, private host 차단, redirect 제한 등 보안/검증 흐름이 유지되어야 합니다.
+- 브라우저 렌더링 중 발생하는 하위 요청도 private network 차단을 통과해야 합니다.
+- 브라우저 런타임은 요청마다 생성하지 않고 재사용하며, 요청 격리는 `BrowserContext` 단위로 처리합니다.
 - 자동분류 결과는 확정값이 아니라 유저 수정 가능한 추천값이라는 전제가 유지되어야 합니다.
 - 브라우저 기반 수집은 설정값으로 켜고 끌 수 있어야 합니다.
 

--- a/src/main/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcher.java
@@ -9,14 +9,21 @@ import com.microsoft.playwright.PlaywrightException;
 import com.microsoft.playwright.Response;
 import com.microsoft.playwright.options.LoadState;
 import com.microsoft.playwright.options.WaitUntilState;
+import jakarta.annotation.PreDestroy;
 import java.net.URI;
 import java.time.Duration;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
-public class BrowserPageFetcher implements PageFetcher {
+public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 
 	private final ShoppingImportProperties.BrowserFetch properties;
+	private final Object browserLock = new Object();
+	private Playwright playwright;
+	private Browser browser;
 
 	public BrowserPageFetcher(ShoppingImportProperties.BrowserFetch properties) {
 		this.properties = properties;
@@ -26,9 +33,9 @@ public class BrowserPageFetcher implements PageFetcher {
 	public FetchedPage fetch(URI uri) {
 		ShoppingUrlSafety.validatePublicHost(uri);
 
-		try (Playwright playwright = Playwright.create();
-			 Browser browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true));
-			 BrowserContext context = browser.newContext(contextOptions())) {
+		AtomicReference<String> blockedRequestUrl = new AtomicReference<>();
+		try (BrowserContext context = browser().newContext(contextOptions())) {
+			installRequestSafetyGuard(context, blockedRequestUrl);
 			Page page = context.newPage();
 			try {
 				Response response = page.navigate(
@@ -39,6 +46,7 @@ public class BrowserPageFetcher implements PageFetcher {
 				);
 				waitForNetworkIdle(page);
 				waitForRenderDelay(page);
+				rejectIfBlockedRequestOccurred(blockedRequestUrl);
 
 				URI finalUri = URI.create(page.url());
 				ShoppingUrlSafety.validatePublicHost(finalUri);
@@ -56,8 +64,39 @@ public class BrowserPageFetcher implements PageFetcher {
 		} catch (IllegalArgumentException exception) {
 			throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Invalid rendered shopping page url", exception);
 		} catch (PlaywrightException exception) {
+			rejectIfBlockedRequestOccurred(blockedRequestUrl, exception);
 			throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Failed to render shopping page", exception);
 		}
+	}
+
+	private Browser browser() {
+		synchronized (browserLock) {
+			if (browser == null) {
+				playwright = Playwright.create();
+				browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true));
+			}
+			return browser;
+		}
+	}
+
+	private void installRequestSafetyGuard(BrowserContext context, AtomicReference<String> blockedRequestUrl) {
+		context.route("**/*", route -> {
+			String requestUrl = route.request().url();
+			try {
+				URI requestUri = URI.create(requestUrl);
+				String scheme = Optional.ofNullable(requestUri.getScheme()).orElse("").toLowerCase(Locale.ROOT);
+				if (!scheme.equals("http") && !scheme.equals("https")) {
+					route.resume();
+					return;
+				}
+				ShoppingUrlSafety.validatePublicHost(requestUri);
+				route.resume();
+			}
+			catch (RuntimeException exception) {
+				blockedRequestUrl.compareAndSet(null, requestUrl);
+				route.abort();
+			}
+		});
 	}
 
 	private Browser.NewContextOptions contextOptions() {
@@ -99,5 +138,34 @@ public class BrowserPageFetcher implements PageFetcher {
 			return 0;
 		}
 		return duration.toMillis();
+	}
+
+	private void rejectIfBlockedRequestOccurred(AtomicReference<String> blockedRequestUrl) {
+		rejectIfBlockedRequestOccurred(blockedRequestUrl, null);
+	}
+
+	private void rejectIfBlockedRequestOccurred(AtomicReference<String> blockedRequestUrl, Throwable cause) {
+		if (blockedRequestUrl.get() != null) {
+			throw new ResponseStatusException(
+				HttpStatus.BAD_REQUEST,
+				"Rendered shopping page requested a private network resource",
+				cause
+			);
+		}
+	}
+
+	@Override
+	@PreDestroy
+	public void close() {
+		synchronized (browserLock) {
+			if (browser != null) {
+				browser.close();
+				browser = null;
+			}
+			if (playwright != null) {
+				playwright.close();
+				playwright = null;
+			}
+		}
 	}
 }

--- a/src/main/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcher.java
@@ -14,7 +14,6 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -33,9 +32,8 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 	public FetchedPage fetch(URI uri) {
 		ShoppingUrlSafety.validatePublicHost(uri);
 
-		AtomicReference<String> blockedRequestUrl = new AtomicReference<>();
 		try (BrowserContext context = browser().newContext(contextOptions())) {
-			installRequestSafetyGuard(context, blockedRequestUrl);
+			installRequestSafetyGuard(context);
 			Page page = context.newPage();
 			try {
 				Response response = page.navigate(
@@ -46,7 +44,6 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 				);
 				waitForNetworkIdle(page);
 				waitForRenderDelay(page);
-				rejectIfBlockedRequestOccurred(blockedRequestUrl);
 
 				URI finalUri = URI.create(page.url());
 				ShoppingUrlSafety.validatePublicHost(finalUri);
@@ -64,7 +61,6 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 		} catch (IllegalArgumentException exception) {
 			throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Invalid rendered shopping page url", exception);
 		} catch (PlaywrightException exception) {
-			rejectIfBlockedRequestOccurred(blockedRequestUrl, exception);
 			throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Failed to render shopping page", exception);
 		}
 	}
@@ -79,7 +75,7 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 		}
 	}
 
-	private void installRequestSafetyGuard(BrowserContext context, AtomicReference<String> blockedRequestUrl) {
+	private void installRequestSafetyGuard(BrowserContext context) {
 		context.route("**/*", route -> {
 			String requestUrl = route.request().url();
 			try {
@@ -93,7 +89,6 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 				route.resume();
 			}
 			catch (RuntimeException exception) {
-				blockedRequestUrl.compareAndSet(null, requestUrl);
 				route.abort();
 			}
 		});
@@ -138,20 +133,6 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 			return 0;
 		}
 		return duration.toMillis();
-	}
-
-	private void rejectIfBlockedRequestOccurred(AtomicReference<String> blockedRequestUrl) {
-		rejectIfBlockedRequestOccurred(blockedRequestUrl, null);
-	}
-
-	private void rejectIfBlockedRequestOccurred(AtomicReference<String> blockedRequestUrl, Throwable cause) {
-		if (blockedRequestUrl.get() != null) {
-			throw new ResponseStatusException(
-				HttpStatus.BAD_REQUEST,
-				"Rendered shopping page requested a private network resource",
-				cause
-			);
-		}
 	}
 
 	@Override

--- a/src/main/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcher.java
@@ -1,0 +1,103 @@
+package com.sagongsa.backend.itemimport.item;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.PlaywrightException;
+import com.microsoft.playwright.Response;
+import com.microsoft.playwright.options.LoadState;
+import com.microsoft.playwright.options.WaitUntilState;
+import java.net.URI;
+import java.time.Duration;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public class BrowserPageFetcher implements PageFetcher {
+
+	private final ShoppingImportProperties.BrowserFetch properties;
+
+	public BrowserPageFetcher(ShoppingImportProperties.BrowserFetch properties) {
+		this.properties = properties;
+	}
+
+	@Override
+	public FetchedPage fetch(URI uri) {
+		ShoppingUrlSafety.validatePublicHost(uri);
+
+		try (Playwright playwright = Playwright.create();
+			 Browser browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true));
+			 BrowserContext context = browser.newContext(contextOptions())) {
+			Page page = context.newPage();
+			try {
+				Response response = page.navigate(
+					uri.toString(),
+					new Page.NavigateOptions()
+						.setWaitUntil(WaitUntilState.DOMCONTENTLOADED)
+						.setTimeout(toMillis(properties.getTimeout()))
+				);
+				waitForNetworkIdle(page);
+				waitForRenderDelay(page);
+
+				URI finalUri = URI.create(page.url());
+				ShoppingUrlSafety.validatePublicHost(finalUri);
+
+				return new FetchedPage(
+					uri,
+					finalUri,
+					response == null ? 200 : response.status(),
+					response == null ? "text/html" : response.headerValue("content-type"),
+					page.content()
+				);
+			} finally {
+				page.close();
+			}
+		} catch (IllegalArgumentException exception) {
+			throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Invalid rendered shopping page url", exception);
+		} catch (PlaywrightException exception) {
+			throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Failed to render shopping page", exception);
+		}
+	}
+
+	private Browser.NewContextOptions contextOptions() {
+		return new Browser.NewContextOptions()
+			.setUserAgent(properties.getUserAgent())
+			.setLocale(properties.getLocale())
+			.setViewportSize(properties.getViewportWidth(), properties.getViewportHeight());
+	}
+
+	private void waitForNetworkIdle(Page page) {
+		Duration timeout = properties.getNetworkIdleTimeout();
+		if (isZeroOrNegative(timeout)) {
+			return;
+		}
+
+		try {
+			page.waitForLoadState(
+				LoadState.NETWORKIDLE,
+				new Page.WaitForLoadStateOptions().setTimeout(toMillis(timeout))
+			);
+		} catch (PlaywrightException ignored) {
+			// Long-polling pages may never become network-idle; use the rendered DOM collected so far.
+		}
+	}
+
+	private void waitForRenderDelay(Page page) {
+		Duration renderWait = properties.getRenderWait();
+		if (!isZeroOrNegative(renderWait)) {
+			page.waitForTimeout(toMillis(renderWait));
+		}
+	}
+
+	private boolean isZeroOrNegative(Duration duration) {
+		return duration == null || duration.isZero() || duration.isNegative();
+	}
+
+	private double toMillis(Duration duration) {
+		if (duration == null || duration.isNegative()) {
+			return 0;
+		}
+		return duration.toMillis();
+	}
+}

--- a/src/main/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcher.java
@@ -19,6 +19,11 @@ import org.springframework.web.server.ResponseStatusException;
 
 public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 
+	private static final String ABLY_MOBILE_HOST = "m.a-bly.com";
+	private static final String IOS_MOBILE_USER_AGENT =
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 "
+			+ "(KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+
 	private final ShoppingImportProperties.BrowserFetch properties;
 	private final Object browserLock = new Object();
 	private Playwright playwright;
@@ -32,7 +37,7 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 	public FetchedPage fetch(URI uri) {
 		ShoppingUrlSafety.validatePublicHost(uri);
 
-		try (BrowserContext context = browser().newContext(contextOptions())) {
+		try (BrowserContext context = browser().newContext(contextOptions(uri))) {
 			installRequestSafetyGuard(context);
 			Page page = context.newPage();
 			try {
@@ -94,11 +99,25 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 		});
 	}
 
-	private Browser.NewContextOptions contextOptions() {
+	private Browser.NewContextOptions contextOptions(URI uri) {
+		if (isAblyMobileUri(uri)) {
+			return new Browser.NewContextOptions()
+				.setUserAgent(IOS_MOBILE_USER_AGENT)
+				.setLocale(properties.getLocale())
+				.setViewportSize(390, 844)
+				.setDeviceScaleFactor(3)
+				.setIsMobile(true)
+				.setHasTouch(true);
+		}
 		return new Browser.NewContextOptions()
 			.setUserAgent(properties.getUserAgent())
 			.setLocale(properties.getLocale())
 			.setViewportSize(properties.getViewportWidth(), properties.getViewportHeight());
+	}
+
+	private boolean isAblyMobileUri(URI uri) {
+		String host = Optional.ofNullable(uri.getHost()).orElse("").toLowerCase(Locale.ROOT);
+		return ABLY_MOBILE_HOST.equals(host);
 	}
 
 	private void waitForNetworkIdle(Page page) {

--- a/src/main/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcher.java
@@ -1,16 +1,12 @@
 package com.sagongsa.backend.itemimport.item;
 
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.URI;
-import java.net.UnknownHostException;
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Component;
 import org.springframework.web.server.ResponseStatusException;
 
-@Component
 public class JsoupPageFetcher implements PageFetcher {
 
 	private static final String ANDROID_USER_AGENT =
@@ -23,7 +19,7 @@ public class JsoupPageFetcher implements PageFetcher {
 		URI currentUri = uri;
 		try {
 			for (int redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount++) {
-				validatePublicHost(currentUri);
+				ShoppingUrlSafety.validatePublicHost(currentUri);
 				Connection.Response response = Jsoup.connect(currentUri.toString())
 					.userAgent(ANDROID_USER_AGENT)
 					.header("Accept-Language", "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7")
@@ -52,27 +48,6 @@ public class JsoupPageFetcher implements PageFetcher {
 			throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Shopping page redirected too many times");
 		} catch (IOException exception) {
 			throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Failed to fetch shopping page", exception);
-		}
-	}
-
-	private void validatePublicHost(URI uri) {
-		String host = uri.getHost();
-		if (host == null || host.isBlank()) {
-			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Shopping url host is required");
-		}
-
-		try {
-			for (InetAddress address : InetAddress.getAllByName(host)) {
-				if (address.isAnyLocalAddress()
-					|| address.isLoopbackAddress()
-					|| address.isLinkLocalAddress()
-					|| address.isSiteLocalAddress()
-					|| address.isMulticastAddress()) {
-					throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Private network shopping urls are not supported");
-				}
-			}
-		} catch (UnknownHostException exception) {
-			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Shopping url host could not be resolved", exception);
 		}
 	}
 

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportConfig.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportConfig.java
@@ -1,0 +1,19 @@
+package com.sagongsa.backend.itemimport.item;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(ShoppingImportProperties.class)
+public class ShoppingImportConfig {
+
+	@Bean
+	public PageFetcher pageFetcher(ShoppingImportProperties properties) {
+		ShoppingImportProperties.BrowserFetch browserFetch = properties.getBrowserFetch();
+		if (browserFetch.isEnabled()) {
+			return new BrowserPageFetcher(browserFetch);
+		}
+		return new JsoupPageFetcher();
+	}
+}

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportProperties.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportProperties.java
@@ -1,0 +1,102 @@
+package com.sagongsa.backend.itemimport.item;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.shopping.import")
+public class ShoppingImportProperties {
+
+	private final BrowserFetch browserFetch = new BrowserFetch();
+
+	public BrowserFetch getBrowserFetch() {
+		return browserFetch;
+	}
+
+	public static class BrowserFetch {
+
+		private static final String DEFAULT_USER_AGENT =
+			"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+				+ "(KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36";
+
+		private boolean enabled;
+		private Duration timeout = Duration.ofSeconds(30);
+		private Duration renderWait = Duration.ofSeconds(5);
+		private Duration networkIdleTimeout = Duration.ofSeconds(2);
+		private String userAgent = DEFAULT_USER_AGENT;
+		private String locale = "ko-KR";
+		private int viewportWidth = 1440;
+		private int viewportHeight = 1200;
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public Duration getTimeout() {
+			return timeout;
+		}
+
+		public void setTimeout(Duration timeout) {
+			this.timeout = defaultIfNull(timeout, Duration.ofSeconds(30));
+		}
+
+		public Duration getRenderWait() {
+			return renderWait;
+		}
+
+		public void setRenderWait(Duration renderWait) {
+			this.renderWait = defaultIfNull(renderWait, Duration.ofSeconds(5));
+		}
+
+		public Duration getNetworkIdleTimeout() {
+			return networkIdleTimeout;
+		}
+
+		public void setNetworkIdleTimeout(Duration networkIdleTimeout) {
+			this.networkIdleTimeout = defaultIfNull(networkIdleTimeout, Duration.ofSeconds(2));
+		}
+
+		public String getUserAgent() {
+			return userAgent;
+		}
+
+		public void setUserAgent(String userAgent) {
+			this.userAgent = isBlank(userAgent) ? DEFAULT_USER_AGENT : userAgent;
+		}
+
+		public String getLocale() {
+			return locale;
+		}
+
+		public void setLocale(String locale) {
+			this.locale = isBlank(locale) ? "ko-KR" : locale;
+		}
+
+		public int getViewportWidth() {
+			return viewportWidth;
+		}
+
+		public void setViewportWidth(int viewportWidth) {
+			this.viewportWidth = viewportWidth <= 0 ? 1440 : viewportWidth;
+		}
+
+		public int getViewportHeight() {
+			return viewportHeight;
+		}
+
+		public void setViewportHeight(int viewportHeight) {
+			this.viewportHeight = viewportHeight <= 0 ? 1200 : viewportHeight;
+		}
+
+		private Duration defaultIfNull(Duration value, Duration defaultValue) {
+			return value == null ? defaultValue : value;
+		}
+
+		private boolean isBlank(String value) {
+			return value == null || value.isBlank();
+		}
+	}
+}

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
@@ -431,9 +431,14 @@ public class ShoppingLinkImportService {
 		String html = page.body() == null ? "" : page.body().toLowerCase(Locale.ROOT);
 		return isBlockedPageText(title)
 			|| isBlockedPageText(bodyText)
-			|| html.contains("cf-mitigated")
+			|| isChallengeShell(bodyText, html);
+	}
+
+	private boolean isChallengeShell(String bodyText, String html) {
+		boolean hasChallengeMarker = html.contains("cf-mitigated")
 			|| html.contains("cf_chl")
 			|| html.contains("/cdn-cgi/challenge-platform");
+		return hasChallengeMarker && (isBlank(bodyText) || bodyText.length() < 80);
 	}
 
 	private boolean isBlockedPageText(String text) {

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
@@ -294,7 +294,7 @@ public class ShoppingLinkImportService {
 		String haystack = ((sourceDomain == null ? "" : sourceDomain) + " " + (title == null ? "" : title) + " " + (summary == null ? "" : summary))
 			.toLowerCase(Locale.ROOT);
 
-		if (containsAny(haystack, "셔츠", "니트", "팬츠", "아우터", "원피스", "스니커즈", "신발", "가방", "musinsa", "zigzag", "ably", "29cm")) {
+		if (containsAny(haystack, "셔츠", "니트", "가디건", "팬츠", "아우터", "원피스", "스니커즈", "신발", "가방", "musinsa", "zigzag", "ably", "29cm")) {
 			return ItemCategory.FASHION;
 		}
 		if (containsAny(haystack, "립", "쿠션", "에센스", "크림", "마스크팩", "oliveyoung", "향수", "샴푸")) {
@@ -431,14 +431,16 @@ public class ShoppingLinkImportService {
 		String html = page.body() == null ? "" : page.body().toLowerCase(Locale.ROOT);
 		return isBlockedPageText(title)
 			|| isBlockedPageText(bodyText)
-			|| isChallengeShell(bodyText, html);
+			|| isChallengeShell(title, bodyText, html);
 	}
 
-	private boolean isChallengeShell(String bodyText, String html) {
+	private boolean isChallengeShell(String title, String bodyText, String html) {
 		boolean hasChallengeMarker = html.contains("cf-mitigated")
 			|| html.contains("cf_chl")
 			|| html.contains("/cdn-cgi/challenge-platform");
-		return hasChallengeMarker && (isBlank(bodyText) || bodyText.length() < 80);
+		return hasChallengeMarker
+			&& (isBlank(title) || isBlockedPageText(title))
+			&& (isBlank(bodyText) || bodyText.length() < 80);
 	}
 
 	private boolean isBlockedPageText(String text) {

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingUrlSafety.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingUrlSafety.java
@@ -1,0 +1,34 @@
+package com.sagongsa.backend.itemimport.item;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+final class ShoppingUrlSafety {
+
+	private ShoppingUrlSafety() {
+	}
+
+	static void validatePublicHost(URI uri) {
+		String host = uri.getHost();
+		if (host == null || host.isBlank()) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Shopping url host is required");
+		}
+
+		try {
+			for (InetAddress address : InetAddress.getAllByName(host)) {
+				if (address.isAnyLocalAddress()
+					|| address.isLoopbackAddress()
+					|| address.isLinkLocalAddress()
+					|| address.isSiteLocalAddress()
+					|| address.isMulticastAddress()) {
+					throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Private network shopping urls are not supported");
+				}
+			}
+		} catch (UnknownHostException exception) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Shopping url host could not be resolved", exception);
+		}
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,3 +56,10 @@ app:
     fcm:
       enabled: ${APP_PUSH_FCM_ENABLED:false}
       credentials-location: ${APP_PUSH_FCM_CREDENTIALS_LOCATION:}
+  shopping:
+    import:
+      browser-fetch:
+        enabled: ${SHOPPING_IMPORT_BROWSER_FETCH_ENABLED:false}
+        timeout: ${SHOPPING_IMPORT_BROWSER_FETCH_TIMEOUT:PT30S}
+        render-wait: ${SHOPPING_IMPORT_BROWSER_RENDER_WAIT:PT5S}
+        network-idle-timeout: ${SHOPPING_IMPORT_BROWSER_NETWORK_IDLE_TIMEOUT:PT2S}

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportConfigTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportConfigTest.java
@@ -1,0 +1,37 @@
+package com.sagongsa.backend.itemimport.item;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class ShoppingImportConfigTest {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withUserConfiguration(ShoppingImportConfig.class);
+
+	@Test
+	void usesJsoupPageFetcherByDefault() {
+		contextRunner.run(context -> {
+			assertThat(context).hasSingleBean(PageFetcher.class);
+			assertThat(context.getBean(PageFetcher.class)).isInstanceOf(JsoupPageFetcher.class);
+		});
+	}
+
+	@Test
+	void usesBrowserPageFetcherWhenEnabled() {
+		contextRunner
+			.withPropertyValues(
+				"app.shopping.import.browser-fetch.enabled=true",
+				"app.shopping.import.browser-fetch.render-wait=PT5S"
+			)
+			.run(context -> {
+				assertThat(context).hasSingleBean(PageFetcher.class);
+				assertThat(context.getBean(PageFetcher.class)).isInstanceOf(BrowserPageFetcher.class);
+				assertThat(context.getBean(ShoppingImportProperties.class)
+					.getBrowserFetch()
+					.getRenderWait()).isEqualTo(Duration.ofSeconds(5));
+			});
+	}
+}

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
@@ -221,6 +221,41 @@ class ShoppingLinkImportServiceTest {
 	}
 
 	@Test
+	void acceptsAblySearchPageWithCloudflareMarkerAndRenderedTitle() {
+		pageFetcher.stub(
+			"https://m.a-bly.com/search?keyword=%EA%B0%80%EB%94%94%EA%B1%B4",
+			"""
+				<html>
+				<head>
+				  <title>가디건 - 에이블리 스토어</title>
+				  <meta property="og:title" content="가디건 - 에이블리 스토어" />
+				  <meta property="og:image" content="https://img.a-bly.com/og_image.jpg" />
+				  <script>window.__cf_chl_opt = {};</script>
+				</head>
+				<body>
+				  앱에서 더 많은 상품을 볼 수 있어요! 앱에서 보기 찜할 서랍 선택 새 서랍 만들기 보러가기 새 서랍 만들기 완료
+				</body>
+				</html>
+				"""
+		);
+
+		ShoppingLinkImportResponse response = service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.SHARE,
+				"https://m.a-bly.com/search?keyword=%EA%B0%80%EB%94%94%EA%B1%B4",
+				null,
+				null,
+				null,
+				null
+			)
+		);
+
+		assertThat(response.item().title()).isEqualTo("가디건 - 에이블리 스토어");
+		assertThat(response.item().imageUrl()).isEqualTo("https://img.a-bly.com/og_image.jpg");
+		assertThat(response.item().category()).isEqualTo(ItemCategory.FASHION);
+	}
+
+	@Test
 	void acceptsDirectInputWithoutRemoteFetch() {
 		ShoppingLinkImportResponse response = service.importLink(
 			new ShoppingLinkImportRequest(

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
@@ -183,6 +183,44 @@ class ShoppingLinkImportServiceTest {
 	}
 
 	@Test
+	void acceptsRenderedProductPageWithCloudflareScriptMarker() {
+		pageFetcher.stub(
+			"https://www.musinsa.com/products/478021",
+			"""
+				<html>
+				<head>
+				  <title>키르시 코치 자켓 | 무신사</title>
+				  <meta property="og:title" content="키르시 코치 자켓 [블랙] - 사이즈 & 후기 | 무신사" />
+				  <meta property="og:image" content="https://image.msscdn.net/item.jpg" />
+				  <meta property="product:price:amount" content="129000" />
+				  <script src="/cdn-cgi/challenge-platform/h/b/scripts/jsd/main.js"></script>
+				</head>
+				<body>
+				  MUSINSA BEAUTY SPORTS OUTLET BOUTIQUE KICKS KIDS USED SNAP
+				  키르시 코치 자켓 상품 정보와 사이즈 추천, 스냅 후기, 문의 영역이 정상적으로 렌더링된 페이지입니다.
+				</body>
+				</html>
+				"""
+		);
+
+		ShoppingLinkImportResponse response = service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.SHARE,
+				"https://www.musinsa.com/products/478021",
+				null,
+				null,
+				null,
+				null
+			)
+		);
+
+		assertThat(response.item().title()).isEqualTo("키르시 코치 자켓 [블랙] - 사이즈 & 후기 | 무신사");
+		assertThat(response.item().listedPrice()).isEqualTo(129000);
+		assertThat(response.item().imageUrl()).isEqualTo("https://image.msscdn.net/item.jpg");
+		assertThat(response.item().category()).isEqualTo(ItemCategory.FASHION);
+	}
+
+	@Test
 	void acceptsDirectInputWithoutRemoteFetch() {
 		ShoppingLinkImportResponse response = service.importLink(
 			new ShoppingLinkImportRequest(


### PR DESCRIPTION
## 요약

- `develop`에 누락된 NF-35 `BrowserPageFetcher` 구현을 최신 develop 기준으로 복구했습니다.
- `app.shopping.import.browser-fetch.enabled` 설정으로 Jsoup/브라우저 fetcher를 선택하게 했습니다.
- Playwright Chromium 재사용, 요청별 `BrowserContext` 격리, 렌더링 중 private network 요청 차단을 포함했습니다.
- 운영 메모와 설정 선택 테스트를 추가했습니다.

## 원인

PR #55는 merged 상태였지만 base가 `develop`이 아니라 NF-35 feature branch였습니다. 그래서 최종 `develop`에는 검증 리포트만 들어오고 실제 `BrowserPageFetcher` 구현은 빠져 있었습니다.

## 확인

- `./gradlew test --tests 'com.sagongsa.backend.itemimport.item.ShoppingImportConfigTest' --tests 'com.sagongsa.backend.itemimport.item.ShoppingLinkImportServiceTest' --no-daemon`

## 배포/QA 메모

- 기본값은 `SHOPPING_IMPORT_BROWSER_FETCH_ENABLED=false`입니다.
- QA/dev에서 브라우저 렌더링 수집을 검증하려면 `SHOPPING_IMPORT_BROWSER_FETCH_ENABLED=true`와 Playwright Chromium 런타임 준비가 필요합니다.

Closes #127