### PR TITLE
[bug] NF-62 test1 QA BE 입력 검증 및 탈퇴 재가입 정책 보완

### DIFF
--- a/src/main/java/com/sagongsa/backend/auth/SocialAccountLinkService.java
+++ b/src/main/java/com/sagongsa/backend/auth/SocialAccountLinkService.java
@@ -5,6 +5,7 @@ import com.sagongsa.backend.domain.auth.SocialAccountRepository;
 import com.sagongsa.backend.domain.auth.UserAccount;
 import com.sagongsa.backend.domain.auth.UserAccountRepository;
 import com.sagongsa.backend.domain.enums.SocialProvider;
+import com.sagongsa.backend.domain.enums.UserStatus;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,11 +29,18 @@ public class SocialAccountLinkService {
 		SocialProvider provider = resolveProvider(profile.provider());
 
 		return socialAccountRepository.findByProviderAndProviderUserId(provider, profile.providerUserId())
-			.map(existingAccount -> {
-				existingAccount.updateProfile(profile.email(), profile.profileImageUrl());
-				return profile.withUserId(existingAccount.getUser().getId());
-			})
+			.map(existingAccount -> linkExistingAccount(profile, existingAccount))
 			.orElseGet(() -> createNewAccount(profile, provider));
+	}
+
+	private SocialUserProfile linkExistingAccount(SocialUserProfile profile, SocialAccount existingAccount) {
+		existingAccount.updateProfile(profile.email(), profile.profileImageUrl());
+		UserAccount linkedUser = existingAccount.getUser();
+		if (linkedUser.getStatus() == UserStatus.WITHDRAWN) {
+			linkedUser = userAccountRepository.save(UserAccount.create());
+			existingAccount.relinkUser(linkedUser);
+		}
+		return profile.withUserId(linkedUser.getId());
 	}
 
 	private SocialUserProfile createNewAccount(SocialUserProfile profile, SocialProvider provider) {
@@ -49,10 +57,7 @@ public class SocialAccountLinkService {
 			return profile.withUserId(userAccount.getId());
 		} catch (DataIntegrityViolationException exception) {
 			return socialAccountRepository.findByProviderAndProviderUserId(provider, profile.providerUserId())
-				.map(existingAccount -> {
-					existingAccount.updateProfile(profile.email(), profile.profileImageUrl());
-					return profile.withUserId(existingAccount.getUser().getId());
-				})
+				.map(existingAccount -> linkExistingAccount(profile, existingAccount))
 				.orElseThrow(() -> exception);
 		}
 	}

--- a/src/main/java/com/sagongsa/backend/domain/auth/SocialAccount.java
+++ b/src/main/java/com/sagongsa/backend/domain/auth/SocialAccount.java
@@ -63,6 +63,10 @@ public class SocialAccount extends BaseEntity {
 		this.profileImageUrl = profileImageUrl;
 	}
 
+	public void relinkUser(UserAccount user) {
+		this.user = user;
+	}
+
 	public UserAccount getUser() {
 		return user;
 	}

--- a/src/main/java/com/sagongsa/backend/mypage/UpdateProfileRequest.java
+++ b/src/main/java/com/sagongsa/backend/mypage/UpdateProfileRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 record UpdateProfileRequest(
-	@Size(min = 1, max = 10, message = "닉네임은 1~10자여야 합니다.")
+	@Size(min = 2, max = 8, message = "닉네임은 2~8자여야 합니다.")
 	@Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "닉네임은 한글, 영문, 숫자만 허용됩니다.")
 	String nickname,
 

--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingService.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingService.java
@@ -204,7 +204,7 @@ public class OnboardingService {
 			throw new OnboardingBadRequestException("Request body is required.");
 		}
 
-		String nickname = request.nickname() != null && !request.nickname().isBlank()
+		String nickname = request.nickname() != null
 			? requireNicknameText(request.nickname())
 			: null;
 		String mascotName = requireText(request.mascotName(), "mascotName", 40);
@@ -236,11 +236,16 @@ public class OnboardingService {
 
 	private static final java.util.regex.Pattern NICKNAME_PATTERN =
 		java.util.regex.Pattern.compile("^[가-힣a-zA-Z0-9]+$");
+	private static final int NICKNAME_MIN_LENGTH = 2;
+	private static final int NICKNAME_MAX_LENGTH = 8;
 
 	private String requireNicknameText(String value) {
+		if (!value.equals(value.trim())) {
+			throw new OnboardingBadRequestException("nickname must not have leading or trailing whitespace.");
+		}
 		String trimmed = value.trim();
-		if (trimmed.length() < 1 || trimmed.length() > 10) {
-			throw new OnboardingBadRequestException("nickname must be between 1 and 10 characters.");
+		if (trimmed.length() < NICKNAME_MIN_LENGTH || trimmed.length() > NICKNAME_MAX_LENGTH) {
+			throw new OnboardingBadRequestException("nickname must be between 2 and 8 characters.");
 		}
 		if (!NICKNAME_PATTERN.matcher(trimmed).matches()) {
 			throw new OnboardingBadRequestException("닉네임은 한글, 영문, 숫자만 허용됩니다.");
@@ -272,8 +277,8 @@ public class OnboardingService {
 		if (monthlyBudgetAmount == null) {
 			throw new OnboardingBadRequestException("monthlyBudgetAmount is required.");
 		}
-		if (monthlyBudgetAmount < 0) {
-			throw new OnboardingBadRequestException("monthlyBudgetAmount must be zero or greater.");
+		if (monthlyBudgetAmount <= 0) {
+			throw new OnboardingBadRequestException("monthlyBudgetAmount must be greater than zero.");
 		}
 		return monthlyBudgetAmount;
 	}

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
@@ -549,8 +549,8 @@ public class WishlistService {
 	}
 
 	private Integer validateListedPrice(Integer listedPrice) {
-		if (listedPrice != null && listedPrice < 0) {
-			throw new BadRequestException("listedPrice must be zero or greater.");
+		if (listedPrice != null && listedPrice <= 0) {
+			throw new BadRequestException("listedPrice must be greater than zero.");
 		}
 		return listedPrice;
 	}

--- a/src/test/java/com/sagongsa/backend/auth/SocialAccountLinkServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/auth/SocialAccountLinkServiceTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.sagongsa.backend.domain.auth.SocialAccountRepository;
 import com.sagongsa.backend.domain.auth.UserAccountRepository;
 import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -81,5 +83,49 @@ class SocialAccountLinkServiceTest extends PostgreSqlContainerTest {
 		assertThat(socialAccountRepository.count()).isEqualTo(1);
 		assertThat(socialAccountRepository.findAll().getFirst().getEmail()).isEqualTo("kakao@test.dev");
 		assertThat(socialAccountRepository.findAll().getFirst().getProfileImageUrl()).isEqualTo("https://example.com/kakao-after.png");
+	}
+
+	@Test
+	void createsNewUserWhenExistingSocialAccountBelongsToWithdrawnUser() {
+		SocialUserProfile firstLogin = socialAccountLinkService.linkOrCreateUser(
+			new SocialUserProfile(
+				"google",
+				"withdrawn-google-123",
+				"Google Tester",
+				"before@test.dev",
+				"https://example.com/before.png",
+				java.util.Map.of(),
+				null
+			)
+		);
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"update users set status = 'WITHDRAWN', withdrawn_at = ?, updated_at = ? where id = ?",
+			now, now, firstLogin.userId()
+		);
+
+		SocialUserProfile secondLogin = socialAccountLinkService.linkOrCreateUser(
+			new SocialUserProfile(
+				"google",
+				"withdrawn-google-123",
+				"Google Tester",
+				"after@test.dev",
+				"https://example.com/after.png",
+				java.util.Map.of(),
+				null
+			)
+		);
+
+		assertThat(secondLogin.userId()).isNotEqualTo(firstLogin.userId());
+		assertThat(userAccountRepository.count()).isEqualTo(2);
+		assertThat(socialAccountRepository.count()).isEqualTo(1);
+		assertThat(socialAccountRepository.findAll().getFirst().getUser().getId()).isEqualTo(secondLogin.userId());
+		assertThat(socialAccountRepository.findAll().getFirst().getEmail()).isEqualTo("after@test.dev");
+		assertThat(queryString("select status from users where id = ?", secondLogin.userId())).isEqualTo("ACTIVE");
+		assertThat(queryString("select onboarding_status from users where id = ?", secondLogin.userId())).isEqualTo("NOT_STARTED");
+	}
+
+	private String queryString(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(sql, String.class, args);
 	}
 }

--- a/src/test/java/com/sagongsa/backend/mypage/MypageApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/mypage/MypageApiIntegrationTest.java
@@ -76,14 +76,40 @@ class MypageApiIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
-	void 닉네임_10자_초과_400() throws Exception {
+	void 닉네임_9자_400() throws Exception {
 		UUID userId = insertUser("너굴이", "너구리");
 
 		mockMvc.perform(patch(BASE + "/profile")
 				.header("X-User-Id", userId)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
-					{"nickname":"열한글자닉네임초과123"}
+					{"nickname":"123456789"}
+					"""))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void 닉네임_1자_400() throws Exception {
+		UUID userId = insertUser("너굴이", "너구리");
+
+		mockMvc.perform(patch(BASE + "/profile")
+				.header("X-User-Id", userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"nickname":"a"}
+					"""))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void 닉네임_공백_400() throws Exception {
+		UUID userId = insertUser("너굴이", "너구리");
+
+		mockMvc.perform(patch(BASE + "/profile")
+				.header("X-User-Id", userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"nickname":" 닉네임"}
 					"""))
 			.andExpect(status().isBadRequest());
 	}

--- a/src/test/java/com/sagongsa/backend/onboarding/OnboardingCompleteIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/onboarding/OnboardingCompleteIntegrationTest.java
@@ -193,6 +193,25 @@ class OnboardingCompleteIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void completeWithOneCharacterNicknameReturns400() throws Exception {
+		UUID userId = insertUser("NOT_STARTED");
+
+		mockMvc.perform(post("/api/v1/onboarding/complete")
+				.header("X-User-Id", userId.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+						"nickname": "a",
+						"mascotName": "wigul",
+						"timezone": "Asia/Seoul",
+						"monthlyBudgetAmount": 300000,
+						"regretFrequencyChoice": "FOUR_OR_MORE"
+					}
+					"""))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
 	void completeWithSpecialCharNicknameReturns400() throws Exception {
 		UUID userId = insertUser("NOT_STARTED");
 
@@ -202,6 +221,44 @@ class OnboardingCompleteIntegrationTest extends PostgreSqlContainerTest {
 				.content("""
 					{
 						"nickname": "ab!",
+						"mascotName": "wigul",
+						"timezone": "Asia/Seoul",
+						"monthlyBudgetAmount": 300000,
+						"regretFrequencyChoice": "FOUR_OR_MORE"
+					}
+					"""))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void completeWithOuterWhitespaceNicknameReturns400() throws Exception {
+		UUID userId = insertUser("NOT_STARTED");
+
+		mockMvc.perform(post("/api/v1/onboarding/complete")
+				.header("X-User-Id", userId.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+						"nickname": " nick",
+						"mascotName": "wigul",
+						"timezone": "Asia/Seoul",
+						"monthlyBudgetAmount": 300000,
+						"regretFrequencyChoice": "FOUR_OR_MORE"
+					}
+					"""))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void completeWithBlankNicknameReturns400() throws Exception {
+		UUID userId = insertUser("NOT_STARTED");
+
+		mockMvc.perform(post("/api/v1/onboarding/complete")
+				.header("X-User-Id", userId.toString())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+						"nickname": "   ",
 						"mascotName": "wigul",
 						"timezone": "Asia/Seoul",
 						"monthlyBudgetAmount": 300000,

--- a/src/test/java/com/sagongsa/backend/onboarding/OnboardingServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/onboarding/OnboardingServiceTest.java
@@ -94,9 +94,44 @@ class OnboardingServiceTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
-	void acceptsZeroMonthlyBudgetAmount() {
+	void rejectsZeroMonthlyBudgetAmount() {
 		UUID userId = insertUser("NOT_STARTED");
-		OnboardingCompleteResponse response = onboardingService.complete(userId, request("너굴", "Asia/Seoul", 0, "LESS_THAN_ONCE"));
+		assertThatThrownBy(() -> onboardingService.complete(userId, request("너굴", "Asia/Seoul", 0, "LESS_THAN_ONCE")))
+			.isInstanceOf(OnboardingBadRequestException.class);
+	}
+
+	@Test
+	void rejectsNicknameShorterThanTwoCharacters() {
+		UUID userId = insertUser("NOT_STARTED");
+		assertThatThrownBy(() -> onboardingService.complete(userId, request("a", "너굴", "Asia/Seoul", 100000, "LESS_THAN_ONCE")))
+			.isInstanceOf(OnboardingBadRequestException.class);
+	}
+
+	@Test
+	void rejectsNicknameLongerThanEightCharacters() {
+		UUID userId = insertUser("NOT_STARTED");
+		assertThatThrownBy(() -> onboardingService.complete(userId, request("123456789", "너굴", "Asia/Seoul", 100000, "LESS_THAN_ONCE")))
+			.isInstanceOf(OnboardingBadRequestException.class);
+	}
+
+	@Test
+	void rejectsNicknameWithOuterWhitespace() {
+		UUID userId = insertUser("NOT_STARTED");
+		assertThatThrownBy(() -> onboardingService.complete(userId, request(" 닉네임", "너굴", "Asia/Seoul", 100000, "LESS_THAN_ONCE")))
+			.isInstanceOf(OnboardingBadRequestException.class);
+	}
+
+	@Test
+	void rejectsBlankNickname() {
+		UUID userId = insertUser("NOT_STARTED");
+		assertThatThrownBy(() -> onboardingService.complete(userId, request("   ", "너굴", "Asia/Seoul", 100000, "LESS_THAN_ONCE")))
+			.isInstanceOf(OnboardingBadRequestException.class);
+	}
+
+	@Test
+	void acceptsNicknameExactlyEightCharacters() {
+		UUID userId = insertUser("NOT_STARTED");
+		OnboardingCompleteResponse response = onboardingService.complete(userId, request("12345678", "너굴", "Asia/Seoul", 100000, "LESS_THAN_ONCE"));
 		assertThat(response.onboardingStatus()).isEqualTo("COMPLETED");
 	}
 
@@ -220,6 +255,10 @@ class OnboardingServiceTest extends PostgreSqlContainerTest {
 
 	private OnboardingCompleteRequest request(String mascotName, String timezone, Integer monthlyBudgetAmount, String regretFrequencyChoice) {
 		return new OnboardingCompleteRequest(null, mascotName, timezone, monthlyBudgetAmount, regretFrequencyChoice);
+	}
+
+	private OnboardingCompleteRequest request(String nickname, String mascotName, String timezone, Integer monthlyBudgetAmount, String regretFrequencyChoice) {
+		return new OnboardingCompleteRequest(nickname, mascotName, timezone, monthlyBudgetAmount, regretFrequencyChoice);
 	}
 
 	private String queryString(String sql, UUID userId) {

--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistApiIntegrationTest.java
@@ -102,6 +102,26 @@ class WishlistApiIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void rejectsZeroListedPriceOnCreate() throws Exception {
+		UUID userId = createUser();
+
+		mockMvc.perform(post(WISHLIST_ITEMS_PATH)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+				{
+					"inputSource": "SHARE",
+					"originalUrl": "https://shop.example.com/product?id=100",
+					"normalizedUrl": "https://shop.example.com/product?id=100",
+					"title": "Zero price item",
+					"listedPrice": 0,
+					"category": "DIGITAL"
+				}
+				"""))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
 	void blocksDuplicateSavedNormalizedUrlForSameUser() throws Exception {
 		UUID userId = createUser();
 		String request = """

--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistServiceTest.java
@@ -119,6 +119,18 @@ class WishlistServiceTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void rejectsZeroListedPrice() {
+		UUID userId = createActiveUser();
+
+		assertThatThrownBy(() -> wishlistService.create(userId, new WishlistItemCreateRequest(
+			"SHARE", "https://shop.example.com/product", null, "상품", null,
+			0, null, "DIGITAL", null, false,
+			null, null, null, null, null
+		)))
+			.isInstanceOf(BadRequestException.class);
+	}
+
+	@Test
 	void rejectsCurrencyCodeNotThreeCharacters() {
 		UUID userId = createActiveUser();
 


### PR DESCRIPTION
## 작업 내용
- 탈퇴 유저에 연결된 기존 social account 로그인 시 기존 탈퇴 유저를 재사용하지 않고 새 ACTIVE 유저로 재연결하도록 수정했습니다.
- 온보딩 닉네임 검증을 입력값 기준 2~8자, 한글/영문/숫자, 앞뒤 공백 금지로 강화했습니다.
- 온보딩 예산은 1 이상만 허용하도록 수정했습니다.
- 위시 `listedPrice`는 입력된 경우 1 이상만 허용하고, 가격 미확인용 `null`은 유지했습니다.
- 마이페이지 프로필 닉네임 검증을 2~8자로 맞췄습니다.

## QA No
- No 13
- No 47
- No 60
- No 180 / 205
- No 415 / 420

## 테스트
- `./gradlew test --tests com.sagongsa.backend.auth.SocialAccountLinkServiceTest --tests com.sagongsa.backend.onboarding.OnboardingServiceTest --tests com.sagongsa.backend.onboarding.OnboardingCompleteIntegrationTest --tests com.sagongsa.backend.wishlist.WishlistServiceTest --tests com.sagongsa.backend.wishlist.WishlistApiIntegrationTest --tests com.sagongsa.backend.mypage.MypageApiIntegrationTest --no-daemon`
- `./gradlew test --no-daemon`
- `git diff --check`

Closes #129