### PR TITLE
[feat] NF-63 QA 피드 마이페이지 상태팩 추가

### DIFF
--- a/src/main/java/com/sagongsa/backend/dev/DevQaController.java
+++ b/src/main/java/com/sagongsa/backend/dev/DevQaController.java
@@ -40,6 +40,16 @@ public class DevQaController {
 		return ResponseEntity.ok(qaScenarioService.createRegretNotificationReadyScenario());
 	}
 
+	@PostMapping("/scenarios/feed-ready")
+	public ResponseEntity<QaFeedScenarioResponse> createFeedReadyScenario() {
+		return ResponseEntity.ok(qaScenarioService.createFeedReadyScenario());
+	}
+
+	@PostMapping("/scenarios/mypage-consumption")
+	public ResponseEntity<QaDecisionScenarioResponse> createMypageConsumptionScenario() {
+		return ResponseEntity.ok(qaScenarioService.createMypageConsumptionScenario());
+	}
+
 	@PostMapping("/reminders/{reminderId}/process")
 	public ResponseEntity<QaReminderProcessResponse> processDueReminder(@PathVariable UUID reminderId) {
 		return ResponseEntity.ok(qaScenarioService.processDueReminder(reminderId));

--- a/src/main/java/com/sagongsa/backend/dev/QaFeedScenarioResponse.java
+++ b/src/main/java/com/sagongsa/backend/dev/QaFeedScenarioResponse.java
@@ -1,0 +1,19 @@
+package com.sagongsa.backend.dev;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public record QaFeedScenarioResponse(
+	UUID userId,
+	String nickname,
+	UUID peerUserId,
+	String peerNickname,
+	List<UUID> postIds,
+	UUID myPostId,
+	UUID peerPostId,
+	List<UUID> commentIds,
+	List<UUID> voteIds,
+	Map<String, String> paths
+) {
+}

--- a/src/main/java/com/sagongsa/backend/dev/QaScenarioService.java
+++ b/src/main/java/com/sagongsa/backend/dev/QaScenarioService.java
@@ -220,6 +220,24 @@ public class QaScenarioService {
 	}
 
 	@Transactional
+	public QaDecisionScenarioResponse createMypageConsumptionScenario() {
+		QaDecisionScenarioResponse scenario = createResultCombinationsScenario();
+		Map<String, String> paths = new LinkedHashMap<>(scenario.paths());
+		paths.put("statsMonths", "/api/v1/users/me/stats/months");
+		paths.put("stats", "/api/v1/users/me/stats?yearMonth=" + scenario.yearMonth());
+		paths.put("wishHistory", "/api/v1/users/me/wishes/history?yearMonth=" + scenario.yearMonth());
+		return new QaDecisionScenarioResponse(
+			scenario.userId(),
+			scenario.nickname(),
+			scenario.budgetCycleId(),
+			scenario.yearMonth(),
+			scenario.itemIds(),
+			scenario.decisionIds(),
+			paths
+		);
+	}
+
+	@Transactional
 	public QaRegretReminderScenarioResponse createRegretNotificationReadyScenario() {
 		QaUserScenarioResponse user = createQaUser();
 		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
@@ -242,6 +260,43 @@ public class QaScenarioService {
 			itemId,
 			decisionId,
 			reminderId,
+			paths
+		);
+	}
+
+	@Transactional
+	public QaFeedScenarioResponse createFeedReadyScenario() {
+		QaUserScenarioResponse viewer = createQaUser();
+		QaUserScenarioResponse peer = createQaUser();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+
+		UUID myItemId = insertSavedItem(viewer.userId(), "QA 내 피드 상품", 39000, "HOBBY", "GO", now.minusMinutes(3));
+		UUID peerItemId = insertSavedItem(peer.userId(), "QA 타인 피드 상품", 54000, "LIVING", "GO", now.minusMinutes(2));
+		UUID myPostId = insertFeedPost(
+			viewer.userId(), myItemId, "QA 내 게시글", "내 게시글 수정/삭제 확인용", 39000, now.minusMinutes(3)
+		);
+		UUID peerPostId = insertFeedPost(
+			peer.userId(), peerItemId, "QA 타인 게시글", "댓글/투표/신고 확인용", 54000, now.minusMinutes(2)
+		);
+		UUID commentId = insertPostComment(viewer.userId(), peerPostId, "QA 댓글 확인", now.minusMinutes(1));
+		UUID voteId = insertPostVote(viewer.userId(), peerPostId, "GO", now.minusSeconds(30));
+
+		Map<String, String> paths = new LinkedHashMap<>(viewer.paths());
+		paths.put("feed", "/api/v1/social/posts");
+		paths.put("myPosts", "/api/v1/users/me/posts");
+		paths.put("myVotes", "/api/v1/users/me/votes");
+		paths.put("peerCleanup", "/api/dev/qa/users/" + peer.userId());
+
+		return new QaFeedScenarioResponse(
+			viewer.userId(),
+			viewer.nickname(),
+			peer.userId(),
+			peer.nickname(),
+			List.of(myPostId, peerPostId),
+			myPostId,
+			peerPostId,
+			List.of(commentId),
+			List.of(voteId),
 			paths
 		);
 	}
@@ -457,6 +512,73 @@ public class QaScenarioService {
 			now
 		);
 		return reminderId;
+	}
+
+	private UUID insertFeedPost(
+		UUID userId,
+		UUID itemId,
+		String title,
+		String body,
+		int price,
+		OffsetDateTime createdAt
+	) {
+		UUID postId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into feed_posts (
+				id, user_id, item_id, decision_id, title, body, go_count, stop_count,
+				created_at, updated_at, deleted_at, image_url, price
+			)
+			values (?, ?, ?, null, ?, ?, 0, 0, ?, ?, null, null, ?)
+			""",
+			postId,
+			userId,
+			itemId,
+			title,
+			body,
+			createdAt,
+			createdAt,
+			price
+		);
+		return postId;
+	}
+
+	private UUID insertPostComment(UUID userId, UUID postId, String body, OffsetDateTime createdAt) {
+		UUID commentId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into post_comments (
+				id, post_id, user_id, body, created_at, updated_at, deleted_at
+			)
+			values (?, ?, ?, ?, ?, ?, null)
+			""",
+			commentId,
+			postId,
+			userId,
+			body,
+			createdAt,
+			createdAt
+		);
+		return commentId;
+	}
+
+	private UUID insertPostVote(UUID userId, UUID postId, String voteType, OffsetDateTime createdAt) {
+		UUID voteId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into post_votes (
+				id, post_id, user_id, vote_type, canceled_at, created_at, updated_at
+			)
+			values (?, ?, ?, ?, null, ?, ?)
+			""",
+			voteId,
+			postId,
+			userId,
+			voteType,
+			createdAt,
+			createdAt
+		);
+		return voteId;
 	}
 
 	private UUID insertUnreadNotification(UUID userId, OffsetDateTime now) {

--- a/src/test/java/com/sagongsa/backend/dev/DevQaControllerIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/dev/DevQaControllerIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.sagongsa.backend.dev;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -43,6 +44,113 @@ class DevQaControllerIntegrationTest extends PostgreSqlContainerTest {
 	@BeforeEach
 	void setUp() {
 		jdbcTemplate.execute("truncate table users cascade");
+	}
+
+	@Test
+	void feedReadyScenarioCreatesMinePeerCommentAndVoteState() throws Exception {
+		String body = mockMvc.perform(post("/api/dev/qa/scenarios/feed-ready"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.postIds.length()").value(2))
+			.andExpect(jsonPath("$.commentIds.length()").value(1))
+			.andExpect(jsonPath("$.voteIds.length()").value(1))
+			.andExpect(jsonPath("$.paths.feed").value("/api/v1/social/posts"))
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		UUID userId = UUID.fromString(objectMapper.readTree(body).get("userId").asText());
+		UUID peerUserId = UUID.fromString(objectMapper.readTree(body).get("peerUserId").asText());
+		UUID myPostId = UUID.fromString(objectMapper.readTree(body).get("myPostId").asText());
+		UUID peerPostId = UUID.fromString(objectMapper.readTree(body).get("peerPostId").asText());
+
+		mockMvc.perform(get("/api/v1/social/posts")
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.posts.length()").value(2));
+
+		mockMvc.perform(get("/api/v1/social/posts/{postId}", peerPostId)
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.mine").value(false))
+			.andExpect(jsonPath("$.myVote").value("GO"))
+			.andExpect(jsonPath("$.goCount").value(1))
+			.andExpect(jsonPath("$.commentCount").value(1));
+
+		mockMvc.perform(post("/api/v1/social/posts/{postId}/votes", myPostId)
+				.header(USER_ID_HEADER, userId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"voteType":"GO"}
+					"""))
+			.andExpect(status().isForbidden());
+
+		mockMvc.perform(get("/api/v1/social/posts/{postId}", myPostId)
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.mine").value(true))
+			.andExpect(jsonPath("$.myVote").value(nullValue()))
+			.andExpect(jsonPath("$.goCount").value(0));
+
+		mockMvc.perform(get("/api/v1/social/posts/{postId}/comments", peerPostId)
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.total").value(1))
+			.andExpect(jsonPath("$.comments[0].mine").value(true));
+
+		mockMvc.perform(get("/api/v1/users/me/posts")
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.posts[0].id").value(myPostId.toString()))
+			.andExpect(jsonPath("$.posts[0].mine").value(true));
+
+		mockMvc.perform(get("/api/v1/users/me/votes")
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.posts[0].id").value(peerPostId.toString()))
+			.andExpect(jsonPath("$.posts[0].myVote").value("GO"));
+
+		mockMvc.perform(delete("/api/dev/qa/users/{userId}", userId))
+			.andExpect(status().isNoContent());
+		mockMvc.perform(delete("/api/dev/qa/users/{userId}", peerUserId))
+			.andExpect(status().isNoContent());
+
+		assertThat(queryInteger("select count(*) from users where id in (?, ?)", userId, peerUserId)).isZero();
+		assertThat(queryInteger("select count(*) from feed_posts where id in (?, ?)", myPostId, peerPostId)).isZero();
+	}
+
+	@Test
+	void mypageConsumptionScenarioSupportsStatsMonthsAndWishHistory() throws Exception {
+		String body = mockMvc.perform(post("/api/dev/qa/scenarios/mypage-consumption"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.paths.statsMonths").value("/api/v1/users/me/stats/months"))
+			.andExpect(jsonPath("$.paths.stats").exists())
+			.andExpect(jsonPath("$.paths.wishHistory").exists())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		UUID userId = UUID.fromString(objectMapper.readTree(body).get("userId").asText());
+		String yearMonth = objectMapper.readTree(body).get("yearMonth").asText();
+
+		mockMvc.perform(get("/api/v1/users/me/stats/months")
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.months").isArray())
+			.andExpect(jsonPath("$.months[0]").value(yearMonth));
+
+		mockMvc.perform(get("/api/v1/users/me/stats")
+				.header(USER_ID_HEADER, userId)
+				.param("yearMonth", yearMonth))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.yearMonth").value(yearMonth))
+			.andExpect(jsonPath("$.boughtCount").value(2))
+			.andExpect(jsonPath("$.restrainedCount").value(2));
+
+		mockMvc.perform(get("/api/v1/users/me/wishes/history")
+				.header(USER_ID_HEADER, userId)
+				.param("yearMonth", yearMonth))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.wishes.length()").value(4));
 	}
 
 	@Test


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-63`
- Jira: https://parkjaehong.atlassian.net/browse/NF-63
- GitHub: Related #136
- GitHub: Closes # (Final PR만)

> PR 제목: `NF-63 QA 피드 마이페이지 상태팩 추가`
> 브랜치: `feat/NF-63-qa-feed-pack`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #136의 4/5 단계
- 선행 PR: #139
- 후속 PR: #141

### 이 PR에서 변경한 것
- `POST /api/dev/qa/scenarios/feed-ready`를 추가했습니다.
- QA viewer와 peer 유저를 생성하고 다음 피드 상태를 구성합니다.
  - viewer 본인 게시글
  - peer 게시글
  - viewer가 peer 게시글에 남긴 댓글
  - viewer가 peer 게시글에 남긴 GO 투표
- `POST /api/dev/qa/scenarios/mypage-consumption`을 추가했습니다.
- 마이페이지 통계 월 목록, 통계 상세, 위시 히스토리 조회용 GO/STOP 소비 데이터를 생성합니다.
- 응답에 viewer/peer cleanup path와 피드/내 게시글/내 투표/마이페이지 path를 포함했습니다.
- 피드 목록, 게시글 상세, 댓글 목록, 내 게시글, 내 투표, 마이페이지 소비 API smoke를 추가했습니다.
- 본인 게시글 투표 금지 상태도 QA 시나리오 테스트에서 확인했습니다.

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
- AC3: 피드/마이페이지 QA가 사용할 주요 ID와 API path 응답 확장
- AC9: 본인 게시글/타인 게시글/투표/댓글이 포함된 피드 상태 생성
- AC10: viewer/peer QA 유저 cleanup 검증
- AC11: 피드 및 마이페이지 소비 상태팩 통합 테스트 추가
- NF-63 QA 시트의 `mypage-consumption` 계열 조회 API smoke 보강

### Not covered (후속 작업)
- 문서/Swagger/dev static 정리는 후속 PR

---

## 🧪 테스트 결과 (필수)
### 로컬
```
./gradlew test --tests com.sagongsa.backend.dev.DevQaControllerIntegrationTest --no-daemon
./gradlew test --no-daemon
```
- ✅ 결과: 통과

### CI
- 이 PR은 stacked PR이라 base가 feature branch입니다.
- 현재 workflow는 `develop` 대상 PR에서 자동 실행되므로, 이 PR은 로컬 테스트 결과와 하위 develop-base PR CI를 함께 확인합니다.

### Smoke 테스트
- 시나리오: feed-ready 생성 후 social feed, post detail, comments, my posts, my votes 조회
- 결과: ✅ 본인/타인 게시글, GO 투표, 댓글, 마이페이지 피드 조회 상태 확인
- 시나리오: viewer가 본인 게시글에 투표 시도
- 결과: ✅ 403 반환, 본인 게시글 투표 카운트 유지
- 시나리오: mypage-consumption 생성 후 stats months, stats, wishes history 조회
- 결과: ✅ 현재 월 통계와 GO/STOP 위시 히스토리 조회 확인

---

## 🧭 영향 범위 체크 (필수)
- [x] API 변경 (요약: non-prod 전용 `/api/dev/qa/scenarios/feed-ready`, `/api/dev/qa/scenarios/mypage-consumption` 추가)
- [ ] DB 변경 (마이그레이션: 없음)
- [ ] 설정 변경 (항목: 없음)
- [ ] Breaking change (무엇: 없음)

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인: `QaScenarioService#createFeedReadyScenario`, `QaScenarioService#createMypageConsumptionScenario`, `DevQaControllerIntegrationTest#feedReadyScenarioCreatesMinePeerCommentAndVoteState`, `DevQaControllerIntegrationTest#mypageConsumptionScenarioSupportsStatsMonthsAndWishHistory`
- 트레이드오프/대안: 마이페이지 소비 상태팩은 기존 결정 조합 seed를 재사용하고, 마이페이지 조회 path를 별도로 응답에 추가했습니다.