### PR TITLE
[feat] NF-63 QA 기본 상태팩 추가

### DIFF
--- a/src/main/java/com/sagongsa/backend/dev/DevQaController.java
+++ b/src/main/java/com/sagongsa/backend/dev/DevQaController.java
@@ -25,6 +25,11 @@ public class DevQaController {
 		return ResponseEntity.ok(qaScenarioService.createQaUser());
 	}
 
+	@PostMapping("/scenarios/basic")
+	public ResponseEntity<QaBasicScenarioResponse> createBasicScenario() {
+		return ResponseEntity.ok(qaScenarioService.createBasicScenario());
+	}
+
 	@DeleteMapping("/users/{userId}")
 	public ResponseEntity<Void> deleteQaUser(@PathVariable UUID userId) {
 		qaScenarioService.deleteQaUser(userId);

--- a/src/main/java/com/sagongsa/backend/dev/QaBasicScenarioResponse.java
+++ b/src/main/java/com/sagongsa/backend/dev/QaBasicScenarioResponse.java
@@ -1,0 +1,18 @@
+package com.sagongsa.backend.dev;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public record QaBasicScenarioResponse(
+	UUID userId,
+	String nickname,
+	UUID budgetCycleId,
+	String yearMonth,
+	List<UUID> itemIds,
+	List<UUID> decisionIds,
+	UUID deliberationItemId,
+	List<UUID> notificationIds,
+	Map<String, String> paths
+) {
+}

--- a/src/main/java/com/sagongsa/backend/dev/QaScenarioService.java
+++ b/src/main/java/com/sagongsa/backend/dev/QaScenarioService.java
@@ -5,6 +5,7 @@ import java.time.YearMonth;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
@@ -117,6 +118,59 @@ public class QaScenarioService {
 	}
 
 	@Transactional
+	public QaBasicScenarioResponse createBasicScenario() {
+		QaUserScenarioResponse user = createQaUser();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+
+		UUID decidedItemId = insertSavedItem(
+			user.userId(),
+			"QA 기본팩 무선 이어폰",
+			120000,
+			"DIGITAL",
+			"GO",
+			now
+		);
+		UUID decisionId = insertGoDecision(user.userId(), decidedItemId, user.budgetCycleId(), 120000, now);
+		UUID deliberationItemId = insertSavedItem(
+			user.userId(),
+			"QA 숙려 진입용 키보드",
+			45000,
+			"DIGITAL",
+			"SAVED",
+			now.minusHours(25)
+		);
+		UUID notificationId = insertUnreadNotification(user.userId(), now);
+
+		jdbcTemplate.update(
+			"""
+			update budget_cycles
+			   set monthly_budget_amount = 100000,
+			       spent_amount = 120000,
+			       updated_at = ?
+			 where id = ?
+			""",
+			now,
+			user.budgetCycleId()
+		);
+
+		Map<String, String> paths = new LinkedHashMap<>(user.paths());
+		paths.put("deliberation", "/api/v1/deliberations/items/" + deliberationItemId);
+		paths.put("consumption", "/api/v1/my/consumption?month=" + user.yearMonth());
+
+		return new QaBasicScenarioResponse(
+			user.userId(),
+			user.nickname(),
+			user.budgetCycleId(),
+			user.yearMonth(),
+			List.of(deliberationItemId, decidedItemId),
+			List.of(decisionId),
+			deliberationItemId,
+			List.of(notificationId),
+			paths
+		);
+	}
+
+	@Transactional
 	public void deleteQaUser(UUID userId) {
 		if (!userExists(userId)) {
 			return;
@@ -155,6 +209,78 @@ public class QaScenarioService {
 			QA_PROVIDER_USER_ID_PREFIX + userId
 		);
 		return Boolean.TRUE.equals(exists);
+	}
+
+	private UUID insertSavedItem(
+		UUID userId,
+		String title,
+		int listedPrice,
+		String category,
+		String status,
+		OffsetDateTime createdAt
+	) {
+		UUID itemId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into saved_items (
+				id, user_id, input_source, title, listed_price, currency_code, category,
+				category_locked_by_user, status, created_at, updated_at
+			)
+			values (?, ?, 'DIRECT_INPUT', ?, ?, 'KRW', ?, false, ?, ?, ?)
+			""",
+			itemId,
+			userId,
+			title,
+			listedPrice,
+			category,
+			status,
+			createdAt,
+			createdAt
+		);
+		return itemId;
+	}
+
+	private UUID insertGoDecision(UUID userId, UUID itemId, UUID budgetCycleId, int finalPrice, OffsetDateTime now) {
+		UUID decisionId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into purchase_decisions (
+				id, user_id, item_id, budget_cycle_id, result, final_price, budget_after_amount,
+				similar_category_spend_amount, rationality_result, self_check_yes_count,
+				is_changed, change_count, decided_at, created_at, updated_at
+			)
+			values (?, ?, ?, ?, 'GO', ?, ?, 0, 'RATIONAL', 1, false, 0, ?, ?, ?)
+			""",
+			decisionId,
+			userId,
+			itemId,
+			budgetCycleId,
+			finalPrice,
+			finalPrice,
+			now,
+			now,
+			now
+		);
+		return decisionId;
+	}
+
+	private UUID insertUnreadNotification(UUID userId, OffsetDateTime now) {
+		UUID notificationId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into notifications (
+				id, user_id, notification_type, title, body, item_id, decision_id, reminder_id,
+				target_path, is_read, read_at, created_at, updated_at
+			)
+			values (?, ?, 'BUDGET_WARNING', 'QA 예산 초과 알림', '이번 달 예산을 초과한 상태입니다.',
+				null, null, null, '/api/v1/home/summary', false, null, ?, ?)
+			""",
+			notificationId,
+			userId,
+			now,
+			now
+		);
+		return notificationId;
 	}
 
 	private void deleteSocialData(UUID userId) {

--- a/src/test/java/com/sagongsa/backend/dev/DevQaControllerIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/dev/DevQaControllerIntegrationTest.java
@@ -45,6 +45,59 @@ class DevQaControllerIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void basicScenarioCreatesHomeNotificationWishlistAndDeliberationState() throws Exception {
+		String body = mockMvc.perform(post("/api/dev/qa/scenarios/basic"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.nickname").value(startsWith("QA너굴")))
+			.andExpect(jsonPath("$.itemIds.length()").value(2))
+			.andExpect(jsonPath("$.decisionIds.length()").value(1))
+			.andExpect(jsonPath("$.notificationIds.length()").value(1))
+			.andExpect(jsonPath("$.paths.deliberation").exists())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		UUID userId = UUID.fromString(objectMapper.readTree(body).get("userId").asText());
+		UUID deliberationItemId = UUID.fromString(objectMapper.readTree(body).get("deliberationItemId").asText());
+
+		mockMvc.perform(get("/api/v1/home/summary")
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.budget.monthlyBudgetAmount").value(100000))
+			.andExpect(jsonPath("$.budget.spentAmount").value(120000))
+			.andExpect(jsonPath("$.budget.exhausted").value(true))
+			.andExpect(jsonPath("$.notifications.unreadCount").value(1));
+
+		mockMvc.perform(get("/api/v1/notifications")
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$[0].type").value("BUDGET_WARNING"))
+			.andExpect(jsonPath("$[0].read").value(false));
+
+		mockMvc.perform(get("/api/v1/wishlist/items")
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.items[0].id").value(deliberationItemId.toString()))
+			.andExpect(jsonPath("$.items[0].status").value("SAVED"));
+
+		mockMvc.perform(get("/api/v1/deliberations/items/{itemId}", deliberationItemId)
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.item.id").value(deliberationItemId.toString()))
+			.andExpect(jsonPath("$.budget.monthlyBudgetAmount").value(100000))
+			.andExpect(jsonPath("$.budget.spentAmount").value(120000))
+			.andExpect(jsonPath("$.similarCategorySpendAmount").value(120000));
+
+		mockMvc.perform(delete("/api/dev/qa/users/{userId}", userId))
+			.andExpect(status().isNoContent());
+
+		assertThat(queryInteger("select count(*) from users where id = ?", userId)).isZero();
+		assertThat(queryInteger("select count(*) from saved_items where user_id = ?", userId)).isZero();
+		assertThat(queryInteger("select count(*) from purchase_decisions where user_id = ?", userId)).isZero();
+		assertThat(queryInteger("select count(*) from notifications where user_id = ?", userId)).isZero();
+	}
+
+	@Test
 	void createsQaUserWithCurrentBudgetAndScenarioPaths() throws Exception {
 		String body = mockMvc.perform(post("/api/dev/qa/users"))
 			.andExpect(status().isOk())


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-63`
- Jira: https://parkjaehong.atlassian.net/browse/NF-63
- GitHub: Related #136
- GitHub: Closes # (Final PR만)

> PR 제목: `NF-63 QA 기본 상태팩 추가`
> 브랜치: `feat/NF-63-qa-basic-pack`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #136의 2/5 단계
- 선행 PR: #137
- 후속 PR: #139

### 이 PR에서 변경한 것
- `POST /api/dev/qa/scenarios/basic`을 추가했습니다.
- basic 호출 한 번으로 QA 유저와 함께 다음 상태를 생성합니다.
  - 예산 초과 홈 상태
  - 읽지 않은 예산 알림
  - 위시 목록에 노출되는 `SAVED` 상품
  - 숙려 화면 진입 가능한 상품
  - 유사 카테고리 소비금액 계산용 GO 결정
- 응답에 `itemIds`, `decisionIds`, `notificationIds`, `deliberationItemId`, 주요 path를 포함했습니다.
- 홈/알림/위시/숙려 조회 smoke와 cleanup 검증을 통합 테스트에 추가했습니다.

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
- AC2: basic 호출 한 번으로 주요 화면 진입용 기본 상태 생성
- AC3: QA가 사용할 주요 ID와 API path 응답 확장
- AC4: 읽지 않은 알림 상태를 홈/알림 API에서 확인
- AC5: 예산 초과 상태를 홈 API에서 확인
- AC6: 숙려 진입 가능 위시를 `/api/v1/deliberations/items/{itemId}`에서 확인
- AC10: basic 시나리오 데이터 cleanup 검증
- AC11: basic 시나리오 통합 테스트 추가

### Not covered (후속 작업)
- AC7: GO/STOP 및 합리/비합리 결과 조합은 후속 PR
- AC8: due reminder worker 수동 실행 API는 후속 PR
- AC9: 피드 상태팩은 후속 PR

---

## 🧪 테스트 결과 (필수)
### 로컬
```
./gradlew test --tests com.sagongsa.backend.dev.DevQaControllerIntegrationTest --no-daemon
./gradlew test --no-daemon
```
- ✅ 결과: 통과

### CI
- 이 PR은 stacked PR이라 base가 feature branch입니다.
- 현재 workflow는 `develop` 대상 PR에서 자동 실행되므로, 이 PR은 로컬 테스트 결과와 하위 develop-base PR CI를 함께 확인합니다.

### Smoke 테스트
- 시나리오: basic 생성 후 홈/알림/위시/숙려 API 조회
- 결과: ✅ 예산 초과, unread 알림, 위시 항목, 숙려 projection 정상 확인

---

## 🧭 영향 범위 체크 (필수)
- [x] API 변경 (요약: non-prod 전용 `/api/dev/qa/scenarios/basic` 추가)
- [ ] DB 변경 (마이그레이션: 없음)
- [ ] 설정 변경 (항목: 없음)
- [ ] Breaking change (무엇: 없음)

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인: `QaScenarioService#createBasicScenario`, `DevQaControllerIntegrationTest#basicScenarioCreatesHomeNotificationWishlistAndDeliberationState`
- 트레이드오프/대안: basic pack은 홈/알림/위시/숙려까지로 제한하고, 결정 조합/worker/피드는 후속 PR로 분리했습니다.