### PR TITLE
[feat] NF-63 QA 시나리오 골격 추가

### DIFF
--- a/src/main/java/com/sagongsa/backend/dev/DevQaController.java
+++ b/src/main/java/com/sagongsa/backend/dev/DevQaController.java
@@ -1,0 +1,33 @@
+package com.sagongsa.backend.dev;
+
+import java.util.UUID;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/dev/qa")
+@Profile("!prod")
+public class DevQaController {
+
+	private final QaScenarioService qaScenarioService;
+
+	public DevQaController(QaScenarioService qaScenarioService) {
+		this.qaScenarioService = qaScenarioService;
+	}
+
+	@PostMapping("/users")
+	public ResponseEntity<QaUserScenarioResponse> createQaUser() {
+		return ResponseEntity.ok(qaScenarioService.createQaUser());
+	}
+
+	@DeleteMapping("/users/{userId}")
+	public ResponseEntity<Void> deleteQaUser(@PathVariable UUID userId) {
+		qaScenarioService.deleteQaUser(userId);
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/src/main/java/com/sagongsa/backend/dev/QaScenarioService.java
+++ b/src/main/java/com/sagongsa/backend/dev/QaScenarioService.java
@@ -1,0 +1,288 @@
+package com.sagongsa.backend.dev;
+
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class QaScenarioService {
+
+	private static final String QA_NICKNAME_PREFIX = "QA너굴";
+	private static final String QA_PROVIDER_USER_ID_PREFIX = "DEV_QA:";
+	private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public QaScenarioService(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Transactional
+	public QaUserScenarioResponse createQaUser() {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		String yearMonth = currentYearMonth();
+
+		jdbcTemplate.update(
+			"insert into users (id, status, onboarding_status, created_at, updated_at) values (?, 'ACTIVE', 'COMPLETED', ?, ?)",
+			userId,
+			now,
+			now
+		);
+		jdbcTemplate.update(
+			"""
+			insert into social_accounts (
+				id, user_id, provider, provider_user_id, email, profile_image_url, created_at, updated_at
+			)
+			values (?, ?, 'KAKAO', ?, null, null, ?, ?)
+			""",
+			UUID.randomUUID(),
+			userId,
+			QA_PROVIDER_USER_ID_PREFIX + userId,
+			now,
+			now
+		);
+
+		Long seq = jdbcTemplate.queryForObject("select nextval('user_nickname_seq')", Long.class);
+		String nickname = QA_NICKNAME_PREFIX + seq;
+		jdbcTemplate.update(
+			"""
+			insert into user_profiles (
+				user_id, nickname, mascot_name, timezone, profile_image_url, notification_enabled, created_at, updated_at
+			)
+			values (?, ?, '너구리', 'Asia/Seoul', null, true, ?, ?)
+			""",
+			userId,
+			nickname,
+			now,
+			now
+		);
+
+		jdbcTemplate.update(
+			"""
+			insert into user_notification_settings (
+				user_id, push_enabled, regret_reminder_enabled, wishlist_reminder_enabled,
+				budget_warning_enabled, social_vote_enabled, updated_at
+			)
+			values (?, true, true, false, false, false, ?)
+			""",
+			userId,
+			now
+		);
+
+		jdbcTemplate.update(
+			"""
+			insert into mascot_profiles (
+				user_id, mascot_state, last_reaction_message, last_state_changed_at, reaction_expires_at, updated_at
+			)
+			values (?, 'DEFAULT', null, ?, null, ?)
+			""",
+			userId,
+			now,
+			now
+		);
+
+		UUID budgetCycleId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into budget_cycles (
+				id, user_id, year_month, monthly_budget_amount, spent_amount,
+				warning_threshold_rate, created_at, updated_at
+			)
+			values (?, ?, ?, 500000, 0, 80.00, ?, ?)
+			""",
+			budgetCycleId,
+			userId,
+			yearMonth,
+			now,
+			now
+		);
+
+		return new QaUserScenarioResponse(
+			userId,
+			nickname,
+			budgetCycleId,
+			yearMonth,
+			paths(userId)
+		);
+	}
+
+	@Transactional
+	public void deleteQaUser(UUID userId) {
+		if (!userExists(userId)) {
+			return;
+		}
+		if (!isQaUser(userId)) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Only QA scenario users can be deleted.");
+		}
+
+		deleteSocialData(userId);
+		deleteDecisionData(userId);
+		deleteUserSettings(userId);
+		jdbcTemplate.update("delete from users where id = ?", userId);
+	}
+
+	private boolean userExists(UUID userId) {
+		Boolean exists = jdbcTemplate.queryForObject(
+			"select exists(select 1 from users where id = ?)",
+			Boolean.class,
+			userId
+		);
+		return Boolean.TRUE.equals(exists);
+	}
+
+	private boolean isQaUser(UUID userId) {
+		Boolean exists = jdbcTemplate.queryForObject(
+			"""
+			select exists(
+				select 1
+				from social_accounts
+				where user_id = ?
+				  and provider_user_id = ?
+			)
+			""",
+			Boolean.class,
+			userId,
+			QA_PROVIDER_USER_ID_PREFIX + userId
+		);
+		return Boolean.TRUE.equals(exists);
+	}
+
+	private void deleteSocialData(UUID userId) {
+		jdbcTemplate.update(
+			"""
+			delete from share_tokens
+			where feed_post_id in (
+				select id from feed_posts where user_id = ?
+			)
+			""",
+			userId
+		);
+		jdbcTemplate.update(
+			"""
+			delete from post_reports
+			where reporter_user_id = ?
+			   or (target_type = 'POST' and target_id in (
+					select id from feed_posts where user_id = ?
+			   ))
+			   or (target_type = 'COMMENT' and target_id in (
+					select id
+					from post_comments
+					where user_id = ?
+					   or post_id in (select id from feed_posts where user_id = ?)
+			   ))
+			   or (target_type = 'USER' and target_id = ?)
+			""",
+			userId,
+			userId,
+			userId,
+			userId,
+			userId
+		);
+		jdbcTemplate.update("delete from user_blocks where blocker_user_id = ? or blocked_user_id = ?", userId, userId);
+		jdbcTemplate.update(
+			"""
+			delete from post_votes
+			where user_id = ?
+			   or post_id in (select id from feed_posts where user_id = ?)
+			""",
+			userId,
+			userId
+		);
+		jdbcTemplate.update(
+			"""
+			delete from post_comments
+			where user_id = ?
+			   or post_id in (select id from feed_posts where user_id = ?)
+			""",
+			userId,
+			userId
+		);
+		jdbcTemplate.update("delete from feed_posts where user_id = ?", userId);
+	}
+
+	private void deleteDecisionData(UUID userId) {
+		jdbcTemplate.update("delete from notifications where user_id = ?", userId);
+		jdbcTemplate.update("delete from purchase_reflections where user_id = ?", userId);
+		jdbcTemplate.update("delete from reminder_schedules where user_id = ?", userId);
+		jdbcTemplate.update("delete from mascot_state_events where user_id = ?", userId);
+		jdbcTemplate.update(
+			"""
+			delete from self_check_answers
+			where response_set_id in (
+				select sc.id
+				from self_check_response_sets sc
+				join purchase_decisions pd on pd.id = sc.decision_id
+				where pd.user_id = ?
+			)
+			""",
+			userId
+		);
+		jdbcTemplate.update(
+			"""
+			delete from self_check_response_sets
+			where decision_id in (
+				select id from purchase_decisions where user_id = ?
+			)
+			""",
+			userId
+		);
+		jdbcTemplate.update("delete from purchase_decision_change_logs where user_id = ?", userId);
+		jdbcTemplate.update("delete from purchase_decisions where user_id = ?", userId);
+		jdbcTemplate.update(
+			"""
+			delete from item_source_metadata
+			where item_id in (
+				select id from saved_items where user_id = ?
+			)
+			""",
+			userId
+		);
+		jdbcTemplate.update("delete from saved_items where user_id = ?", userId);
+		jdbcTemplate.update("delete from budget_cycles where user_id = ?", userId);
+	}
+
+	private void deleteUserSettings(UUID userId) {
+		jdbcTemplate.update(
+			"""
+			delete from survey_answers
+			where response_set_id in (
+				select id from survey_response_sets where user_id = ?
+			)
+			""",
+			userId
+		);
+		jdbcTemplate.update("delete from survey_response_sets where user_id = ?", userId);
+		jdbcTemplate.update("delete from user_terms_agreements where user_id = ?", userId);
+		jdbcTemplate.update("delete from marketing_consent_histories where user_id = ?", userId);
+		jdbcTemplate.update("delete from device_push_tokens where user_id = ?", userId);
+		jdbcTemplate.update("delete from user_notification_settings where user_id = ?", userId);
+		jdbcTemplate.update("delete from refresh_tokens where user_id = ?", userId);
+		jdbcTemplate.update("delete from social_accounts where user_id = ?", userId);
+		jdbcTemplate.update("delete from mascot_profiles where user_id = ?", userId);
+		jdbcTemplate.update("delete from user_profiles where user_id = ?", userId);
+	}
+
+	private Map<String, String> paths(UUID userId) {
+		Map<String, String> paths = new LinkedHashMap<>();
+		paths.put("home", "/api/v1/home/summary");
+		paths.put("notifications", "/api/v1/notifications");
+		paths.put("wishlist", "/api/v1/wishlist/items");
+		paths.put("mypage", "/api/v1/users/me");
+		paths.put("cleanup", "/api/dev/qa/users/" + userId);
+		return paths;
+	}
+
+	private String currentYearMonth() {
+		return YearMonth.now(SEOUL_ZONE).toString();
+	}
+}

--- a/src/main/java/com/sagongsa/backend/dev/QaUserScenarioResponse.java
+++ b/src/main/java/com/sagongsa/backend/dev/QaUserScenarioResponse.java
@@ -1,0 +1,13 @@
+package com.sagongsa.backend.dev;
+
+import java.util.Map;
+import java.util.UUID;
+
+public record QaUserScenarioResponse(
+	UUID userId,
+	String nickname,
+	UUID budgetCycleId,
+	String yearMonth,
+	Map<String, String> paths
+) {
+}

--- a/src/test/java/com/sagongsa/backend/dev/DevQaControllerIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/dev/DevQaControllerIntegrationTest.java
@@ -1,0 +1,141 @@
+package com.sagongsa.backend.dev;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class DevQaControllerIntegrationTest extends PostgreSqlContainerTest {
+
+	private static final String USER_ID_HEADER = "X-User-Id";
+	private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.execute("truncate table users cascade");
+	}
+
+	@Test
+	void createsQaUserWithCurrentBudgetAndScenarioPaths() throws Exception {
+		String body = mockMvc.perform(post("/api/dev/qa/users"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.nickname").value(startsWith("QA너굴")))
+			.andExpect(jsonPath("$.yearMonth").value(YearMonth.now(SEOUL_ZONE).toString()))
+			.andExpect(jsonPath("$.paths.home").value("/api/v1/home/summary"))
+			.andExpect(jsonPath("$.paths.mypage").value("/api/v1/users/me"))
+			.andExpect(jsonPath("$.paths.cleanup").exists())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		UUID userId = UUID.fromString(objectMapper.readTree(body).get("userId").asText());
+
+		assertThat(queryInteger("select count(*) from users where id = ? and status = 'ACTIVE'", userId)).isOne();
+		assertThat(queryInteger(
+			"select count(*) from social_accounts where user_id = ? and provider_user_id = ?",
+			userId,
+			"DEV_QA:" + userId
+		)).isOne();
+		assertThat(queryInteger("select count(*) from user_profiles where user_id = ?", userId)).isOne();
+		assertThat(queryInteger("select count(*) from user_notification_settings where user_id = ?", userId)).isOne();
+		assertThat(queryInteger("select count(*) from mascot_profiles where user_id = ?", userId)).isOne();
+		assertThat(queryInteger(
+			"select count(*) from budget_cycles where user_id = ? and year_month = ?",
+			userId,
+			YearMonth.now(SEOUL_ZONE).toString()
+		)).isOne();
+
+		mockMvc.perform(get("/api/v1/home/summary")
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.userProfile.nickname").value(startsWith("QA너굴")))
+			.andExpect(jsonPath("$.budget.yearMonth").value(YearMonth.now(SEOUL_ZONE).toString()));
+	}
+
+	@Test
+	void deletesOnlyQaScenarioUser() throws Exception {
+		String body = mockMvc.perform(post("/api/dev/qa/users"))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+		UUID userId = UUID.fromString(objectMapper.readTree(body).get("userId").asText());
+
+		mockMvc.perform(delete("/api/dev/qa/users/{userId}", userId))
+			.andExpect(status().isNoContent());
+
+		assertThat(queryInteger("select count(*) from users where id = ?", userId)).isZero();
+		assertThat(queryInteger("select count(*) from social_accounts where user_id = ?", userId)).isZero();
+		assertThat(queryInteger("select count(*) from user_profiles where user_id = ?", userId)).isZero();
+		assertThat(queryInteger("select count(*) from budget_cycles where user_id = ?", userId)).isZero();
+		assertThat(queryInteger("select count(*) from user_notification_settings where user_id = ?", userId)).isZero();
+		assertThat(queryInteger("select count(*) from mascot_profiles where user_id = ?", userId)).isZero();
+	}
+
+	@Test
+	void rejectsDeletingNonQaUser() throws Exception {
+		UUID userId = insertNonQaUserWithQaNickname();
+
+		mockMvc.perform(delete("/api/dev/qa/users/{userId}", userId))
+			.andExpect(status().isBadRequest());
+
+		assertThat(queryInteger("select count(*) from users where id = ?", userId)).isOne();
+		assertThat(queryInteger("select count(*) from user_profiles where user_id = ?", userId)).isOne();
+	}
+
+	private UUID insertNonQaUserWithQaNickname() {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"insert into users (id, status, onboarding_status, created_at, updated_at) values (?, 'ACTIVE', 'COMPLETED', ?, ?)",
+			userId,
+			now,
+			now
+		);
+		jdbcTemplate.update(
+			"""
+			insert into user_profiles (
+				user_id, nickname, mascot_name, timezone, profile_image_url, notification_enabled, created_at, updated_at
+			)
+			values (?, 'QA너굴99999', '너구리', 'Asia/Seoul', null, true, ?, ?)
+			""",
+			userId,
+			now,
+			now
+		);
+		return userId;
+	}
+
+	private Integer queryInteger(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(sql, Integer.class, args);
+	}
+}


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-63`
- Jira: https://parkjaehong.atlassian.net/browse/NF-63
- GitHub: Related #136
- GitHub: Closes # (Final PR만)

> PR 제목: `NF-63 QA 시나리오 골격 추가`
> 브랜치: `feat/NF-63-qa-scenario-base`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #136의 1/5 단계
- 선행 PR: 없음
- 후속 PR: #138

### 이 PR에서 변경한 것
- non-prod 전용 `/api/dev/qa` 컨트롤러를 추가했습니다.
- `POST /api/dev/qa/users`로 QA 전용 유저, 프로필, 알림 설정, 마스코트, 현재 월 예산을 생성합니다.
- QA 유저는 `social_accounts.provider_user_id = DEV_QA:{userId}` marker를 함께 저장합니다.
- `DELETE /api/dev/qa/users/{userId}`는 QA marker가 있는 유저만 정리하도록 보호했습니다.
- QA 응답에 주요 API path와 cleanup path를 포함했습니다.
- 생성/cleanup/비QA 삭제 방지/홈 진입 smoke 통합 테스트를 추가했습니다.

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
- AC1: prod profile에서는 `/api/dev/qa/**`가 노출되지 않도록 `@Profile("!prod")`로 분리
- AC3: QA가 사용할 `userId`, `budgetCycleId`, 주요 API path 응답
- AC10: QA marker 기반 cleanup 보호 추가
- AC11: PR1 범위 통합 테스트 추가

### Not covered (후속 작업)
- AC2: full basic scenario pack 생성은 후속 PR
- AC4~AC9: 알림/예산초과/숙려/결정조합/worker/피드 상태팩은 후속 PR

---

## 🧪 테스트 결과 (필수)
### 로컬
```
./gradlew test --tests com.sagongsa.backend.dev.DevQaControllerIntegrationTest --no-daemon
./gradlew test --no-daemon
```
- ✅ 결과: 통과

### CI
- develop base PR이라 GitHub Actions 자동 실행 대상입니다.

### Smoke 테스트
- 시나리오: QA 유저 생성 후 `X-User-Id`로 `/api/v1/home/summary` 조회
- 결과: ✅ 홈 요약 응답 정상 조회

---

## 🧭 영향 범위 체크 (필수)
- [x] API 변경 (요약: non-prod 전용 `/api/dev/qa/users` 생성/삭제 API 추가)
- [ ] DB 변경 (마이그레이션: 없음)
- [ ] 설정 변경 (항목: 없음)
- [ ] Breaking change (무엇: 없음)

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인: `QaScenarioService`의 QA 유저 생성값, QA marker 판별, cleanup 순서
- 트레이드오프/대안: nickname prefix만으로 cleanup을 허용하지 않고 social account marker를 함께 확인하도록 했습니다.