### PR TITLE
[chore] NF-64 GitHub Actions CD 파이프라인 구축

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -1,0 +1,47 @@
+name: Deploy QA Backend
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      - name: Grant execute permission for Gradle
+        run: chmod +x ./gradlew
+
+      - name: Build bootJar
+        run: ./gradlew clean bootJar -x test --no-daemon
+
+      - name: Prepare SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.GCP_VM_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "${{ secrets.GCP_VM_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Upload jar
+        run: |
+          scp -i ~/.ssh/deploy_key \
+            build/libs/wigul-backend-0.0.1-SNAPSHOT.jar \
+            ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }}:/home/${{ secrets.GCP_VM_USER }}/404_BE/build/libs/wigul-backend-0.0.1-SNAPSHOT.jar
+
+      - name: Restart service
+        run: |
+          ssh -i ~/.ssh/deploy_key \
+            ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }} \
+            "sudo systemctl restart wigul-backend && sudo systemctl status wigul-backend --no-pager"


### PR DESCRIPTION
# 🧰 Chore PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-64**
- Jira: https://parkjaehong.atlassian.net/browse/NF-64

---

### 🔒 Close Issue (필수)
- GitHub: Closes #144

---

## 🧩 한눈에 요약 (필수)
### 무엇을 변경했나? (인프라/빌드/CI/의존성 등)
- [ ] 인프라
- [x] 설정파일
- [ ] 빌드 파일
- [x] CI
- [x] 런타임/비즈니스 로직 리팩터링 없음 (있으면 Refactor PR 템플릿 사용)

### 왜 필요한가? (안정성/속도/보안/개발경험)
- `develop` 머지 후 QA 백엔드 서버 배포를 GitHub Actions에서 실행할 수 있도록 CD workflow 기준선을 추가합니다.
- 수동 배포 과정에서 발생할 수 있는 빌드 산출물 누락, SSH 업로드 경로 차이, 서비스 재시작 누락을 줄입니다.

### 범위(스코프)
- Included: `.github/workflows/deploy-qa.yml` 추가
- Included: `develop` push 및 수동 실행(`workflow_dispatch`) 트리거 구성
- Included: bootJar 빌드, SSH key 준비, JAR 업로드, `wigul-backend` systemd 서비스 재시작
- Not included: 서버 신규 프로비저닝, GitHub Secrets 실제 값 등록, 무중단 배포 고도화

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `git diff --cached --check`
- Result: 통과
- Command: `python3` + PyYAML로 `.github/workflows/deploy-qa.yml` 파싱
- Result: 통과

### CI
- 링크/결과: PR 생성 후 GitHub Actions 확인 필요

### Smoke / 수동 검증 (해당 시)
- 시나리오: 실제 QA 서버 배포
- 결과: GitHub Secrets 등록 후 `workflow_dispatch`로 확인 필요

### 테스트 공백(있다면 이유 필수)
- 실제 SSH 업로드/서비스 재시작은 `GCP_VM_SSH_KEY`, `GCP_VM_HOST`, `GCP_VM_USER` secret이 GitHub에 등록된 뒤 Actions 환경에서만 검증 가능합니다.

---

## 🧭 영향 범위 (필수)
- [ ] 설정/환경변수 변경 없음
- [x] 설정/환경변수 변경 있음 (항목: GitHub Secrets `GCP_VM_SSH_KEY`, `GCP_VM_HOST`, `GCP_VM_USER` 필요)
- [ ] CI/빌드 파이프라인 영향 없음
- [x] CI/빌드 파이프라인 영향 있음 (요약: `develop` push 시 QA 배포 workflow 실행)
- [x] 의존성(dependency) 변경 없음
- [ ] 의존성(dependency) 변경 있음 (패키지/버전/주요 변경점: )

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- `develop` push마다 QA 배포가 실행되므로 secret 또는 서버 systemd 설정이 맞지 않으면 배포 job이 실패할 수 있습니다.
- 원격 서버의 JAR 경로(`/home/${USER}/404_BE/build/libs/...`)와 서비스명(`wigul-backend`)이 실제 서버 설정과 달라지면 재시작이 실패합니다.
- `bootJar -x test`로 배포 산출물을 만들기 때문에 테스트 검증은 별도 CI workflow 통과를 전제로 합니다.

### 롤백
- [x] 단순 revert로 가능
- [ ] 버전 pin/되돌리기 필요 (대상: , 방법: )
- [x] 배포 롤백(이전 JAR 또는 이전 커밋 재배포) 가능

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/설정: `.github/workflows/deploy-qa.yml`
- 트레이드오프/대안: 최초 CD 기준선이라 무중단 배포나 health check 고도화는 제외하고 SSH 업로드 + systemd restart 방식으로 시작합니다.
- 성능/보안/호환성 영향: SSH private key는 GitHub Secret으로만 주입되며 repository에는 저장하지 않습니다.
