### PR TITLE
[fix] NF-63 QA 예산 0원 상태 시나리오 보강

### DIFF
--- a/docs/issues/NF-63-qa-scenario-pack.md
+++ b/docs/issues/NF-63-qa-scenario-pack.md
@@ -58,6 +58,23 @@ POST /api/dev/qa/scenarios/basic
 - 숙려 진입용 상품
 - 유사 카테고리 소비금액 계산용 GO 결정
 
+### 예산 0원 상태팩
+
+```http
+POST /api/dev/qa/scenarios/budget-zero
+```
+
+확인 가능한 화면/API:
+
+- `GET /api/v1/home/summary`
+- `GET /api/v1/users/me/stats?yearMonth={yearMonth}`
+
+생성 상태:
+
+- 현재 월 예산 0원
+- 현재 월 소비금액 0원
+- 마이페이지 통계의 예산 0원 조회 상태
+
 ### 결정 조합 상태팩
 
 ```http

--- a/src/main/java/com/sagongsa/backend/dev/DevQaController.java
+++ b/src/main/java/com/sagongsa/backend/dev/DevQaController.java
@@ -30,6 +30,11 @@ public class DevQaController {
 		return ResponseEntity.ok(qaScenarioService.createBasicScenario());
 	}
 
+	@PostMapping("/scenarios/budget-zero")
+	public ResponseEntity<QaUserScenarioResponse> createBudgetZeroScenario() {
+		return ResponseEntity.ok(qaScenarioService.createBudgetZeroScenario());
+	}
+
 	@PostMapping("/scenarios/result-combinations")
 	public ResponseEntity<QaDecisionScenarioResponse> createResultCombinationsScenario() {
 		return ResponseEntity.ok(qaScenarioService.createResultCombinationsScenario());

--- a/src/main/java/com/sagongsa/backend/dev/QaScenarioService.java
+++ b/src/main/java/com/sagongsa/backend/dev/QaScenarioService.java
@@ -178,6 +178,35 @@ public class QaScenarioService {
 	}
 
 	@Transactional
+	public QaUserScenarioResponse createBudgetZeroScenario() {
+		QaUserScenarioResponse user = createQaUser();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+
+		jdbcTemplate.update(
+			"""
+			update budget_cycles
+			   set monthly_budget_amount = 0,
+			       spent_amount = 0,
+			       updated_at = ?
+			 where id = ?
+			""",
+			now,
+			user.budgetCycleId()
+		);
+
+		Map<String, String> paths = new LinkedHashMap<>(user.paths());
+		paths.put("stats", "/api/v1/users/me/stats?yearMonth=" + user.yearMonth());
+
+		return new QaUserScenarioResponse(
+			user.userId(),
+			user.nickname(),
+			user.budgetCycleId(),
+			user.yearMonth(),
+			paths
+		);
+	}
+
+	@Transactional
 	public QaDecisionScenarioResponse createResultCombinationsScenario() {
 		QaUserScenarioResponse user = createQaUser();
 		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);

--- a/src/test/java/com/sagongsa/backend/dev/DevQaControllerIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/dev/DevQaControllerIntegrationTest.java
@@ -154,6 +154,37 @@ class DevQaControllerIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void budgetZeroScenarioSupportsHomeAndMypageBudgetState() throws Exception {
+		String body = mockMvc.perform(post("/api/dev/qa/scenarios/budget-zero"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.paths.home").value("/api/v1/home/summary"))
+			.andExpect(jsonPath("$.paths.stats").exists())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		UUID userId = UUID.fromString(objectMapper.readTree(body).get("userId").asText());
+		String yearMonth = objectMapper.readTree(body).get("yearMonth").asText();
+
+		mockMvc.perform(get("/api/v1/home/summary")
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.budget.monthlyBudgetAmount").value(0))
+			.andExpect(jsonPath("$.budget.spentAmount").value(0))
+			.andExpect(jsonPath("$.budget.remainingAmount").value(0))
+			.andExpect(jsonPath("$.budget.exhausted").value(false));
+
+		mockMvc.perform(get("/api/v1/users/me/stats")
+				.header(USER_ID_HEADER, userId)
+				.param("yearMonth", yearMonth))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.yearMonth").value(yearMonth))
+			.andExpect(jsonPath("$.budgetAmount").value(0))
+			.andExpect(jsonPath("$.spentAmount").value(0))
+			.andExpect(jsonPath("$.usageRate").value(nullValue()));
+	}
+
+	@Test
 	void resultCombinationsScenarioCreatesGoStopAndRationalityCases() throws Exception {
 		String body = mockMvc.perform(post("/api/dev/qa/scenarios/result-combinations"))
 			.andExpect(status().isOk())


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-63**
- Jira: https://parkjaehong.atlassian.net/browse/NF-63
- GitHub: Closes #142
- Related: #136

> PR 제목: `NF-63 QA 예산 0원 상태 시나리오 보강`  
> 브랜치: `fix/NF-63-qa-budget-zero`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #142

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- NF-63 QA Scenario Pack에서 예산 초과 상태는 `basic` 시나리오로 재현 가능했지만, AC5의 예산 0원 상태를 홈/마이페이지 API에서 확인하는 시나리오가 없었습니다.

### 왜 발생했나? (Root Cause)
- 기존 시나리오 분리 과정에서 `basic`은 예산 초과, `mypage-consumption`은 소비 통계 조회에 집중했고, 예산 0원 상태 검증은 별도 seed/test로 빠졌습니다.

### 어떻게 고쳤나?
- `POST /api/dev/qa/scenarios/budget-zero` dev-only 시나리오를 추가했습니다.
- 해당 시나리오는 현재 월 `monthly_budget_amount = 0`, `spent_amount = 0` 상태를 생성합니다.
- 홈 요약과 마이페이지 통계 API에서 예산 0원 상태를 확인하는 통합 테스트를 추가했습니다.
- NF-63 QA 시나리오 문서에 예산 0원 상태팩 사용법을 추가했습니다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법(가능하면)
- Steps:
  1. `origin/develop`에서 `/api/dev/qa/scenarios/**` 목록 확인
  2. 예산 0원 전용 시나리오 또는 테스트 확인
- 기대 결과: 홈/마이페이지 통계에서 예산 0원 상태를 재현할 수 있음
- 실제 결과: 예산 초과 상태만 명시적으로 존재

### 재발 방지(있다면)
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [x] 런북/문서 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] AC1: `POST /api/dev/qa/scenarios/budget-zero` 호출로 QA 유저와 예산 0원 budget cycle이 생성된다.
- [x] AC2: 생성된 `userId`로 `/api/v1/home/summary`에서 예산 0원 상태를 확인할 수 있다.
- [x] AC3: 생성된 `userId`로 `/api/v1/users/me/stats?yearMonth={yearMonth}`에서 마이페이지 예산 0원 상태를 확인할 수 있다.
- [x] AC4: 예산 0원 상태팩 사용법이 NF-63 QA 시나리오 문서에 반영된다.

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command:
```bash
./gradlew test --tests com.sagongsa.backend.dev.DevQaControllerIntegrationTest --no-daemon
./gradlew test --no-daemon
```
- Result: ✅ 통과

### CI
- 링크/결과: develop base PR이라 GitHub Actions 자동 실행 대상입니다.

### Smoke / 수동 검증
- 시나리오: `budget-zero` 생성 후 홈 요약과 마이페이지 통계 조회
- 결과: ✅ `monthlyBudgetAmount=0`, `budgetAmount=0`, `usageRate=null` 확인

### 테스트 공백(있다면 이유 필수)
- 없음

---

## 🧭 영향 범위 (필수)
- [ ] API 스펙 변경 없음
- [x] API 스펙 변경 있음 (요약: non-prod 전용 `/api/dev/qa/scenarios/budget-zero` 추가)
- [x] DB 스키마 변경 없음
- [ ] DB 스키마 변경 있음 (마이그레이션/락/시간: )
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음 (항목: )
- [x] 캐시/큐/외부 연동 영향 없음
- [ ] 캐시/큐/외부 연동 영향 있음 (요약: )

---

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음
- [ ] Breaking change 있음 → 무엇이 깨지는지 / 마이그레이션 / 롤아웃 전략:

---

## 🚀 배포/릴리즈 (해당 시 필수)
### Feature Flag
- [x] 사용 안함
- [ ] 사용함 → Flag/기본값/롤아웃:

### 모니터링/알림
- 확인할 대시보드/지표: dev 서버 `/api/dev/qa/scenarios/budget-zero` 2xx/4xx/5xx
- 에러/로그 키워드: `QaScenario`, `budget-zero`

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- dev-only QA seed API라 운영 영향은 낮습니다.
- 예산 0원 상태에서 API 응답 의미가 달라질 수 있으므로 홈/마이페이지 stats smoke로 고정했습니다.

### 롤백
- [ ] 플래그/설정으로 우회 가능
- [x] 배포 롤백(이전 태그/이미지) 가능
- [ ] 데이터 롤백/역마이그레이션 필요 (절차: )

---

## 📸 증빙 (선택)
- 신규 테스트: `DevQaControllerIntegrationTest#budgetZeroScenarioSupportsHomeAndMypageBudgetState`
- 전/후 비교: 예산 0원 상태팩 신규 추가

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직: `QaScenarioService#createBudgetZeroScenario`, `DevQaControllerIntegrationTest#budgetZeroScenarioSupportsHomeAndMypageBudgetState`
- 트레이드오프/대안: `basic`을 더 키우지 않고 AC5 누락만 별도 시나리오로 좁게 보강했습니다.
- 성능/보안/호환성 영향: non-prod `@Profile("!prod")` 컨트롤러 하위 API라 운영 노출 없음.