### PR TITLE
[bug] NF-63 피드 신고 기타 사유 및 본인 게시글 투표 검증 보완

### DIFF
--- a/src/main/java/com/sagongsa/backend/social/ReportService.java
+++ b/src/main/java/com/sagongsa/backend/social/ReportService.java
@@ -32,6 +32,7 @@ class ReportService {
     }
 
     void reportPost(UUID reporterId, UUID postId, ReportCategory category, String reason) {
+        validateReason(category, reason);
         socialPostService.findPostOrThrow(postId);
         if (postReportRepository.existsByReporterIdAndTargetTypeAndTargetId(reporterId, ReportTargetType.POST, postId)) {
             throw new SocialFeedForbiddenException("이미 신고한 게시글입니다.");
@@ -41,6 +42,7 @@ class ReportService {
     }
 
     void reportComment(UUID reporterId, UUID postId, UUID commentId, ReportCategory category, String reason) {
+        validateReason(category, reason);
         socialPostService.findPostOrThrow(postId);
         PostComment comment = postCommentRepository.findById(commentId)
             .orElseThrow(() -> new SocialFeedNotFoundException("댓글을 찾을 수 없습니다."));
@@ -55,6 +57,7 @@ class ReportService {
     }
 
     void reportUser(UUID reporterId, UUID targetUserId, ReportCategory category, String reason) {
+        validateReason(category, reason);
         if (reporterId.equals(targetUserId)) {
             throw new SocialFeedForbiddenException("자기 자신은 신고할 수 없습니다.");
         }
@@ -64,6 +67,12 @@ class ReportService {
         }
         UserAccount reporter = findUserOrThrow(reporterId);
         postReportRepository.save(new PostReport(reporter, ReportTargetType.USER, targetUserId, category, reason));
+    }
+
+    private void validateReason(ReportCategory category, String reason) {
+        if (category == ReportCategory.OTHER && (reason == null || reason.isBlank())) {
+            throw new SocialFeedBadRequestException("기타 신고 사유는 상세 사유를 입력해야 합니다.");
+        }
     }
 
     private UserAccount findUserOrThrow(UUID userId) {

--- a/src/main/java/com/sagongsa/backend/social/SocialFeedBadRequestException.java
+++ b/src/main/java/com/sagongsa/backend/social/SocialFeedBadRequestException.java
@@ -1,0 +1,7 @@
+package com.sagongsa.backend.social;
+
+class SocialFeedBadRequestException extends RuntimeException {
+	SocialFeedBadRequestException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/social/SocialFeedExceptionHandler.java
+++ b/src/main/java/com/sagongsa/backend/social/SocialFeedExceptionHandler.java
@@ -10,6 +10,12 @@ class SocialFeedExceptionHandler {
 
 	record ErrorBody(String code, String message) {}
 
+	@ExceptionHandler(SocialFeedBadRequestException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	ErrorBody handleBadRequest(SocialFeedBadRequestException ex) {
+		return new ErrorBody("INVALID_REQUEST", ex.getMessage());
+	}
+
 	@ExceptionHandler(SocialFeedNotFoundException.class)
 	@ResponseStatus(HttpStatus.NOT_FOUND)
 	ErrorBody handleNotFound(SocialFeedNotFoundException ex) {

--- a/src/main/java/com/sagongsa/backend/social/VoteService.java
+++ b/src/main/java/com/sagongsa/backend/social/VoteService.java
@@ -35,6 +35,9 @@ class VoteService {
 		FeedPost post = socialPostService.findPostOrThrow(postId);
 		UserAccount user = userAccountRepository.findById(userId)
 			.orElseThrow(() -> new SocialFeedNotFoundException("사용자를 찾을 수 없습니다."));
+		if (post.getUser().getId().equals(userId)) {
+			throw new SocialFeedForbiddenException("본인 게시글에는 투표할 수 없습니다.");
+		}
 
 		Optional<PostVote> existing = postVoteRepository.findByPostIdAndUserId(postId, userId);
 		PostVoteType resultVote;

--- a/src/test/java/com/sagongsa/backend/social/ReportServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/social/ReportServiceTest.java
@@ -62,6 +62,26 @@ class ReportServiceTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void 게시글_기타_신고는_상세_사유가_필수() {
+		UUID reporter = insertUser();
+		UUID author = insertUser();
+		UUID postId = insertPost(author);
+
+		assertThatThrownBy(() -> reportService.reportPost(reporter, postId, ReportCategory.OTHER, " "))
+			.isInstanceOf(SocialFeedBadRequestException.class);
+	}
+
+	@Test
+	void 게시글_기타_신고는_상세_사유가_있으면_성공() {
+		UUID reporter = insertUser();
+		UUID author = insertUser();
+		UUID postId = insertPost(author);
+
+		assertThatNoException().isThrownBy(() ->
+			reportService.reportPost(reporter, postId, ReportCategory.OTHER, "기타 상세 사유"));
+	}
+
+	@Test
 	void 같은_게시글_두번_신고하면_예외() {
 		UUID reporter = insertUser();
 		UUID author = insertUser();
@@ -102,6 +122,29 @@ class ReportServiceTest extends PostgreSqlContainerTest {
 
 		assertThatNoException().isThrownBy(() ->
 			reportService.reportComment(reporter, postId, comment.id(), ReportCategory.OBSCENE, "부적절한 내용")
+		);
+	}
+
+	@Test
+	void 댓글_기타_신고는_상세_사유가_필수() {
+		UUID reporter = insertUser();
+		UUID author = insertUser();
+		UUID postId = insertPost(author);
+		CommentResponse comment = commentService.createComment(author, postId, new CreateCommentRequest("댓글"));
+
+		assertThatThrownBy(() -> reportService.reportComment(reporter, postId, comment.id(), ReportCategory.OTHER, null))
+			.isInstanceOf(SocialFeedBadRequestException.class);
+	}
+
+	@Test
+	void 댓글_기타_신고는_상세_사유가_있으면_성공() {
+		UUID reporter = insertUser();
+		UUID author = insertUser();
+		UUID postId = insertPost(author);
+		CommentResponse comment = commentService.createComment(author, postId, new CreateCommentRequest("댓글"));
+
+		assertThatNoException().isThrownBy(() ->
+			reportService.reportComment(reporter, postId, comment.id(), ReportCategory.OTHER, "기타 상세 사유")
 		);
 	}
 

--- a/src/test/java/com/sagongsa/backend/social/SocialFeedApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/social/SocialFeedApiIntegrationTest.java
@@ -279,6 +279,22 @@ class SocialFeedApiIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void 게시글_기타_신고_상세사유_없으면_400() throws Exception {
+		UUID reporter = insertUser();
+		UUID author = insertUser();
+		UUID postId = insertPost(author);
+
+		mockMvc.perform(post("/api/v1/social/posts/{postId}/reports", postId)
+				.header("X-User-Id", reporter)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"category":"OTHER","reason":" "}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+	}
+
+	@Test
 	void 같은_게시글_두번_신고_403() throws Exception {
 		UUID reporter = insertUser();
 		UUID author = insertUser();
@@ -329,6 +345,23 @@ class SocialFeedApiIntegrationTest extends PostgreSqlContainerTest {
 					{"category":"OBSCENE","reason":"부적절한 내용"}
 					"""))
 			.andExpect(status().isNoContent());
+	}
+
+	@Test
+	void 댓글_기타_신고_상세사유_없으면_400() throws Exception {
+		UUID reporter = insertUser();
+		UUID author = insertUser();
+		UUID postId = insertPost(author);
+		UUID commentId = insertComment(author, postId);
+
+		mockMvc.perform(post("/api/v1/social/posts/{postId}/comments/{commentId}/reports", postId, commentId)
+				.header("X-User-Id", reporter)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"category":"OTHER"}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
 	}
 
 	@Test

--- a/src/test/java/com/sagongsa/backend/social/VoteIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/social/VoteIntegrationTest.java
@@ -39,7 +39,8 @@ class VoteIntegrationTest extends PostgreSqlContainerTest {
 	@Test
 	void goVoteThenCancelDoesNotGoNegative() throws Exception {
 		UUID userId = insertUser();
-		UUID postId = insertPost(userId);
+		UUID authorId = insertUser();
+		UUID postId = insertPost(authorId);
 
 		// GO 투표
 		mockMvc.perform(post("/api/v1/social/posts/{postId}/votes", postId)
@@ -68,7 +69,8 @@ class VoteIntegrationTest extends PostgreSqlContainerTest {
 	@Test
 	void goToStopSwitchUpdatesCountsCorrectly() throws Exception {
 		UUID userId = insertUser();
-		UUID postId = insertPost(userId);
+		UUID authorId = insertUser();
+		UUID postId = insertPost(authorId);
 
 		// GO 투표
 		mockMvc.perform(post("/api/v1/social/posts/{postId}/votes", postId)
@@ -96,7 +98,8 @@ class VoteIntegrationTest extends PostgreSqlContainerTest {
 	@Test
 	void cancelledVoteCanBeReactivated() throws Exception {
 		UUID userId = insertUser();
-		UUID postId = insertPost(userId);
+		UUID authorId = insertUser();
+		UUID postId = insertPost(authorId);
 
 		String goBody = """
 			{"voteType":"GO"}
@@ -123,6 +126,21 @@ class VoteIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.myVote").value("GO"))
 			.andExpect(jsonPath("$.goCount").value(1));
+	}
+
+	@Test
+	void authorCannotVoteOwnPost() throws Exception {
+		UUID authorId = insertUser();
+		UUID postId = insertPost(authorId);
+
+		mockMvc.perform(post("/api/v1/social/posts/{postId}/votes", postId)
+				.header("X-User-Id", authorId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"voteType":"GO"}
+					"""))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("FORBIDDEN"));
 	}
 
 	private UUID insertUser() {


### PR DESCRIPTION
## 작업 키 / 이슈 링크
- Tracking Key: **NF-63**
- Jira: https://parkjaehong.atlassian.net/browse/NF-63 (임시 키)

### Close Issue
- GitHub: Closes #134

## 한눈에 요약
### 어떤 버그였나?
- test1QA `No 333`, `No 360`: 게시글/댓글 신고에서 `category=OTHER`인데 상세 사유가 비어 있어도 신고가 접수될 수 있었습니다.
- test1QA `No 395`: 게시글 작성자가 자신의 게시글에 `GO`/`STOP` 투표를 할 수 있었습니다.

### 왜 발생했나? (Root Cause)
- 신고 API는 `reason` 길이만 제한하고, `OTHER` 카테고리일 때 상세 사유 필수 여부를 검증하지 않았습니다.
- 투표 API는 게시글 작성자와 투표 요청 사용자가 같은지 확인하지 않았습니다.

### 어떻게 고쳤나?
- `ReportService`에 `OTHER` 신고 상세 사유 필수 검증을 추가했습니다.
- 검증 실패 시 `400 INVALID_REQUEST`로 응답하도록 소셜 피드용 bad request 예외를 추가했습니다.
- `VoteService`에서 본인 게시글 투표를 `403 FORBIDDEN`으로 차단했습니다.
- 게시글/댓글 신고와 투표 API 회귀 테스트를 추가했습니다.

## 재현 & 검증
### 재현 방법
- Steps:
  - 게시글/댓글 신고 API에 `{"category":"OTHER"}` 또는 빈 `reason` 전달
  - 게시글 작성자 계정으로 본인 게시글 투표 API 호출
- 기대 결과:
  - 기타 신고 상세 사유 누락은 `400 INVALID_REQUEST`
  - 본인 게시글 투표는 `403 FORBIDDEN`
- 실제 결과:
  - 수정 전에는 두 케이스 모두 서비스 레벨 검증이 없었습니다.

### 재발 방지
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [ ] 런북/문서 보강

## Acceptance Criteria (AC)
- [x] AC1: 게시글 `OTHER` 신고에서 상세 사유가 없으면 `400 INVALID_REQUEST`를 반환한다.
- [x] AC2: 댓글 `OTHER` 신고에서 상세 사유가 없으면 `400 INVALID_REQUEST`를 반환한다.
- [x] AC3: `OTHER` 신고에 상세 사유가 있으면 기존처럼 신고가 접수된다.
- [x] AC4: 게시글 작성자는 본인 게시글에 투표할 수 없고 `403 FORBIDDEN`을 반환한다.
- [x] AC5: 작성자가 아닌 사용자의 투표/취소/변경 흐름은 기존처럼 동작한다.

## 테스트 / 검증
### 로컬
- Command: `./gradlew test --tests com.sagongsa.backend.social.ReportServiceTest --tests com.sagongsa.backend.social.SocialFeedApiIntegrationTest --tests com.sagongsa.backend.social.VoteIntegrationTest --no-daemon`
- Result: PASS
- Command: `./gradlew test --no-daemon`
- Result: PASS
- Command: `git diff --check`
- Result: PASS

### CI
- 링크/결과: PR 생성 후 GitHub Actions에서 확인

### Smoke / 수동 검증
- 시나리오: 자동 통합 테스트로 신고/투표 API 응답 코드 검증
- 결과: PASS

### 테스트 공백
- 없음

## 영향 범위
- [ ] API 스펙 변경 없음
- [x] API 스펙 변경 있음 (요약: `OTHER` 신고 상세 사유 누락 시 400, 본인 게시글 투표 시 403 응답)
- [x] DB 스키마 변경 없음
- [ ] DB 스키마 변경 있음 (마이그레이션/락/시간: )
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음 (항목: )
- [x] 캐시/큐/외부 연동 영향 없음
- [ ] 캐시/큐/외부 연동 영향 있음 (요약: )

## Breaking / Compatibility
- [x] Breaking change 없음
- [ ] Breaking change 있음 -> 무엇이 깨지는지 / 마이그레이션 / 롤아웃 전략:

## 배포/릴리즈
### Feature Flag
- [x] 사용 안함
- [ ] 사용함 -> Flag/기본값/롤아웃:

### 모니터링/알림
- 확인할 대시보드/지표: 일반 API 4xx 에러율
- 에러/로그 키워드: `INVALID_REQUEST`, `FORBIDDEN`

## 리스크 & 롤백
### 리스크
- 클라이언트가 `OTHER` 신고 시 상세 사유를 보내지 않으면 400을 받습니다. QA 기대 결과와 맞춘 동작입니다.

### 롤백
- [ ] 플래그/설정으로 우회 가능
- [x] 배포 롤백(이전 태그/이미지) 가능
- [ ] 데이터 롤백/역마이그레이션 필요 (절차: )

## 증빙
- test1QA `No 333`, `No 360`, `No 395` 대응

## 리뷰 가이드
- 꼭 봐야 하는 파일/로직: `ReportService`, `VoteService`, `SocialFeedExceptionHandler`
- 트레이드오프/대안: DTO Bean Validation 대신 서비스 정책 검증으로 처리해 신고 대상별 공통 정책을 한 곳에서 유지했습니다.
- 성능/보안/호환성 영향: 추가 DB 쿼리 없이 기존 조회 결과로 검증합니다. DB 스키마/환경변수 영향은 없습니다.
