### PR TITLE
[bug] NF-62 피드 QA 요청사항 보완

### DIFF
--- a/src/main/java/com/sagongsa/backend/domain/enums/ReportCategory.java
+++ b/src/main/java/com/sagongsa/backend/domain/enums/ReportCategory.java
@@ -5,5 +5,6 @@ public enum ReportCategory {
     SPAM,       // 광고/스팸
     OBSCENE,    // 음란성
     PRIVACY,    // 개인정보 노출
+    ILLEGAL_INFORMATION, // 불법 정보 공유
     OTHER       // 기타(직접 입력)
 }

--- a/src/main/java/com/sagongsa/backend/social/SocialPostService.java
+++ b/src/main/java/com/sagongsa/backend/social/SocialPostService.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Service
 @Transactional(readOnly = true)
@@ -55,7 +56,8 @@ class SocialPostService {
 	PostResponse createPost(UUID userId, CreatePostRequest request) {
 		UserAccount user = findUserOrThrow(userId);
 		SavedItem item = resolveItem(userId, request.itemId());
-		FeedPost post = new FeedPost(user, item, request.title(), request.body(), request.imageUrl(), request.price());
+		String imageUrl = resolveImageUrl(request.imageUrl(), item);
+		FeedPost post = new FeedPost(user, item, request.title(), request.body(), imageUrl, request.price());
 		feedPostRepository.save(post);
 		String authorNickname = userProfileRepository.findByUserId(userId).isPresent()
 			? UserProfile.POST_AUTHOR_NICKNAME : UserProfile.UNKNOWN_NICKNAME;
@@ -196,6 +198,13 @@ class SocialPostService {
 		return savedItemRepository.findById(itemId)
 			.filter(item -> item.getUser().getId().equals(userId))
 			.orElse(null);
+	}
+
+	private String resolveImageUrl(String requestImageUrl, SavedItem item) {
+		if (StringUtils.hasText(requestImageUrl)) {
+			return requestImageUrl;
+		}
+		return item != null ? item.getImageUrl() : null;
 	}
 
 	private UserAccount findUserOrThrow(UUID userId) {

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistItemSummaryResponse.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistItemSummaryResponse.java
@@ -17,6 +17,7 @@ public record WishlistItemSummaryResponse(
 	String category,
 	BigDecimal categoryConfidence,
 	boolean categoryLockedByUser,
+	boolean selected,
 	String status,
 	Instant createdAt,
 	Instant updatedAt

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
@@ -449,6 +449,13 @@ public class WishlistService {
 				si.category,
 				si.category_confidence,
 				si.category_locked_by_user,
+				exists (
+					select 1
+					from feed_posts fp
+					where fp.item_id = si.id
+					  and fp.user_id = si.user_id
+					  and fp.deleted_at is null
+				) as selected,
 				si.status,
 				si.created_at,
 				si.updated_at
@@ -496,6 +503,7 @@ public class WishlistService {
 			resultSet.getString("category"),
 			resultSet.getBigDecimal("category_confidence"),
 			resultSet.getBoolean("category_locked_by_user"),
+			resultSet.getBoolean("selected"),
 			resultSet.getString("status"),
 			getInstant(resultSet, "created_at"),
 			getInstant(resultSet, "updated_at")

--- a/src/test/java/com/sagongsa/backend/social/FeedPostProductSectionIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/social/FeedPostProductSectionIntegrationTest.java
@@ -110,6 +110,27 @@ class FeedPostProductSectionIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void feedListUsesWishlistImageWhenPostCreatedFromItem() throws Exception {
+		String userId = createDevUser();
+		String imageUrl = "https://cdn.example.com/wishlist-item.png";
+		String itemId = createTestItem(userId, "크롤링 상품", 129000, "https://shop.example.com/item", imageUrl);
+
+		mockMvc.perform(post("/api/v1/social/posts")
+				.header("X-User-Id", userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"title":"크롤링 상품 게시글","itemId":"%s"}
+					""".formatted(itemId)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.imageUrl").value(imageUrl));
+
+		mockMvc.perform(get("/api/v1/social/posts")
+				.header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.posts[0].imageUrl").value(imageUrl));
+	}
+
+	@Test
 	void otherUserItemIdIsIgnored() throws Exception {
 		String owner = createDevUser();
 		String otherUser = createDevUser();
@@ -135,21 +156,26 @@ class FeedPostProductSectionIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	private String createTestItem(String userId, String name, Integer price, String link) {
+		return createTestItem(userId, name, price, link, null);
+	}
+
+	private String createTestItem(String userId, String name, Integer price, String link, String imageUrl) {
 		UUID itemId = UUID.randomUUID();
 		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
 		jdbcTemplate.update(
 			"""
 			INSERT INTO saved_items (
-				id, user_id, input_source, original_url, normalized_url, title, listed_price,
+				id, user_id, input_source, original_url, normalized_url, title, image_url, listed_price,
 				currency_code, category, category_locked_by_user, status, created_at, updated_at
 			)
-			VALUES (?, ?, 'DIRECT_INPUT', ?, ?, ?, ?, 'KRW', 'DIGITAL', false, 'SAVED', ?, ?)
+			VALUES (?, ?, 'DIRECT_INPUT', ?, ?, ?, ?, ?, 'KRW', 'DIGITAL', false, 'SAVED', ?, ?)
 			""",
 			itemId,
 			UUID.fromString(userId),
 			link,
 			link,
 			name,
+			imageUrl,
 			price,
 			now,
 			now

--- a/src/test/java/com/sagongsa/backend/social/ReportServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/social/ReportServiceTest.java
@@ -1,5 +1,6 @@
 package com.sagongsa.backend.social;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -41,6 +42,23 @@ class ReportServiceTest extends PostgreSqlContainerTest {
 
 		assertThatNoException().isThrownBy(() ->
 			reportService.reportPost(reporter, postId, ReportCategory.SPAM, "스팸입니다"));
+	}
+
+	@Test
+	void 불법_정보_공유_신고_성공() {
+		UUID reporter = insertUser();
+		UUID author = insertUser();
+		UUID postId = insertPost(author);
+
+		reportService.reportPost(reporter, postId, ReportCategory.ILLEGAL_INFORMATION, null);
+
+		String category = jdbcTemplate.queryForObject(
+			"select report_category from post_reports where reporter_user_id = ? and target_id = ?",
+			String.class,
+			reporter,
+			postId
+		);
+		assertThat(category).isEqualTo("ILLEGAL_INFORMATION");
 	}
 
 	@Test

--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistApiIntegrationTest.java
@@ -294,6 +294,39 @@ class WishlistApiIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void marksSelectedItemsAlreadyUsedByVisibleFeedPost() throws Exception {
+		UUID userId = createUser();
+		OffsetDateTime older = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);
+		OffsetDateTime newer = OffsetDateTime.now(ZoneOffset.UTC);
+		UUID selectedItemId = insertItem(userId, "Selected item", "FASHION", "SAVED", older);
+		UUID unselectedItemId = insertItem(userId, "Unselected item", "FASHION", "SAVED", newer);
+		insertFeedPost(userId, selectedItemId, false);
+
+		mockMvc.perform(get(WISHLIST_ITEMS_PATH)
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.items", hasSize(2)))
+			.andExpect(jsonPath("$.items[0].id").value(unselectedItemId.toString()))
+			.andExpect(jsonPath("$.items[0].selected").value(false))
+			.andExpect(jsonPath("$.items[1].id").value(selectedItemId.toString()))
+			.andExpect(jsonPath("$.items[1].selected").value(true));
+	}
+
+	@Test
+	void ignoresDeletedFeedPostWhenMarkingSelectedItems() throws Exception {
+		UUID userId = createUser();
+		UUID itemId = insertItem(userId, "Deleted post item", "FASHION", "SAVED", OffsetDateTime.now(ZoneOffset.UTC));
+		insertFeedPost(userId, itemId, true);
+
+		mockMvc.perform(get(WISHLIST_ITEMS_PATH)
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.items", hasSize(1)))
+			.andExpect(jsonPath("$.items[0].id").value(itemId.toString()))
+			.andExpect(jsonPath("$.items[0].selected").value(false));
+	}
+
+	@Test
 	void rejectsMalformedCursorQueryParameter() throws Exception {
 		UUID userId = createUser();
 
@@ -577,6 +610,27 @@ class WishlistApiIntegrationTest extends PostgreSqlContainerTest {
 			createdAt
 		);
 		return itemId;
+	}
+
+	private UUID insertFeedPost(UUID userId, UUID itemId, boolean deleted) {
+		UUID postId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into feed_posts (
+				id, user_id, item_id, title, body, go_count, stop_count,
+				deleted_at, created_at, updated_at
+			)
+			values (?, ?, ?, '작성된 글', '내용', 0, 0, ?, ?, ?)
+			""",
+			postId,
+			userId,
+			itemId,
+			deleted ? now : null,
+			now,
+			now
+		);
+		return postId;
 	}
 
 	private UUID insertShareItem(UUID userId, String title, String url, String category, String status, OffsetDateTime createdAt) {

--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistCursorTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistCursorTest.java
@@ -86,6 +86,7 @@ class WishlistCursorTest {
 			"FASHION",
 			BigDecimal.valueOf(0.85),
 			false,
+			false,
 			"SAVED",
 			CREATED_AT,
 			UPDATED_AT


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-62**
- Jira: https://parkjaehong.atlassian.net/browse/NF-62
- GitHub: Related #132

> PR 제목: `[bug] NF-62 피드 QA 요청사항 보완`  
> 브랜치: `fix/NF-62-feed-qa-fixes`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #132

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- 피드 게시글 생성 시 위시리스트 itemId를 연결해도 피드 imageUrl이 request.imageUrl에만 의존해서 크롤링 위시리스트 이미지가 리스트에 노출되지 않았습니다.
- 글 작성 화면의 위시 목록 응답에 이미 피드 작성에 사용된 항목 여부가 없어 FE에서 선택 완료 항목을 하이라이트하기 어려웠습니다.
- 신고 카테고리 enum에 피그마 옵션인 불법 정보 공유가 없어 게시글/댓글 신고 옵션과 API 계약이 맞지 않았습니다.

### 왜 발생했나? (Root Cause)
- `SocialPostService.createPost`가 연결된 `SavedItem.imageUrl`을 fallback으로 사용하지 않았습니다.
- `WishlistService.list`의 summary 응답이 `saved_items` 기준 필드만 반환하고 `feed_posts.item_id` 사용 여부를 계산하지 않았습니다.
- `ReportCategory`에 `ILLEGAL_INFORMATION` 값이 정의되어 있지 않았습니다.

### 어떻게 고쳤나?
- 피드 생성 시 요청 imageUrl이 비어 있으면 연결된 위시리스트 item의 imageUrl을 저장하도록 보완했습니다.
- 위시리스트 목록 응답에 visible feed post 사용 여부를 나타내는 `selected` boolean을 추가했습니다.
- 신고 카테고리에 `ILLEGAL_INFORMATION`을 추가했습니다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법(가능하면)
- Steps:
  1. 이미지가 있는 크롤링 위시리스트 itemId로 피드 게시글 생성
  2. 피드 리스트 조회
  3. 글 작성 화면용 위시리스트 목록 조회
  4. 신고 API에 불법 정보 공유 카테고리 전달
- 기대 결과:
  - 피드 리스트의 imageUrl에 위시리스트 이미지가 노출됩니다.
  - 이미 피드 작성에 사용된 위시 항목은 `selected=true`로 반환됩니다.
  - `ILLEGAL_INFORMATION` 신고 카테고리가 정상 저장됩니다.
- 실제 결과:
  - 기존에는 imageUrl이 비거나 selected 필드/신고 카테고리가 없어 FE QA 요구사항을 만족하지 못했습니다.

### 재발 방지(있다면)
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [ ] 런북/문서 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] AC1: itemId 기반 피드 작성 시 요청 imageUrl이 없으면 위시리스트 imageUrl을 피드 imageUrl로 사용한다.
- [x] AC2: 위시리스트 목록 응답에 visible feed post 사용 여부를 `selected`로 제공한다.
- [x] AC3: 신고 API에서 `ILLEGAL_INFORMATION` 카테고리를 사용할 수 있다.

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew test --tests 'com.sagongsa.backend.social.FeedPostProductSectionIntegrationTest' --tests 'com.sagongsa.backend.social.ReportServiceTest' --tests 'com.sagongsa.backend.wishlist.WishlistApiIntegrationTest' --tests 'com.sagongsa.backend.wishlist.WishlistCursorTest'`
- Result: PASS
- Command: `./gradlew test`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

### CI
- 링크/결과: Gradle Test PASS

### Smoke / 수동 검증
- 시나리오: 통합 테스트로 피드 이미지 fallback, 위시 selected 응답, 신고 카테고리 저장 검증
- 결과: PASS

### 테스트 공백(있다면 이유 필수)
- 없음

---

## 🧭 영향 범위 (필수)
- [ ] API 스펙 변경 없음
- [x] API 스펙 변경 있음 (요약: 위시리스트 목록 응답 `selected` 추가, 신고 카테고리 enum 값 추가)
- [x] DB 스키마 변경 없음
- [ ] DB 스키마 변경 있음 (마이그레이션/락/시간: )
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음 (항목: )
- [x] 캐시/큐/외부 연동 영향 없음
- [ ] 캐시/큐/외부 연동 영향 있음 (요약: )

---

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음
- [ ] Breaking change 있음 → 무엇이 깨지는지 / 마이그레이션 / 롤아웃 전략:

---

## 🚀 배포/릴리즈 (해당 시 필수)
### Feature Flag
- [x] 사용 안함
- [ ] 사용함 → Flag/기본값/롤아웃:

### 모니터링/알림
- 확인할 대시보드/지표: 기본 API/CI 상태
- 에러/로그 키워드: 신고 카테고리 역직렬화 오류, 위시리스트 목록 조회 오류

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 위시리스트 목록 응답 필드가 추가되어 FE DTO 매핑이 엄격한 경우 확인이 필요합니다.
- `selected`는 삭제되지 않은 피드 게시글 기준으로만 true 처리합니다.

### 롤백
- [ ] 플래그/설정으로 우회 가능
- [x] 배포 롤백(이전 태그/이미지) 가능
- [ ] 데이터 롤백/역마이그레이션 필요 (절차: )

---

## 📸 증빙 (선택)
- 스크린샷/로그/메트릭 링크: GitHub Actions Gradle Test PASS
- 전/후 비교(가능하면): 테스트 케이스로 검증

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직:
  - `SocialPostService#createPost` imageUrl fallback
  - `WishlistService#summarySelect` selected 계산
  - `ReportCategory.ILLEGAL_INFORMATION`
- 트레이드오프/대안:
  - selected는 별도 엔드포인트 대신 기존 위시 목록 응답에 boolean 필드로 추가했습니다.
- 성능/보안/호환성 영향:
  - 위시 목록 조회에 `exists` 서브쿼리가 추가됩니다. `feed_posts.item_id` 기준 존재 여부만 확인합니다.
