### PR TITLE
[chore] NF-64 QA 배포 상태 확인 sudo 제거

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -53,4 +53,4 @@ jobs:
           ssh -i ~/.ssh/deploy_key \
             -o IdentitiesOnly=yes \
             ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }} \
-            "sudo -n systemctl restart wigul-backend && sudo -n systemctl status wigul-backend --no-pager"
+            "sudo -n systemctl restart wigul-backend && systemctl status wigul-backend --no-pager"


### PR DESCRIPTION
# 🧰 Chore PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-64**
- Jira: https://parkjaehong.atlassian.net/browse/NF-64
- Related: #148

---

### 🔒 Close Issue (필수)
- GitHub: Closes #149

---

## 🧩 한눈에 요약 (필수)
### 무엇을 변경했나? (인프라/빌드/CI/의존성 등)
- [ ] 인프라
- [x] 설정파일
- [ ] 빌드 파일
- [x] CI
- [x] 런타임/비즈니스 로직 리팩터링 없음 (있으면 Refactor PR 템플릿 사용)

### 왜 필요한가? (안정성/속도/보안/개발경험)
- QA 배포 restart 명령은 `sudo -n`으로 유지하되, 상태 확인은 일반 `systemctl status`로 실행하도록 조정합니다.
- 재시작 권한 확인과 상태 출력 명령을 분리해 불필요한 sudo 사용을 줄입니다.

### 범위(스코프)
- Included: `Restart service` 단계에서 `sudo -n systemctl status`를 `systemctl status`로 변경
- Not included: VM sudoers 설정 변경, systemd service 설정 변경, CD workflow 재실행 검증

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `git diff --check`
- Result: 통과
- Command: `python3` + PyYAML로 `.github/workflows/deploy-qa.yml` 파싱
- Result: 통과

### CI
- 링크/결과: PR 생성 후 GitHub Actions 확인 필요

### Smoke / 수동 검증 (해당 시)
- 시나리오: 실제 QA CD workflow 재실행
- 결과: 이 PR 범위에서는 실행하지 않음

### 테스트 공백(있다면 이유 필수)
- 요청 범위가 이슈/PR/머지까지라 CD workflow 재실행 검증은 제외했습니다.

---

## 🧭 영향 범위 (필수)
- [ ] 설정/환경변수 변경 없음
- [x] 설정/환경변수 변경 있음 (항목: CD status command에서 sudo 제거)
- [ ] CI/빌드 파이프라인 영향 없음
- [x] CI/빌드 파이프라인 영향 있음 (요약: QA deploy workflow restart 단계 명령 조정)
- [x] 의존성(dependency) 변경 없음
- [ ] 의존성(dependency) 변경 있음 (패키지/버전/주요 변경점: )

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 원격 유저가 `systemctl status wigul-backend`를 조회할 권한이 없으면 status 단계에서 실패할 수 있습니다.
- restart 자체는 여전히 `sudo -n` 권한에 의존합니다.

### 롤백
- [x] 단순 revert로 가능
- [ ] 버전 pin/되돌리기 필요 (대상: , 방법: )
- [x] 배포 롤백(이전 JAR 또는 이전 커밋 재배포) 가능

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/설정: `.github/workflows/deploy-qa.yml`
- 트레이드오프/대안: status 확인까지 sudo로 묶지 않고, restart만 명시적으로 sudo 권한을 사용합니다.
- 성능/보안/호환성 영향: workflow secret 변경 없음, repository에 민감 정보 저장 없음
