### PR TITLE
[feat] NF-63 QA 결정 회고 알림팩 추가

### DIFF
--- a/src/main/java/com/sagongsa/backend/dev/DevQaController.java
+++ b/src/main/java/com/sagongsa/backend/dev/DevQaController.java
@@ -30,6 +30,21 @@ public class DevQaController {
 		return ResponseEntity.ok(qaScenarioService.createBasicScenario());
 	}
 
+	@PostMapping("/scenarios/result-combinations")
+	public ResponseEntity<QaDecisionScenarioResponse> createResultCombinationsScenario() {
+		return ResponseEntity.ok(qaScenarioService.createResultCombinationsScenario());
+	}
+
+	@PostMapping("/scenarios/regret-notification-ready")
+	public ResponseEntity<QaRegretReminderScenarioResponse> createRegretNotificationReadyScenario() {
+		return ResponseEntity.ok(qaScenarioService.createRegretNotificationReadyScenario());
+	}
+
+	@PostMapping("/reminders/{reminderId}/process")
+	public ResponseEntity<QaReminderProcessResponse> processDueReminder(@PathVariable UUID reminderId) {
+		return ResponseEntity.ok(qaScenarioService.processDueReminder(reminderId));
+	}
+
 	@DeleteMapping("/users/{userId}")
 	public ResponseEntity<Void> deleteQaUser(@PathVariable UUID userId) {
 		qaScenarioService.deleteQaUser(userId);

--- a/src/main/java/com/sagongsa/backend/dev/QaDecisionScenarioResponse.java
+++ b/src/main/java/com/sagongsa/backend/dev/QaDecisionScenarioResponse.java
@@ -1,0 +1,16 @@
+package com.sagongsa.backend.dev;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public record QaDecisionScenarioResponse(
+	UUID userId,
+	String nickname,
+	UUID budgetCycleId,
+	String yearMonth,
+	List<UUID> itemIds,
+	Map<String, UUID> decisionIds,
+	Map<String, String> paths
+) {
+}

--- a/src/main/java/com/sagongsa/backend/dev/QaRegretReminderScenarioResponse.java
+++ b/src/main/java/com/sagongsa/backend/dev/QaRegretReminderScenarioResponse.java
@@ -1,0 +1,16 @@
+package com.sagongsa.backend.dev;
+
+import java.util.Map;
+import java.util.UUID;
+
+public record QaRegretReminderScenarioResponse(
+	UUID userId,
+	String nickname,
+	UUID budgetCycleId,
+	String yearMonth,
+	UUID itemId,
+	UUID decisionId,
+	UUID reminderId,
+	Map<String, String> paths
+) {
+}

--- a/src/main/java/com/sagongsa/backend/dev/QaReminderProcessResponse.java
+++ b/src/main/java/com/sagongsa/backend/dev/QaReminderProcessResponse.java
@@ -1,0 +1,4 @@
+package com.sagongsa.backend.dev;
+
+public record QaReminderProcessResponse(int processedCount) {
+}

--- a/src/main/java/com/sagongsa/backend/dev/QaScenarioService.java
+++ b/src/main/java/com/sagongsa/backend/dev/QaScenarioService.java
@@ -1,9 +1,11 @@
 package com.sagongsa.backend.dev;
 
+import com.sagongsa.backend.notification.ReminderNotificationWorker;
 import java.time.OffsetDateTime;
 import java.time.YearMonth;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,11 +22,14 @@ public class QaScenarioService {
 	private static final String QA_NICKNAME_PREFIX = "QA너굴";
 	private static final String QA_PROVIDER_USER_ID_PREFIX = "DEV_QA:";
 	private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+	private static final List<String> SELF_CHECK_CODES = List.of("NEED", "BUDGET", "ALTERNATIVE", "DELAY");
 
 	private final JdbcTemplate jdbcTemplate;
+	private final ReminderNotificationWorker reminderNotificationWorker;
 
-	public QaScenarioService(JdbcTemplate jdbcTemplate) {
+	public QaScenarioService(JdbcTemplate jdbcTemplate, ReminderNotificationWorker reminderNotificationWorker) {
 		this.jdbcTemplate = jdbcTemplate;
+		this.reminderNotificationWorker = reminderNotificationWorker;
 	}
 
 	@Transactional
@@ -130,7 +135,9 @@ public class QaScenarioService {
 			"GO",
 			now
 		);
-		UUID decisionId = insertGoDecision(user.userId(), decidedItemId, user.budgetCycleId(), 120000, now);
+		UUID decisionId = insertDecision(
+			user.userId(), decidedItemId, user.budgetCycleId(), "GO", 120000, 120000, "RATIONAL", 1, now
+		);
 		UUID deliberationItemId = insertSavedItem(
 			user.userId(),
 			"QA 숙려 진입용 키보드",
@@ -168,6 +175,83 @@ public class QaScenarioService {
 			List.of(notificationId),
 			paths
 		);
+	}
+
+	@Transactional
+	public QaDecisionScenarioResponse createResultCombinationsScenario() {
+		QaUserScenarioResponse user = createQaUser();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		Map<String, UUID> decisionIds = new LinkedHashMap<>();
+		List<UUID> itemIds = new ArrayList<>();
+		int budgetAfter = 0;
+
+		budgetAfter = insertDecisionCase(
+			user, itemIds, decisionIds, "goRational", "QA GO 합리 결과", "GO", 25000, budgetAfter, "RATIONAL", 1, now
+		);
+		budgetAfter = insertDecisionCase(
+			user, itemIds, decisionIds, "goIrrational", "QA GO 비합리 결과", "GO", 70000, budgetAfter, "IRRATIONAL", 3, now.minusMinutes(1)
+		);
+		budgetAfter = insertDecisionCase(
+			user, itemIds, decisionIds, "stopRational", "QA STOP 합리 결과", "STOP", 35000, budgetAfter, "RATIONAL", 0, now.minusMinutes(2)
+		);
+		insertDecisionCase(
+			user, itemIds, decisionIds, "stopIrrational", "QA STOP 비합리 결과", "STOP", 90000, budgetAfter, "IRRATIONAL", 4, now.minusMinutes(3)
+		);
+
+		jdbcTemplate.update(
+			"update budget_cycles set spent_amount = ?, updated_at = ? where id = ?",
+			budgetAfter,
+			now,
+			user.budgetCycleId()
+		);
+
+		Map<String, String> paths = new LinkedHashMap<>(user.paths());
+		paths.put("consumption", "/api/v1/my/consumption?month=" + user.yearMonth());
+
+		return new QaDecisionScenarioResponse(
+			user.userId(),
+			user.nickname(),
+			user.budgetCycleId(),
+			user.yearMonth(),
+			itemIds,
+			decisionIds,
+			paths
+		);
+	}
+
+	@Transactional
+	public QaRegretReminderScenarioResponse createRegretNotificationReadyScenario() {
+		QaUserScenarioResponse user = createQaUser();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		UUID itemId = insertSavedItem(user.userId(), "QA 회고 알림용 구매", 88000, "DIGITAL", "GO", now.minusDays(7));
+		UUID decisionId = insertDecision(
+			user.userId(), itemId, user.budgetCycleId(), "GO", 88000, 88000, "RATIONAL", 1, now.minusDays(7)
+		);
+		UUID reminderId = insertDueRegretReminder(user.userId(), itemId, decisionId, now.minusMinutes(1), now);
+		jdbcTemplate.update("update budget_cycles set spent_amount = 88000, updated_at = ? where id = ?", now, user.budgetCycleId());
+
+		Map<String, String> paths = new LinkedHashMap<>(user.paths());
+		paths.put("processDueReminder", "/api/dev/qa/reminders/" + reminderId + "/process");
+		paths.put("reflection", "/api/v1/reflections");
+
+		return new QaRegretReminderScenarioResponse(
+			user.userId(),
+			user.nickname(),
+			user.budgetCycleId(),
+			user.yearMonth(),
+			itemId,
+			decisionId,
+			reminderId,
+			paths
+		);
+	}
+
+	public QaReminderProcessResponse processDueReminder(UUID reminderId) {
+		UUID userId = reminderOwnerId(reminderId);
+		if (!isQaUser(userId)) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Only QA scenario reminders can be processed.");
+		}
+		return new QaReminderProcessResponse(reminderNotificationWorker.processDueReminder(reminderId));
 	}
 
 	@Transactional
@@ -211,6 +295,17 @@ public class QaScenarioService {
 		return Boolean.TRUE.equals(exists);
 	}
 
+	private UUID reminderOwnerId(UUID reminderId) {
+		return jdbcTemplate.query(
+				"select user_id from reminder_schedules where id = ?",
+				(rs, rowNumber) -> rs.getObject("user_id", UUID.class),
+				reminderId
+			)
+			.stream()
+			.findFirst()
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Reminder was not found."));
+	}
+
 	private UUID insertSavedItem(
 		UUID userId,
 		String title,
@@ -240,7 +335,41 @@ public class QaScenarioService {
 		return itemId;
 	}
 
-	private UUID insertGoDecision(UUID userId, UUID itemId, UUID budgetCycleId, int finalPrice, OffsetDateTime now) {
+	private int insertDecisionCase(
+		QaUserScenarioResponse user,
+		List<UUID> itemIds,
+		Map<String, UUID> decisionIds,
+		String key,
+		String title,
+		String result,
+		int listedPrice,
+		int currentBudgetAfter,
+		String rationality,
+		int yesCount,
+		OffsetDateTime decidedAt
+	) {
+		UUID itemId = insertSavedItem(user.userId(), title, listedPrice, "DIGITAL", result, decidedAt);
+		Integer finalPrice = "GO".equals(result) ? listedPrice : null;
+		int nextBudgetAfter = finalPrice == null ? currentBudgetAfter : currentBudgetAfter + finalPrice;
+		UUID decisionId = insertDecision(
+			user.userId(), itemId, user.budgetCycleId(), result, finalPrice, nextBudgetAfter, rationality, yesCount, decidedAt
+		);
+		itemIds.add(itemId);
+		decisionIds.put(key, decisionId);
+		return nextBudgetAfter;
+	}
+
+	private UUID insertDecision(
+		UUID userId,
+		UUID itemId,
+		UUID budgetCycleId,
+		String result,
+		Integer finalPrice,
+		int budgetAfterAmount,
+		String rationality,
+		int yesCount,
+		OffsetDateTime decidedAt
+	) {
 		UUID decisionId = UUID.randomUUID();
 		jdbcTemplate.update(
 			"""
@@ -249,19 +378,85 @@ public class QaScenarioService {
 				similar_category_spend_amount, rationality_result, self_check_yes_count,
 				is_changed, change_count, decided_at, created_at, updated_at
 			)
-			values (?, ?, ?, ?, 'GO', ?, ?, 0, 'RATIONAL', 1, false, 0, ?, ?, ?)
+			values (?, ?, ?, ?, ?, ?, ?, 0, ?, ?, false, 0, ?, ?, ?)
 			""",
 			decisionId,
 			userId,
 			itemId,
 			budgetCycleId,
+			result,
 			finalPrice,
-			finalPrice,
-			now,
+			budgetAfterAmount,
+			rationality,
+			yesCount,
+			decidedAt,
+			decidedAt,
+			decidedAt
+		);
+		insertSelfCheck(decisionId, rationality, yesCount, decidedAt);
+		return decisionId;
+	}
+
+	private void insertSelfCheck(UUID decisionId, String rationality, int yesCount, OffsetDateTime submittedAt) {
+		UUID responseSetId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into self_check_response_sets (
+				id, decision_id, yes_count, rationality_result, submitted_at, created_at, updated_at
+			)
+			values (?, ?, ?, ?, ?, ?, ?)
+			""",
+			responseSetId,
+			decisionId,
+			yesCount,
+			rationality,
+			submittedAt,
+			submittedAt,
+			submittedAt
+		);
+		for (int i = 0; i < SELF_CHECK_CODES.size(); i++) {
+			jdbcTemplate.update(
+				"""
+				insert into self_check_answers (
+					id, response_set_id, question_code, answer_boolean, created_at, updated_at
+				)
+				values (?, ?, ?, ?, ?, ?)
+				""",
+				UUID.randomUUID(),
+				responseSetId,
+				SELF_CHECK_CODES.get(i),
+				i < yesCount,
+				submittedAt,
+				submittedAt
+			);
+		}
+	}
+
+	private UUID insertDueRegretReminder(
+		UUID userId,
+		UUID itemId,
+		UUID decisionId,
+		OffsetDateTime scheduledFor,
+		OffsetDateTime now
+	) {
+		UUID reminderId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into reminder_schedules (
+				id, user_id, item_id, decision_id, reminder_type, scheduled_for,
+				status, sent_at, canceled_at, cancel_reason, created_at, updated_at
+			)
+			values (?, ?, ?, ?, 'REGRET_CHECK_7_DAYS', ?, 'SCHEDULED', null, null, null, ?, ?)
+			""",
+			reminderId,
+			userId,
+			itemId,
+			decisionId,
+			scheduledFor,
 			now,
 			now
 		);
-		return decisionId;
+		return reminderId;
 	}
 
 	private UUID insertUnreadNotification(UUID userId, OffsetDateTime now) {

--- a/src/main/java/com/sagongsa/backend/notification/ReminderNotificationWorker.java
+++ b/src/main/java/com/sagongsa/backend/notification/ReminderNotificationWorker.java
@@ -44,6 +44,36 @@ public class ReminderNotificationWorker {
 		return processedCount;
 	}
 
+	public int processDueReminder(UUID reminderId) {
+		if (!isDueReminder(reminderId)) {
+			return 0;
+		}
+		return processReminder(reminderId) ? 1 : 0;
+	}
+
+	private boolean isDueReminder(UUID reminderId) {
+		Boolean exists = jdbcTemplate.queryForObject(
+			"""
+			select exists(
+				select 1
+				from reminder_schedules rs
+				join users u on u.id = rs.user_id
+				left join user_notification_settings uns on uns.user_id = rs.user_id
+				where rs.id = ?
+				  and rs.reminder_type = 'REGRET_CHECK_7_DAYS'
+				  and rs.status = 'SCHEDULED'
+				  and rs.scheduled_for <= ?
+				  and u.status = 'ACTIVE'
+				  and coalesce(uns.regret_reminder_enabled, true) = true
+			)
+			""",
+			Boolean.class,
+			reminderId,
+			OffsetDateTime.now(ZoneOffset.UTC)
+		);
+		return Boolean.TRUE.equals(exists);
+	}
+
 	private List<UUID> findDueReminderIds() {
 		return jdbcTemplate.query(
 			"""

--- a/src/test/java/com/sagongsa/backend/dev/DevQaControllerIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/dev/DevQaControllerIntegrationTest.java
@@ -20,10 +20,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest
+@SpringBootTest(properties = "app.notification.reminder-worker.enabled=false")
 @AutoConfigureMockMvc
 class DevQaControllerIntegrationTest extends PostgreSqlContainerTest {
 
@@ -42,6 +43,102 @@ class DevQaControllerIntegrationTest extends PostgreSqlContainerTest {
 	@BeforeEach
 	void setUp() {
 		jdbcTemplate.execute("truncate table users cascade");
+	}
+
+	@Test
+	void resultCombinationsScenarioCreatesGoStopAndRationalityCases() throws Exception {
+		String body = mockMvc.perform(post("/api/dev/qa/scenarios/result-combinations"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.decisionIds.goRational").exists())
+			.andExpect(jsonPath("$.decisionIds.goIrrational").exists())
+			.andExpect(jsonPath("$.decisionIds.stopRational").exists())
+			.andExpect(jsonPath("$.decisionIds.stopIrrational").exists())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		UUID userId = UUID.fromString(objectMapper.readTree(body).get("userId").asText());
+		String yearMonth = objectMapper.readTree(body).get("yearMonth").asText();
+
+		mockMvc.perform(get("/api/v1/my/consumption")
+				.header(USER_ID_HEADER, userId)
+				.param("month", yearMonth))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.items.length()").value(4));
+
+		assertThat(queryInteger(
+			"select count(*) from purchase_decisions where user_id = ? and result = 'GO'",
+			userId
+		)).isEqualTo(2);
+		assertThat(queryInteger(
+			"select count(*) from purchase_decisions where user_id = ? and result = 'STOP'",
+			userId
+		)).isEqualTo(2);
+		assertThat(queryInteger(
+			"select count(*) from purchase_decisions where user_id = ? and rationality_result = 'RATIONAL'",
+			userId
+		)).isEqualTo(2);
+		assertThat(queryInteger(
+			"select count(*) from purchase_decisions where user_id = ? and rationality_result = 'IRRATIONAL'",
+			userId
+		)).isEqualTo(2);
+	}
+
+	@Test
+	void regretNotificationReadyScenarioCanProcessDueReminderAndCreateReflection() throws Exception {
+		String body = mockMvc.perform(post("/api/dev/qa/scenarios/regret-notification-ready"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.paths.processDueReminder").exists())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		UUID userId = UUID.fromString(objectMapper.readTree(body).get("userId").asText());
+		UUID decisionId = UUID.fromString(objectMapper.readTree(body).get("decisionId").asText());
+		UUID reminderId = UUID.fromString(objectMapper.readTree(body).get("reminderId").asText());
+
+		mockMvc.perform(post("/api/dev/qa/reminders/{reminderId}/process", reminderId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.processedCount").value(1));
+
+		assertThat(queryString("select status from reminder_schedules where id = ?", reminderId)).isEqualTo("SENT");
+		mockMvc.perform(get("/api/v1/notifications")
+				.header(USER_ID_HEADER, userId)
+				.param("unreadOnly", "true"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$[0].type").value("REGRET_CHECK_READY"))
+			.andExpect(jsonPath("$[0].reminderId").value(reminderId.toString()));
+
+		mockMvc.perform(post("/api/v1/reflections")
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+						"decisionId": "%s",
+						"satisfactionScore": 5,
+						"regretLevel": "NONE",
+						"stillUsing": true,
+						"reflectionNote": "QA 회고 확인"
+					}
+					""".formatted(decisionId)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.decisionId").value(decisionId.toString()))
+			.andExpect(jsonPath("$.reminderId").value(reminderId.toString()));
+	}
+
+	@Test
+	void rejectsProcessingNonQaReminder() throws Exception {
+		UUID userId = insertNonQaUserWithQaNickname();
+		UUID reminderId = insertNonQaDueReminder(userId);
+
+		mockMvc.perform(post("/api/dev/qa/reminders/{reminderId}/process", reminderId))
+			.andExpect(status().isBadRequest());
+
+		assertThat(queryString("select status from reminder_schedules where id = ?", reminderId)).isEqualTo("SCHEDULED");
+		assertThat(queryInteger(
+			"select count(*) from notifications where reminder_id = ?",
+			reminderId
+		)).isZero();
 	}
 
 	@Test
@@ -188,7 +285,63 @@ class DevQaControllerIntegrationTest extends PostgreSqlContainerTest {
 		return userId;
 	}
 
+	private UUID insertNonQaDueReminder(UUID userId) {
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		UUID itemId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into saved_items (
+				id, user_id, input_source, title, listed_price, currency_code, category,
+				category_locked_by_user, status, created_at, updated_at
+			)
+			values (?, ?, 'DIRECT_INPUT', '일반 유저 회고 상품', 10000, 'KRW', 'DIGITAL', false, 'GO', ?, ?)
+			""",
+			itemId,
+			userId,
+			now,
+			now
+		);
+		UUID decisionId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into purchase_decisions (
+				id, user_id, item_id, budget_cycle_id, result, final_price, rationality_result,
+				self_check_yes_count, is_changed, change_count, decided_at, created_at, updated_at
+			)
+			values (?, ?, ?, null, 'GO', 10000, 'RATIONAL', 1, false, 0, ?, ?, ?)
+			""",
+			decisionId,
+			userId,
+			itemId,
+			now.minusDays(7),
+			now.minusDays(7),
+			now.minusDays(7)
+		);
+		UUID reminderId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into reminder_schedules (
+				id, user_id, item_id, decision_id, reminder_type, scheduled_for,
+				status, sent_at, canceled_at, cancel_reason, created_at, updated_at
+			)
+			values (?, ?, ?, ?, 'REGRET_CHECK_7_DAYS', ?, 'SCHEDULED', null, null, null, ?, ?)
+			""",
+			reminderId,
+			userId,
+			itemId,
+			decisionId,
+			now.minusMinutes(1),
+			now,
+			now
+		);
+		return reminderId;
+	}
+
 	private Integer queryInteger(String sql, Object... args) {
 		return jdbcTemplate.queryForObject(sql, Integer.class, args);
+	}
+
+	private String queryString(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(sql, String.class, args);
 	}
 }


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-63`
- Jira: https://parkjaehong.atlassian.net/browse/NF-63
- GitHub: Related #136
- GitHub: Closes # (Final PR만)

> PR 제목: `NF-63 QA 결정 회고 알림팩 추가`
> 브랜치: `feat/NF-63-qa-decision-reminder-pack`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #136의 3/5 단계
- 선행 PR: #138
- 후속 PR: #140

### 이 PR에서 변경한 것
- `POST /api/dev/qa/scenarios/result-combinations`를 추가했습니다.
- GO/STOP 및 합리/비합리 조합 4건을 생성하고 소비관리 API에서 조회 가능하게 했습니다.
- `POST /api/dev/qa/scenarios/regret-notification-ready`를 추가했습니다.
- due 상태의 7일 회고 reminder를 생성합니다.
- `POST /api/dev/qa/reminders/{reminderId}/process`로 QA reminder 1건만 수동 처리할 수 있게 했습니다.
- 회고 알림 처리 후 `/api/v1/reflections` 생성까지 smoke 검증했습니다.
- 테스트에서는 reminder scheduler를 비활성화해 수동 처리 검증이 scheduler와 경쟁하지 않도록 했습니다.

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
- AC3: 결정/회고/worker 시나리오용 주요 ID와 API path 응답
- AC7: GO/STOP 및 합리/비합리 결과 조합 재현
- AC8: due reminder를 notification으로 변환하는 worker 수동 실행 API 동작
- AC10: 생성된 결정/알림/reminder 데이터 cleanup 범위에 포함
- AC11: 결정 조합, worker, 회고 생성 통합 테스트 추가

### Not covered (후속 작업)
- AC9: 피드/마이페이지 상태팩은 후속 PR
- 문서/Swagger/dev static 정리는 후속 PR

---

## 🧪 테스트 결과 (필수)
### 로컬
```
./gradlew test --tests com.sagongsa.backend.dev.DevQaControllerIntegrationTest --no-daemon
./gradlew test --no-daemon
```
- ✅ 결과: 통과

### CI
- 이 PR은 stacked PR이라 base가 feature branch입니다.
- 현재 workflow는 `develop` 대상 PR에서 자동 실행되므로, 이 PR은 로컬 테스트 결과와 하위 develop-base PR CI를 함께 확인합니다.

### Smoke 테스트
- 시나리오: result-combinations 생성 후 소비관리 API 조회
- 결과: ✅ GO 2건, STOP 2건, 합리 2건, 비합리 2건 확인
- 시나리오: regret-notification-ready 생성 후 QA reminder 수동 처리 및 회고 생성
- 결과: ✅ reminder SENT, REGRET_CHECK_READY 알림 생성, reflection 생성 확인
- 시나리오: 비QA reminder 수동 처리 시도
- 결과: ✅ 400 반환, reminder 상태 유지, notification 미생성

---

## 🧭 영향 범위 체크 (필수)
- [x] API 변경 (요약: non-prod 전용 QA 결정/회고/reminder 처리 API 추가)
- [ ] DB 변경 (마이그레이션: 없음)
- [ ] 설정 변경 (항목: 없음)
- [ ] Breaking change (무엇: 없음)

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인: `QaScenarioService#createResultCombinationsScenario`, `QaScenarioService#createRegretNotificationReadyScenario`, `QaScenarioService#processDueReminder`, `ReminderNotificationWorker#processDueReminder`
- 트레이드오프/대안: 전체 due reminder worker를 직접 열지 않고 QA marker가 있는 reminder 1건만 처리하도록 좁혔습니다.