### PR TITLE
[chore] NF-64 QA 배포 SSH 키 처리 방식 수정

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -30,18 +30,27 @@ jobs:
       - name: Prepare SSH
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.GCP_VM_SSH_KEY }}" > ~/.ssh/deploy_key
+          echo "${{ secrets.GCP_VM_SSH_KEY_B64 }}" | base64 -d > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H "${{ secrets.GCP_VM_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Test SSH connection
+        run: |
+          ssh -i ~/.ssh/deploy_key \
+            -o IdentitiesOnly=yes \
+            ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }} \
+            "whoami && hostname"
 
       - name: Upload jar
         run: |
           scp -i ~/.ssh/deploy_key \
+            -o IdentitiesOnly=yes \
             build/libs/wigul-backend-0.0.1-SNAPSHOT.jar \
             ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }}:/home/${{ secrets.GCP_VM_USER }}/404_BE/build/libs/wigul-backend-0.0.1-SNAPSHOT.jar
 
       - name: Restart service
         run: |
           ssh -i ~/.ssh/deploy_key \
+            -o IdentitiesOnly=yes \
             ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }} \
             "sudo systemctl restart wigul-backend && sudo systemctl status wigul-backend --no-pager"


### PR DESCRIPTION
# 🧰 Chore PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-64**
- Jira: https://parkjaehong.atlassian.net/browse/NF-64
- Related: #145

---

### 🔒 Close Issue (필수)
- GitHub: 후속 수정 PR이라 새로 닫을 이슈 없음

---

## 🧩 한눈에 요약 (필수)
### 무엇을 변경했나? (인프라/빌드/CI/의존성 등)
- [ ] 인프라
- [x] 설정파일
- [ ] 빌드 파일
- [x] CI
- [x] 런타임/비즈니스 로직 리팩터링 없음 (있으면 Refactor PR 템플릿 사용)

### 왜 필요한가? (안정성/속도/보안/개발경험)
- QA 배포용 SSH key secret 값이 base64 인코딩 형태로 변경되어, Actions에서 decode 후 key 파일로 저장해야 합니다.
- SSH 접속/업로드/재시작 단계에서 명시적으로 `IdentitiesOnly=yes`를 사용해 의도한 deploy key만 사용하도록 합니다.
- JAR 업로드 전 SSH 접속 smoke를 추가해 secret/host/user 설정 문제를 더 빠르게 확인합니다.

### 범위(스코프)
- Included: `GCP_VM_SSH_KEY` 대신 `GCP_VM_SSH_KEY_B64` 사용
- Included: `base64 -d`로 deploy key 생성
- Included: `Test SSH connection` 단계 추가
- Included: `ssh`/`scp`에 `-o IdentitiesOnly=yes` 옵션 추가
- Not included: 서버 systemd 설정 변경, GitHub Secret 실제 값 등록, 배포 서버 경로 변경

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `git diff --check`
- Result: 통과
- Command: `python3` + PyYAML로 `.github/workflows/deploy-qa.yml` 파싱
- Result: 통과

### CI
- 링크/결과: PR 생성 후 GitHub Actions 확인 필요

### Smoke / 수동 검증 (해당 시)
- 시나리오: 실제 QA 서버 배포 workflow 실행
- 결과: GitHub Secret `GCP_VM_SSH_KEY_B64` 등록 후 `workflow_dispatch` 또는 `develop` push에서 확인 필요

### 테스트 공백(있다면 이유 필수)
- 실제 SSH 접속은 repository secret과 QA VM 접근 권한이 있는 GitHub Actions 환경에서만 검증 가능합니다.

---

## 🧭 영향 범위 (필수)
- [ ] 설정/환경변수 변경 없음
- [x] 설정/환경변수 변경 있음 (항목: `GCP_VM_SSH_KEY_B64` 필요, 기존 `GCP_VM_SSH_KEY` 미사용)
- [ ] CI/빌드 파이프라인 영향 없음
- [x] CI/빌드 파이프라인 영향 있음 (요약: QA deploy workflow의 SSH key 준비/접속 검증 단계 변경)
- [x] 의존성(dependency) 변경 없음
- [ ] 의존성(dependency) 변경 있음 (패키지/버전/주요 변경점: )

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- `GCP_VM_SSH_KEY_B64` 값이 올바른 private key를 base64 인코딩한 값이 아니면 SSH 준비 단계에서 실패합니다.
- base64 문자열에 줄바꿈/공백이 잘못 포함되면 decode 결과가 깨질 수 있습니다.
- SSH 연결 테스트가 추가되어 secret/네트워크 문제가 있을 경우 JAR 업로드 전에 job이 실패합니다.

### 롤백
- [x] 단순 revert로 가능
- [ ] 버전 pin/되돌리기 필요 (대상: , 방법: )
- [x] 배포 롤백(이전 JAR 또는 이전 커밋 재배포) 가능

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/설정: `.github/workflows/deploy-qa.yml`
- 트레이드오프/대안: GitHub Secret에 raw private key를 저장하는 대신 base64 인코딩 값을 저장하고 Actions에서 decode합니다.
- 성능/보안/호환성 영향: private key는 secret에서만 주입되고, `IdentitiesOnly=yes`로 지정 key 사용을 강제합니다.
