### PR TITLE
[docs] NF-63 QA 시나리오 사용법 문서 추가

### DIFF
--- a/docs/issues/NF-63-qa-scenario-pack.md
+++ b/docs/issues/NF-63-qa-scenario-pack.md
@@ -1,0 +1,164 @@
+# NF-63 Dev QA Scenario Pack
+
+`/api/dev/qa/**`는 non-prod profile에서만 사용하는 QA seed API다.
+운영 데이터나 실제 사용자 데이터는 대상으로 삼지 않는다.
+
+## 공통 사용법
+
+모든 시나리오는 응답의 `userId`를 이후 조회 API의 `X-User-Id` 헤더로 사용한다.
+
+```http
+X-User-Id: {userId}
+```
+
+생성된 QA 유저는 `QA너굴` prefix를 가진다.
+QA cleanup 허용 여부는 `social_accounts.provider_user_id = DEV_QA:{userId}` marker로 판별한다.
+정리는 응답의 `paths.cleanup`으로 수행한다.
+
+```http
+DELETE /api/dev/qa/users/{userId}
+```
+
+`feed-ready`처럼 peer 유저를 함께 만드는 시나리오는 `paths.peerCleanup`도 같이 호출한다.
+
+## API 목록
+
+### QA 유저만 생성
+
+```http
+POST /api/dev/qa/users
+```
+
+생성 상태:
+
+- ACTIVE / COMPLETED 유저
+- user profile
+- notification settings
+- mascot profile
+- 현재 월 budget cycle
+
+### Basic 상태팩
+
+```http
+POST /api/dev/qa/scenarios/basic
+```
+
+확인 가능한 화면/API:
+
+- `GET /api/v1/home/summary`
+- `GET /api/v1/notifications`
+- `GET /api/v1/wishlist/items`
+- `GET /api/v1/deliberations/items/{deliberationItemId}`
+
+생성 상태:
+
+- 예산 초과 홈 상태
+- 읽지 않은 `BUDGET_WARNING` 알림
+- 위시 목록용 `SAVED` 상품
+- 숙려 진입용 상품
+- 유사 카테고리 소비금액 계산용 GO 결정
+
+### 결정 조합 상태팩
+
+```http
+POST /api/dev/qa/scenarios/result-combinations
+```
+
+확인 가능한 화면/API:
+
+- `GET /api/v1/my/consumption?month={yearMonth}`
+
+생성 상태:
+
+- GO + RATIONAL
+- GO + IRRATIONAL
+- STOP + RATIONAL
+- STOP + IRRATIONAL
+
+### 마이페이지 소비 상태팩
+
+```http
+POST /api/dev/qa/scenarios/mypage-consumption
+```
+
+확인 가능한 화면/API:
+
+- `GET /api/v1/users/me/stats/months`
+- `GET /api/v1/users/me/stats?yearMonth={yearMonth}`
+- `GET /api/v1/users/me/wishes/history?yearMonth={yearMonth}`
+
+생성 상태:
+
+- 결정 조합 상태팩과 같은 GO/STOP + 합리/비합리 4건
+- 현재 월 예산 cycle
+- 통계/월 목록/위시 히스토리 조회용 소비 데이터
+
+### 회고 알림 준비 상태팩
+
+```http
+POST /api/dev/qa/scenarios/regret-notification-ready
+```
+
+생성 상태:
+
+- GO 결정
+- due 상태의 `REGRET_CHECK_7_DAYS` reminder
+
+수동 worker 실행:
+
+```http
+POST /api/dev/qa/reminders/{reminderId}/process
+```
+
+이 endpoint는 해당 reminder의 owner가 QA marker를 가진 유저인지 확인한 뒤 그 reminder 1건만 처리한다.
+
+확인 가능한 화면/API:
+
+- `GET /api/v1/notifications?unreadOnly=true`
+- `POST /api/v1/reflections`
+
+### 피드 상태팩
+
+```http
+POST /api/dev/qa/scenarios/feed-ready
+```
+
+확인 가능한 화면/API:
+
+- `GET /api/v1/social/posts`
+- `GET /api/v1/social/posts/{peerPostId}`
+- `GET /api/v1/social/posts/{peerPostId}/comments`
+- `GET /api/v1/users/me/posts`
+- `GET /api/v1/users/me/votes`
+
+생성 상태:
+
+- viewer 본인 게시글
+- peer 게시글
+- viewer가 peer 게시글에 남긴 댓글
+- viewer가 peer 게시글에 남긴 GO 투표
+- viewer 본인 게시글 투표 시 `403 Forbidden`
+
+정리할 때는 viewer cleanup 후 peer cleanup도 호출한다.
+
+## Cleanup 주의사항
+
+cleanup은 `social_accounts.provider_user_id = DEV_QA:{userId}` marker를 가진 유저만 허용한다.
+일반 dev/test 유저나 실제 사용자 ID를 넘기면 `400 Bad Request`가 반환된다.
+
+권장 순서:
+
+1. 시나리오 응답의 `paths.cleanup` 호출
+2. peer 유저가 있으면 `paths.peerCleanup` 호출
+3. 같은 화면을 다시 확인해야 하면 새 시나리오를 재생성
+
+## Stacked PR
+
+- PR #137: QA 시나리오 골격
+- PR #138: 기본 상태팩
+- PR #139: 결정/회고/알림 worker 상태팩
+- PR #140: 피드/마이페이지 상태팩
+- PR #141: 문서 정리
+
+`develop` base인 PR #137은 GitHub Actions가 자동 실행된다.
+feature branch를 base로 둔 상위 stacked PR은 현재 workflow trigger 대상이 아니므로 로컬 테스트 결과와 최종 develop retarget 이후 CI를 함께 확인한다.


### PR DESCRIPTION
# 📝 Docs PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-63**
- Jira: https://parkjaehong.atlassian.net/browse/NF-63
- GitHub: Closes #136

> PR 제목: `NF-63 Docs: QA 시나리오 사용법 문서 추가`  
> 브랜치: `docs/NF-63-qa-scenario-pack-guide`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #136

---

## 🧩 한눈에 요약 (필수)
### 무엇을 문서화/수정했나?
- `docs/issues/NF-63-qa-scenario-pack.md`를 추가했습니다.
- `/api/dev/qa/**` 공통 사용법, 시나리오별 호출 API, 확인 가능한 조회 API, cleanup 순서를 정리했습니다.
- QA marker 기반 cleanup 정책을 문서화했습니다.
- `mypage-consumption` 시나리오와 `POST /api/dev/qa/reminders/{reminderId}/process` 수동 처리 경로를 반영했습니다.
- stacked PR 구성과 feature-base PR CI 주의사항을 문서에 남겼습니다.

### 왜 필요한가? (대상 독자 / 문제)
- 대상 독자: QA, FE, BE 개발자
- 해결하는 문제: QA seed API가 추가되어도 호출 순서와 정리 방법을 모르면 dev 데이터가 누적되거나 화면 진입 조건을 다시 헷갈릴 수 있습니다.

### 범위(스코프)
- Included:
  - QA 유저 생성
  - basic/result-combinations/mypage-consumption/regret-notification-ready/feed-ready 시나리오 사용법
  - QA reminder 1건 수동 처리
  - cleanup 주의사항
  - stacked PR CI 확인 방식
- Not included:
  - 운영 배포 절차
  - Swagger 커스텀 어노테이션 추가
  - FE 화면 사용법

---

## ✅ Done 체크 (필수)
- [x] Done1: QA 시나리오 API 목록 문서화
- [x] Done2: 시나리오별 확인 가능한 조회 API 문서화
- [x] Done3: cleanup 순서와 QA marker 보호 정책 문서화
- [x] Done4: stacked PR의 CI 확인 방식 문서화

---

## 🔍 검증 (필수)
- [x] 링크/앵커/목차 동작 확인
- [x] 예시 명령어/스크립트가 최신 상태인지 확인
- [x] 민감정보(토큰/내부 URL/개인정보/API 키) 포함 여부 점검
- [x] 용어/표현/정책 기준(있다면) 준수

### Preview / 확인 위치
- 문서 경로: `docs/issues/NF-63-qa-scenario-pack.md`
- 주요 섹션 링크: API 목록, Cleanup 주의사항, Stacked PR

---

## 🧪 테스트 결과 (필수)
### 로컬
```
./gradlew test --no-daemon
```
- ✅ 결과: 통과

### CI
- develop base PR이라 GitHub Actions 자동 실행 대상입니다.

---

## 🧭 영향 범위 (필수)
- [x] 코드/동작 변경 없음
- [x] 운영 절차(런북) 변경 없음
- [ ] 운영 절차(런북) 변경 있음 (요약: )
- [x] 외부 공개 문서 변경 없음
- [ ] 외부 공개 문서 변경 있음 (요약: )
- [x] 설정/환경변수 문서 변경 없음
- [ ] 설정/환경변수 문서 변경 있음 (항목: )

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 문서와 실제 API가 어긋나면 QA가 잘못된 path를 호출할 수 있습니다.

### 롤백
- [x] 단순 revert로 가능
- [ ] 별도 안내/공지 필요 (대상: , 내용: )

---

## 📸 증빙 (선택)
- 스크린샷/문서 렌더링 캡처: 없음
- 전/후 비교(가능하면): 신규 문서 추가

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 섹션/문서: `docs/issues/NF-63-qa-scenario-pack.md`
- 사실관계/절차/보안 관련 체크포인트: `/api/dev/qa/**`가 non-prod 전용이고 cleanup이 QA marker 유저만 허용한다는 안내가 맞는지 확인 부탁드립니다.