### PR TITLE
[feat] NF-65 신고/차단 모더레이션 처리 추가

### DIFF
--- a/src/main/java/com/sagongsa/backend/auth/AuthApiController.java
+++ b/src/main/java/com/sagongsa/backend/auth/AuthApiController.java
@@ -35,10 +35,14 @@ public class AuthApiController {
 
 	private final JwtTokenService jwtTokenService;
 	private final UserAccountRepository userAccountRepository;
+	private final UserAccessService userAccessService;
 
-	public AuthApiController(JwtTokenService jwtTokenService, UserAccountRepository userAccountRepository) {
+	public AuthApiController(JwtTokenService jwtTokenService,
+		UserAccountRepository userAccountRepository,
+		UserAccessService userAccessService) {
 		this.jwtTokenService = jwtTokenService;
 		this.userAccountRepository = userAccountRepository;
+		this.userAccessService = userAccessService;
 	}
 
 	@GetMapping("/me")
@@ -52,6 +56,7 @@ public class AuthApiController {
 	)
 	public AuthenticatedUserResponse me(Authentication authentication) {
 		SocialUserProfile profile = extractProfile(authentication);
+		userAccessService.assertApiAccessible(profile.userId());
 		List<String> authorities = authentication.getAuthorities().stream()
 			.map(GrantedAuthority::getAuthority)
 			.sorted()

--- a/src/main/java/com/sagongsa/backend/auth/CurrentUserIdArgumentResolver.java
+++ b/src/main/java/com/sagongsa/backend/auth/CurrentUserIdArgumentResolver.java
@@ -22,14 +22,17 @@ class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResolver {
 
 	private final boolean trustedHeaderEnabled;
 	private final String trustedHeaderName;
+	private final UserAccessService userAccessService;
 
 	CurrentUserIdArgumentResolver(
 		@Value("${app.auth.trusted-user-id-header.enabled:false}") boolean trustedHeaderEnabled,
 		@Value("${app.auth.trusted-user-id-header.name:X-User-Id}") String trustedHeaderName,
-		Environment environment
+		Environment environment,
+		UserAccessService userAccessService
 	) {
 		this.trustedHeaderEnabled = trustedHeaderEnabled || !environment.acceptsProfiles(Profiles.of("prod"));
 		this.trustedHeaderName = trustedHeaderName;
+		this.userAccessService = userAccessService;
 	}
 
 	@Override
@@ -48,12 +51,12 @@ class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResolver {
 		Principal principal = webRequest.getUserPrincipal();
 		UUID principalUserId = resolvePrincipalUserId(principal);
 		if (principalUserId != null) {
-			return principalUserId;
+			return validateAccessibleUser(principalUserId);
 		}
 
 		String rawUserId = webRequest.getHeader(trustedHeaderName);
 		if (trustedHeaderEnabled && StringUtils.hasText(rawUserId)) {
-			return parseUserId(rawUserId, trustedHeaderName + " header");
+			return validateAccessibleUser(parseUserId(rawUserId, trustedHeaderName + " header"));
 		}
 
 		if (trustedHeaderEnabled) {
@@ -88,5 +91,10 @@ class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResolver {
 			return parseUserId(principal.getName(), "authenticated principal");
 		}
 		return null;
+	}
+
+	private UUID validateAccessibleUser(UUID userId) {
+		userAccessService.assertApiAccessible(userId);
+		return userId;
 	}
 }

--- a/src/main/java/com/sagongsa/backend/auth/JwtTokenService.java
+++ b/src/main/java/com/sagongsa/backend/auth/JwtTokenService.java
@@ -35,20 +35,24 @@ public class JwtTokenService {
 	private final JwtDecoder jwtDecoder;
 	private final AppAuthProperties properties;
 	private final JdbcTemplate jdbcTemplate;
+	private final UserAccessService userAccessService;
 
 	public JwtTokenService(
 		JwtEncoder jwtEncoder,
 		JwtDecoder jwtDecoder,
 		AppAuthProperties properties,
-		JdbcTemplate jdbcTemplate
+		JdbcTemplate jdbcTemplate,
+		UserAccessService userAccessService
 	) {
 		this.jwtEncoder = jwtEncoder;
 		this.jwtDecoder = jwtDecoder;
 		this.properties = properties;
 		this.jdbcTemplate = jdbcTemplate;
+		this.userAccessService = userAccessService;
 	}
 
 	public TokenPair issueTokenPair(SocialUserProfile profile, Collection<? extends GrantedAuthority> authorities) {
+		userAccessService.assertTokenIssueAllowed(profile.userId());
 		Instant issuedAt = Instant.now();
 		List<String> authorityNames = normalizeAuthorities(authorities);
 
@@ -79,9 +83,9 @@ public class JwtTokenService {
 		if (!"refresh".equals(tokenType)) {
 			throw new BadCredentialsException("Invalid refresh token");
 		}
-		consumeRefreshToken(refreshToken);
-
 		SocialUserProfile profile = SocialUserProfile.fromTokenClaims(jwt.getClaims());
+		userAccessService.assertTokenIssueAllowed(profile.userId());
+		consumeRefreshToken(refreshToken);
 		List<String> authorityNames = jwt.getClaimAsStringList("authorities");
 		List<GrantedAuthority> authorities = authorityNames == null
 			? List.of(new SimpleGrantedAuthority("ROLE_USER"))

--- a/src/main/java/com/sagongsa/backend/auth/SocialAccountLinkService.java
+++ b/src/main/java/com/sagongsa/backend/auth/SocialAccountLinkService.java
@@ -7,6 +7,7 @@ import com.sagongsa.backend.domain.auth.UserAccountRepository;
 import com.sagongsa.backend.domain.enums.SocialProvider;
 import com.sagongsa.backend.domain.enums.UserStatus;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,13 +16,16 @@ public class SocialAccountLinkService {
 
 	private final SocialAccountRepository socialAccountRepository;
 	private final UserAccountRepository userAccountRepository;
+	private final UserAccessService userAccessService;
 
 	public SocialAccountLinkService(
 		SocialAccountRepository socialAccountRepository,
-		UserAccountRepository userAccountRepository
+		UserAccountRepository userAccountRepository,
+		UserAccessService userAccessService
 	) {
 		this.socialAccountRepository = socialAccountRepository;
 		this.userAccountRepository = userAccountRepository;
+		this.userAccessService = userAccessService;
 	}
 
 	@Transactional
@@ -39,6 +43,9 @@ public class SocialAccountLinkService {
 		if (linkedUser.getStatus() == UserStatus.WITHDRAWN) {
 			linkedUser = userAccountRepository.save(UserAccount.create());
 			existingAccount.relinkUser(linkedUser);
+		}
+		if (!userAccessService.isAccessible(linkedUser)) {
+			throw new DisabledException("User account is restricted");
 		}
 		return profile.withUserId(linkedUser.getId());
 	}

--- a/src/main/java/com/sagongsa/backend/auth/UserAccessService.java
+++ b/src/main/java/com/sagongsa/backend/auth/UserAccessService.java
@@ -1,0 +1,50 @@
+package com.sagongsa.backend.auth;
+
+import com.sagongsa.backend.domain.auth.UserAccount;
+import com.sagongsa.backend.domain.auth.UserAccountRepository;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class UserAccessService {
+
+	private final UserAccountRepository userAccountRepository;
+
+	public UserAccessService(UserAccountRepository userAccountRepository) {
+		this.userAccountRepository = userAccountRepository;
+	}
+
+	@Transactional
+	public void assertApiAccessible(UUID userId) {
+		userAccountRepository.findById(userId)
+			.ifPresent(user -> {
+				if (!isAccessible(user)) {
+					throw new ResponseStatusException(HttpStatus.FORBIDDEN, "이용이 제한된 계정입니다.");
+				}
+			});
+	}
+
+	@Transactional
+	public void assertTokenIssueAllowed(UUID userId) {
+		if (userId == null) {
+			throw new BadCredentialsException("User account is required");
+		}
+		UserAccount user = userAccountRepository.findById(userId)
+			.orElseThrow(() -> new BadCredentialsException("User account is not available"));
+		if (!isAccessible(user)) {
+			throw new BadCredentialsException("User account is restricted");
+		}
+	}
+
+	@Transactional
+	public boolean isAccessible(UserAccount user) {
+		Instant now = Instant.now();
+		user.activateIfSuspensionExpiredAt(now);
+		return user.canAccessAt(now);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/domain/auth/UserAccount.java
+++ b/src/main/java/com/sagongsa/backend/domain/auth/UserAccount.java
@@ -25,6 +25,12 @@ public class UserAccount extends BaseEntity {
 	@Column
 	private Instant withdrawnAt;
 
+	@Column
+	private Instant suspendedUntil;
+
+	@Column
+	private Instant bannedAt;
+
 	protected UserAccount() {
 	}
 
@@ -44,8 +50,51 @@ public class UserAccount extends BaseEntity {
 		return withdrawnAt;
 	}
 
+	public Instant getSuspendedUntil() {
+		return suspendedUntil;
+	}
+
+	public Instant getBannedAt() {
+		return bannedAt;
+	}
+
+	public boolean canAccessAt(Instant now) {
+		if (status == UserStatus.ACTIVE) {
+			return true;
+		}
+		if (status == UserStatus.SUSPENDED) {
+			return suspendedUntil != null && !suspendedUntil.isAfter(now);
+		}
+		return false;
+	}
+
+	public boolean activateIfSuspensionExpiredAt(Instant now) {
+		if (status == UserStatus.SUSPENDED && suspendedUntil != null && !suspendedUntil.isAfter(now)) {
+			this.status = UserStatus.ACTIVE;
+			this.suspendedUntil = null;
+			return true;
+		}
+		return false;
+	}
+
+	public void suspendUntil(Instant suspendedUntil) {
+		this.status = UserStatus.SUSPENDED;
+		this.suspendedUntil = suspendedUntil;
+		this.bannedAt = null;
+		this.withdrawnAt = null;
+	}
+
+	public void banPermanently() {
+		this.status = UserStatus.BANNED;
+		this.bannedAt = Instant.now();
+		this.suspendedUntil = null;
+		this.withdrawnAt = null;
+	}
+
 	public void withdraw() {
 		this.status = UserStatus.WITHDRAWN;
 		this.withdrawnAt = Instant.now();
+		this.suspendedUntil = null;
+		this.bannedAt = null;
 	}
 }

--- a/src/main/java/com/sagongsa/backend/domain/enums/ModerationStatus.java
+++ b/src/main/java/com/sagongsa/backend/domain/enums/ModerationStatus.java
@@ -1,0 +1,8 @@
+package com.sagongsa.backend.domain.enums;
+
+public enum ModerationStatus {
+	ACTIVE,
+	BLINDED,
+	REVIEW_PENDING,
+	REMOVED
+}

--- a/src/main/java/com/sagongsa/backend/domain/enums/ReportCategory.java
+++ b/src/main/java/com/sagongsa/backend/domain/enums/ReportCategory.java
@@ -1,10 +1,12 @@
 package com.sagongsa.backend.domain.enums;
 
 public enum ReportCategory {
-    PROFANITY,  // 욕설/비방
-    SPAM,       // 광고/스팸
-    OBSCENE,    // 음란성
-    PRIVACY,    // 개인정보 노출
-    ILLEGAL_INFORMATION, // 불법 정보 공유
-    OTHER       // 기타(직접 입력)
+	PROFANITY,  // 욕설/비방
+	DEFAMATION, // 명예훼손
+	OBSCENE,    // 음란물
+	SPAM,       // 도배
+	ADVERTISING, // 부적절한 광고
+	PRIVACY,    // 개인정보 노출
+	ILLEGAL_INFORMATION, // 불법 정보 공유
+	OTHER       // 기타(직접 입력)
 }

--- a/src/main/java/com/sagongsa/backend/domain/enums/UserSanctionType.java
+++ b/src/main/java/com/sagongsa/backend/domain/enums/UserSanctionType.java
@@ -1,0 +1,7 @@
+package com.sagongsa.backend.domain.enums;
+
+public enum UserSanctionType {
+	WARNING,
+	SUSPENSION,
+	PERMANENT_BAN
+}

--- a/src/main/java/com/sagongsa/backend/domain/enums/UserStatus.java
+++ b/src/main/java/com/sagongsa/backend/domain/enums/UserStatus.java
@@ -3,5 +3,6 @@ package com.sagongsa.backend.domain.enums;
 public enum UserStatus {
 	ACTIVE,
 	SUSPENDED,
+	BANNED,
 	WITHDRAWN
 }

--- a/src/main/java/com/sagongsa/backend/domain/social/FeedPost.java
+++ b/src/main/java/com/sagongsa/backend/domain/social/FeedPost.java
@@ -3,9 +3,12 @@ package com.sagongsa.backend.domain.social;
 import com.sagongsa.backend.domain.auth.UserAccount;
 import com.sagongsa.backend.domain.common.UserScopedEntity;
 import com.sagongsa.backend.domain.decision.PurchaseDecision;
+import com.sagongsa.backend.domain.enums.ModerationStatus;
 import com.sagongsa.backend.domain.item.SavedItem;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
@@ -52,6 +55,13 @@ public class FeedPost extends UserScopedEntity {
 	@Column
 	private Instant deletedAt;
 
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private ModerationStatus moderationStatus = ModerationStatus.ACTIVE;
+
+	@Column
+	private Instant moderationStatusUpdatedAt;
+
 	protected FeedPost() {
 	}
 
@@ -78,10 +88,33 @@ public class FeedPost extends UserScopedEntity {
 	public int getGoCount() { return goCount; }
 	public int getStopCount() { return stopCount; }
 	public Instant getDeletedAt() { return deletedAt; }
+	public ModerationStatus getModerationStatus() { return moderationStatus; }
 
 	public boolean isDeleted() { return deletedAt != null; }
+	public boolean isRemovedByModeration() { return moderationStatus == ModerationStatus.REMOVED; }
+	public boolean isVisible() { return deletedAt == null && moderationStatus == ModerationStatus.ACTIVE; }
 
 	public void softDelete() { this.deletedAt = Instant.now(); }
+
+	public void applyReportCount(long reportCount) {
+		if (moderationStatus == ModerationStatus.REMOVED) {
+			return;
+		}
+		if (reportCount >= 5) {
+			updateModerationStatus(ModerationStatus.REVIEW_PENDING);
+			return;
+		}
+		if (reportCount >= 3) {
+			updateModerationStatus(ModerationStatus.BLINDED);
+		}
+	}
+
+	private void updateModerationStatus(ModerationStatus nextStatus) {
+		if (moderationStatus != nextStatus) {
+			moderationStatus = nextStatus;
+			moderationStatusUpdatedAt = Instant.now();
+		}
+	}
 
 	public void updateBody(String body) { this.body = body; }
 

--- a/src/main/java/com/sagongsa/backend/domain/social/FeedPostRepository.java
+++ b/src/main/java/com/sagongsa/backend/domain/social/FeedPostRepository.java
@@ -11,25 +11,25 @@ import org.springframework.data.repository.query.Param;
 
 public interface FeedPostRepository extends JpaRepository<FeedPost, UUID> {
 
-	@Query("SELECT p FROM FeedPost p LEFT JOIN FETCH p.item WHERE p.deletedAt IS NULL ORDER BY p.createdAt DESC")
+	@Query("SELECT p FROM FeedPost p LEFT JOIN FETCH p.item WHERE p.deletedAt IS NULL AND p.moderationStatus = com.sagongsa.backend.domain.enums.ModerationStatus.ACTIVE ORDER BY p.createdAt DESC")
 	List<FeedPost> findAllVisible(Pageable pageable);
 
-	@Query("SELECT p FROM FeedPost p LEFT JOIN FETCH p.item WHERE p.deletedAt IS NULL AND p.createdAt < :cursor ORDER BY p.createdAt DESC")
+	@Query("SELECT p FROM FeedPost p LEFT JOIN FETCH p.item WHERE p.deletedAt IS NULL AND p.moderationStatus = com.sagongsa.backend.domain.enums.ModerationStatus.ACTIVE AND p.createdAt < :cursor ORDER BY p.createdAt DESC")
 	List<FeedPost> findAllVisibleBefore(@Param("cursor") Instant cursor, Pageable pageable);
 
-	@Query("SELECT p FROM FeedPost p LEFT JOIN FETCH p.item WHERE p.deletedAt IS NULL AND p.user.id NOT IN :excludedIds ORDER BY p.createdAt DESC")
+	@Query("SELECT p FROM FeedPost p LEFT JOIN FETCH p.item WHERE p.deletedAt IS NULL AND p.moderationStatus = com.sagongsa.backend.domain.enums.ModerationStatus.ACTIVE AND p.user.id NOT IN :excludedIds ORDER BY p.createdAt DESC")
 	List<FeedPost> findAllVisibleExcluding(@Param("excludedIds") List<UUID> excludedIds, Pageable pageable);
 
-	@Query("SELECT p FROM FeedPost p LEFT JOIN FETCH p.item WHERE p.deletedAt IS NULL AND p.createdAt < :cursor AND p.user.id NOT IN :excludedIds ORDER BY p.createdAt DESC")
+	@Query("SELECT p FROM FeedPost p LEFT JOIN FETCH p.item WHERE p.deletedAt IS NULL AND p.moderationStatus = com.sagongsa.backend.domain.enums.ModerationStatus.ACTIVE AND p.createdAt < :cursor AND p.user.id NOT IN :excludedIds ORDER BY p.createdAt DESC")
 	List<FeedPost> findAllVisibleBeforeExcluding(@Param("cursor") Instant cursor, @Param("excludedIds") List<UUID> excludedIds, Pageable pageable);
 
-	@Query("SELECT p FROM FeedPost p LEFT JOIN FETCH p.item WHERE p.user.id = :userId AND p.deletedAt IS NULL ORDER BY p.createdAt DESC")
+	@Query("SELECT p FROM FeedPost p LEFT JOIN FETCH p.item WHERE p.user.id = :userId AND p.deletedAt IS NULL AND p.moderationStatus = com.sagongsa.backend.domain.enums.ModerationStatus.ACTIVE ORDER BY p.createdAt DESC")
 	List<FeedPost> findByUserIdVisible(@Param("userId") UUID userId, Pageable pageable);
 
-	@Query("SELECT p FROM FeedPost p LEFT JOIN FETCH p.item WHERE p.user.id = :userId AND p.deletedAt IS NULL AND p.createdAt < :cursor ORDER BY p.createdAt DESC")
+	@Query("SELECT p FROM FeedPost p LEFT JOIN FETCH p.item WHERE p.user.id = :userId AND p.deletedAt IS NULL AND p.moderationStatus = com.sagongsa.backend.domain.enums.ModerationStatus.ACTIVE AND p.createdAt < :cursor ORDER BY p.createdAt DESC")
 	List<FeedPost> findByUserIdVisibleBefore(@Param("userId") UUID userId, @Param("cursor") Instant cursor, Pageable pageable);
 
-	long countByUserIdAndDeletedAtIsNull(UUID userId);
+	long countByUserIdAndDeletedAtIsNullAndModerationStatus(UUID userId, com.sagongsa.backend.domain.enums.ModerationStatus moderationStatus);
 
 	@Modifying
 	@Query("UPDATE FeedPost p SET p.deletedAt = CURRENT_TIMESTAMP WHERE p.user.id = :userId")

--- a/src/main/java/com/sagongsa/backend/domain/social/PostComment.java
+++ b/src/main/java/com/sagongsa/backend/domain/social/PostComment.java
@@ -2,8 +2,11 @@ package com.sagongsa.backend.domain.social;
 
 import com.sagongsa.backend.domain.auth.UserAccount;
 import com.sagongsa.backend.domain.common.BaseEntity;
+import com.sagongsa.backend.domain.enums.ModerationStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
@@ -34,6 +37,13 @@ public class PostComment extends BaseEntity {
 	@Column
 	private Instant deletedAt;
 
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private ModerationStatus moderationStatus = ModerationStatus.ACTIVE;
+
+	@Column
+	private Instant moderationStatusUpdatedAt;
+
 	protected PostComment() {
 	}
 
@@ -47,8 +57,31 @@ public class PostComment extends BaseEntity {
 	public UserAccount getUser() { return user; }
 	public String getBody() { return body; }
 	public Instant getDeletedAt() { return deletedAt; }
+	public ModerationStatus getModerationStatus() { return moderationStatus; }
 
 	public boolean isDeleted() { return deletedAt != null; }
+	public boolean isRemovedByModeration() { return moderationStatus == ModerationStatus.REMOVED; }
+	public boolean isVisible() { return deletedAt == null && moderationStatus == ModerationStatus.ACTIVE; }
 
 	public void softDelete() { this.deletedAt = Instant.now(); }
+
+	public void applyReportCount(long reportCount) {
+		if (moderationStatus == ModerationStatus.REMOVED) {
+			return;
+		}
+		if (reportCount >= 5) {
+			updateModerationStatus(ModerationStatus.REVIEW_PENDING);
+			return;
+		}
+		if (reportCount >= 3) {
+			updateModerationStatus(ModerationStatus.BLINDED);
+		}
+	}
+
+	private void updateModerationStatus(ModerationStatus nextStatus) {
+		if (moderationStatus != nextStatus) {
+			moderationStatus = nextStatus;
+			moderationStatusUpdatedAt = Instant.now();
+		}
+	}
 }

--- a/src/main/java/com/sagongsa/backend/domain/social/PostCommentRepository.java
+++ b/src/main/java/com/sagongsa/backend/domain/social/PostCommentRepository.java
@@ -11,21 +11,21 @@ import org.springframework.data.repository.query.Param;
 
 public interface PostCommentRepository extends JpaRepository<PostComment, UUID> {
 
-	@Query("SELECT c FROM PostComment c WHERE c.post.id = :postId AND c.deletedAt IS NULL ORDER BY c.createdAt ASC")
+	@Query("SELECT c FROM PostComment c WHERE c.post.id = :postId AND c.deletedAt IS NULL AND c.moderationStatus = com.sagongsa.backend.domain.enums.ModerationStatus.ACTIVE ORDER BY c.createdAt ASC")
 	Page<PostComment> findVisibleByPostId(@Param("postId") UUID postId, Pageable pageable);
 
-	@Query("SELECT c FROM PostComment c WHERE c.post.id = :postId AND c.deletedAt IS NULL AND c.user.id NOT IN :blockedIds ORDER BY c.createdAt ASC")
+	@Query("SELECT c FROM PostComment c WHERE c.post.id = :postId AND c.deletedAt IS NULL AND c.moderationStatus = com.sagongsa.backend.domain.enums.ModerationStatus.ACTIVE AND c.user.id NOT IN :blockedIds ORDER BY c.createdAt ASC")
 	Page<PostComment> findVisibleByPostIdExcludingBlockers(@Param("postId") UUID postId, @Param("blockedIds") List<UUID> blockedIds, Pageable pageable);
 
 	long countByPostIdAndDeletedAtIsNull(UUID postId);
 
-	@Query("SELECT new com.sagongsa.backend.domain.social.PostCommentCount(c.post.id, COUNT(c)) FROM PostComment c WHERE c.post.id IN :postIds AND c.deletedAt IS NULL GROUP BY c.post.id")
+	@Query("SELECT new com.sagongsa.backend.domain.social.PostCommentCount(c.post.id, COUNT(c)) FROM PostComment c WHERE c.post.id IN :postIds AND c.deletedAt IS NULL AND c.moderationStatus = com.sagongsa.backend.domain.enums.ModerationStatus.ACTIVE GROUP BY c.post.id")
 	List<PostCommentCount> countVisibleByPostIds(@Param("postIds") List<UUID> postIds);
 
-	@Query("SELECT new com.sagongsa.backend.domain.social.PostCommentCount(c.post.id, COUNT(c)) FROM PostComment c WHERE c.post.id IN :postIds AND c.deletedAt IS NULL AND c.user.id NOT IN :blockedIds GROUP BY c.post.id")
+	@Query("SELECT new com.sagongsa.backend.domain.social.PostCommentCount(c.post.id, COUNT(c)) FROM PostComment c WHERE c.post.id IN :postIds AND c.deletedAt IS NULL AND c.moderationStatus = com.sagongsa.backend.domain.enums.ModerationStatus.ACTIVE AND c.user.id NOT IN :blockedIds GROUP BY c.post.id")
 	List<PostCommentCount> countVisibleByPostIdsExcludingBlockers(@Param("postIds") List<UUID> postIds, @Param("blockedIds") List<UUID> blockedIds);
 
-	@Query("SELECT c.user.id FROM PostComment c WHERE c.post.id = :postId AND c.deletedAt IS NULL GROUP BY c.user.id ORDER BY MIN(c.createdAt) ASC")
+	@Query("SELECT c.user.id FROM PostComment c WHERE c.post.id = :postId AND c.deletedAt IS NULL AND c.moderationStatus = com.sagongsa.backend.domain.enums.ModerationStatus.ACTIVE GROUP BY c.user.id ORDER BY MIN(c.createdAt) ASC")
 	List<UUID> findCommenterIdsByPostIdOrderedByFirstComment(@Param("postId") UUID postId);
 
 	@Modifying

--- a/src/main/java/com/sagongsa/backend/domain/social/PostReport.java
+++ b/src/main/java/com/sagongsa/backend/domain/social/PostReport.java
@@ -17,40 +17,50 @@ import java.util.UUID;
 
 @Entity
 @Table(
-    name = "post_reports",
-    uniqueConstraints = @UniqueConstraint(
-        name = "uk_post_reports",
-        columnNames = {"reporter_user_id", "target_type", "target_id"}
-    )
+	name = "post_reports",
+	uniqueConstraints = @UniqueConstraint(
+		name = "uk_post_reports",
+		columnNames = {"reporter_user_id", "target_type", "target_id"}
+	)
 )
 public class PostReport extends BaseEntity {
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "reporter_user_id", nullable = false)
-    private UserAccount reporter;
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "reporter_user_id", nullable = false)
+	private UserAccount reporter;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "target_type", nullable = false, length = 10)
-    private ReportTargetType targetType;
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "reported_user_id", nullable = false)
+	private UserAccount reportedUser;
 
-    @Column(name = "target_id", nullable = false)
-    private UUID targetId;
+	@Enumerated(EnumType.STRING)
+	@Column(name = "target_type", nullable = false, length = 10)
+	private ReportTargetType targetType;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "report_category", nullable = false, length = 20)
-    private ReportCategory reportCategory;
+	@Column(name = "target_id", nullable = false)
+	private UUID targetId;
 
-    @Column(length = 100)
-    private String reason;
+	@Column(name = "post_id")
+	private UUID postId;
 
-    protected PostReport() {}
+	@Enumerated(EnumType.STRING)
+	@Column(name = "report_category", nullable = false, length = 30)
+	private ReportCategory reportCategory;
 
-    public PostReport(UserAccount reporter, ReportTargetType targetType, UUID targetId,
-        ReportCategory reportCategory, String reason) {
-        this.reporter = reporter;
-        this.targetType = targetType;
-        this.targetId = targetId;
-        this.reportCategory = reportCategory;
-        this.reason = reason;
-    }
+	@Column(length = 100)
+	private String reason;
+
+	protected PostReport() {
+	}
+
+	public PostReport(UserAccount reporter, UserAccount reportedUser, ReportTargetType targetType, UUID targetId, UUID postId,
+		ReportCategory reportCategory, String reason) {
+		this.reporter = reporter;
+		this.reportedUser = reportedUser;
+		this.targetType = targetType;
+		this.targetId = targetId;
+		this.postId = postId;
+		this.reportCategory = reportCategory;
+		this.reason = reason;
+	}
 }

--- a/src/main/java/com/sagongsa/backend/domain/social/PostReportRepository.java
+++ b/src/main/java/com/sagongsa/backend/domain/social/PostReportRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostReportRepository extends JpaRepository<PostReport, UUID> {
 
-    boolean existsByReporterIdAndTargetTypeAndTargetId(
-        UUID reporterId, ReportTargetType targetType, UUID targetId);
+	boolean existsByReporterIdAndTargetTypeAndTargetId(
+	    UUID reporterId, ReportTargetType targetType, UUID targetId);
+
+	long countByTargetTypeAndTargetId(ReportTargetType targetType, UUID targetId);
 }

--- a/src/main/java/com/sagongsa/backend/domain/social/PostVoteRepository.java
+++ b/src/main/java/com/sagongsa/backend/domain/social/PostVoteRepository.java
@@ -18,10 +18,10 @@ public interface PostVoteRepository extends JpaRepository<PostVote, UUID> {
 	@Query("SELECT v FROM PostVote v WHERE v.post.id IN :postIds AND v.user.id = :userId")
 	List<PostVote> findByPostIdsAndUserId(@Param("postIds") List<UUID> postIds, @Param("userId") UUID userId);
 
-	@Query("SELECT v FROM PostVote v WHERE v.user.id = :userId AND v.canceledAt IS NULL ORDER BY v.createdAt DESC")
+	@Query("SELECT v FROM PostVote v WHERE v.user.id = :userId AND v.canceledAt IS NULL AND v.post.deletedAt IS NULL AND v.post.moderationStatus = com.sagongsa.backend.domain.enums.ModerationStatus.ACTIVE ORDER BY v.createdAt DESC")
 	List<PostVote> findActiveByUserId(@Param("userId") UUID userId, Pageable pageable);
 
-	@Query("SELECT v FROM PostVote v WHERE v.user.id = :userId AND v.canceledAt IS NULL AND v.createdAt < :cursor ORDER BY v.createdAt DESC")
+	@Query("SELECT v FROM PostVote v WHERE v.user.id = :userId AND v.canceledAt IS NULL AND v.post.deletedAt IS NULL AND v.post.moderationStatus = com.sagongsa.backend.domain.enums.ModerationStatus.ACTIVE AND v.createdAt < :cursor ORDER BY v.createdAt DESC")
 	List<PostVote> findActiveByUserIdBefore(@Param("userId") UUID userId, @Param("cursor") Instant cursor, Pageable pageable);
 
 	@Modifying

--- a/src/main/java/com/sagongsa/backend/mypage/MypageService.java
+++ b/src/main/java/com/sagongsa/backend/mypage/MypageService.java
@@ -8,6 +8,7 @@ import com.sagongsa.backend.domain.budget.BudgetCycle;
 import com.sagongsa.backend.domain.budget.BudgetCycleRepository;
 import com.sagongsa.backend.domain.enums.ItemCategory;
 import com.sagongsa.backend.domain.enums.ItemStatus;
+import com.sagongsa.backend.domain.enums.ModerationStatus;
 import com.sagongsa.backend.domain.item.SavedItemRepository;
 import com.sagongsa.backend.domain.notification.DevicePushTokenRepository;
 import com.sagongsa.backend.domain.social.FeedPostRepository;
@@ -86,7 +87,7 @@ class MypageService {
 		UserAccount user = findUserOrThrow(userId);
 		UserProfile profile = userProfileRepository.findByUserId(userId).orElse(null);
 		SocialAccount social = socialAccountRepository.findByUserId(userId).orElse(null);
-		long postCount = feedPostRepository.countByUserIdAndDeletedAtIsNull(userId);
+		long postCount = feedPostRepository.countByUserIdAndDeletedAtIsNullAndModerationStatus(userId, ModerationStatus.ACTIVE);
 		return MyProfileResponse.of(user, profile, social, postCount);
 	}
 
@@ -100,7 +101,7 @@ class MypageService {
 					request.raccoonName() != null ? request.raccoonName() : "너구리")));
 		profile.updateProfile(request.nickname(), request.raccoonName());
 		SocialAccount social = socialAccountRepository.findByUserId(userId).orElse(null);
-		long postCount = feedPostRepository.countByUserIdAndDeletedAtIsNull(userId);
+		long postCount = feedPostRepository.countByUserIdAndDeletedAtIsNullAndModerationStatus(userId, ModerationStatus.ACTIVE);
 		return MyProfileResponse.of(user, profile, social, postCount);
 	}
 

--- a/src/main/java/com/sagongsa/backend/social/ReportRequest.java
+++ b/src/main/java/com/sagongsa/backend/social/ReportRequest.java
@@ -5,8 +5,8 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 record ReportRequest(
-    @NotNull(message = "신고 사유 항목을 선택해 주세요.")
-    ReportCategory category,
-    @Size(max = 100, message = "신고 사유는 최대 100자까지 가능합니다.")
-    String reason
+	@NotNull(message = "신고 사유 항목을 선택해 주세요.")
+	ReportCategory category,
+	@Size(max = 100, message = "신고 사유는 최대 100자까지 가능합니다.")
+	String reason
 ) {}

--- a/src/main/java/com/sagongsa/backend/social/ReportService.java
+++ b/src/main/java/com/sagongsa/backend/social/ReportService.java
@@ -4,6 +4,8 @@ import com.sagongsa.backend.domain.auth.UserAccount;
 import com.sagongsa.backend.domain.auth.UserAccountRepository;
 import com.sagongsa.backend.domain.enums.ReportCategory;
 import com.sagongsa.backend.domain.enums.ReportTargetType;
+import com.sagongsa.backend.domain.social.FeedPost;
+import com.sagongsa.backend.domain.social.FeedPostRepository;
 import com.sagongsa.backend.domain.social.PostComment;
 import com.sagongsa.backend.domain.social.PostCommentRepository;
 import com.sagongsa.backend.domain.social.PostReport;
@@ -16,67 +18,94 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 class ReportService {
 
-    private final PostReportRepository postReportRepository;
-    private final PostCommentRepository postCommentRepository;
-    private final UserAccountRepository userAccountRepository;
-    private final SocialPostService socialPostService;
+	private final PostReportRepository postReportRepository;
+	private final FeedPostRepository feedPostRepository;
+	private final PostCommentRepository postCommentRepository;
+	private final UserAccountRepository userAccountRepository;
 
-    ReportService(PostReportRepository postReportRepository,
-        PostCommentRepository postCommentRepository,
-        UserAccountRepository userAccountRepository,
-        SocialPostService socialPostService) {
-        this.postReportRepository = postReportRepository;
-        this.postCommentRepository = postCommentRepository;
-        this.userAccountRepository = userAccountRepository;
-        this.socialPostService = socialPostService;
-    }
+	ReportService(PostReportRepository postReportRepository,
+		FeedPostRepository feedPostRepository,
+		PostCommentRepository postCommentRepository,
+		UserAccountRepository userAccountRepository) {
+		this.postReportRepository = postReportRepository;
+		this.feedPostRepository = feedPostRepository;
+		this.postCommentRepository = postCommentRepository;
+		this.userAccountRepository = userAccountRepository;
+	}
 
-    void reportPost(UUID reporterId, UUID postId, ReportCategory category, String reason) {
-        validateReason(category, reason);
-        socialPostService.findPostOrThrow(postId);
-        if (postReportRepository.existsByReporterIdAndTargetTypeAndTargetId(reporterId, ReportTargetType.POST, postId)) {
-            throw new SocialFeedForbiddenException("이미 신고한 게시글입니다.");
-        }
-        UserAccount reporter = findUserOrThrow(reporterId);
-        postReportRepository.save(new PostReport(reporter, ReportTargetType.POST, postId, category, reason));
-    }
+	void reportPost(UUID reporterId, UUID postId, ReportCategory category, String reason) {
+		validateReason(category, reason);
+		FeedPost post = findReportablePostOrThrow(postId);
+		if (post.getUser().getId().equals(reporterId)) {
+			throw new SocialFeedForbiddenException("본인의 게시글은 신고할 수 없습니다.");
+		}
+		if (postReportRepository.existsByReporterIdAndTargetTypeAndTargetId(reporterId, ReportTargetType.POST, postId)) {
+			throw new SocialFeedForbiddenException("이미 신고한 게시글입니다.");
+		}
+		UserAccount reporter = findUserOrThrow(reporterId);
+		postReportRepository.save(
+			new PostReport(reporter, post.getUser(), ReportTargetType.POST, postId, postId, category, reason));
+		long reportCount = postReportRepository.countByTargetTypeAndTargetId(ReportTargetType.POST, postId);
+		post.applyReportCount(reportCount);
+	}
 
-    void reportComment(UUID reporterId, UUID postId, UUID commentId, ReportCategory category, String reason) {
-        validateReason(category, reason);
-        socialPostService.findPostOrThrow(postId);
-        PostComment comment = postCommentRepository.findById(commentId)
-            .orElseThrow(() -> new SocialFeedNotFoundException("댓글을 찾을 수 없습니다."));
-        if (!comment.getPost().getId().equals(postId)) {
-            throw new SocialFeedNotFoundException("댓글을 찾을 수 없습니다.");
-        }
-        if (postReportRepository.existsByReporterIdAndTargetTypeAndTargetId(reporterId, ReportTargetType.COMMENT, commentId)) {
-            throw new SocialFeedForbiddenException("이미 신고한 댓글입니다.");
-        }
-        UserAccount reporter = findUserOrThrow(reporterId);
-        postReportRepository.save(new PostReport(reporter, ReportTargetType.COMMENT, commentId, category, reason));
-    }
+	void reportComment(UUID reporterId, UUID postId, UUID commentId, ReportCategory category, String reason) {
+		validateReason(category, reason);
+		FeedPost post = findReportablePostOrThrow(postId);
+		PostComment comment = findReportableCommentOrThrow(postId, commentId);
+		if (comment.getUser().getId().equals(reporterId)) {
+			throw new SocialFeedForbiddenException("본인의 댓글은 신고할 수 없습니다.");
+		}
+		if (postReportRepository.existsByReporterIdAndTargetTypeAndTargetId(reporterId, ReportTargetType.COMMENT, commentId)) {
+			throw new SocialFeedForbiddenException("이미 신고한 댓글입니다.");
+		}
+		UserAccount reporter = findUserOrThrow(reporterId);
+		postReportRepository.save(
+			new PostReport(reporter, comment.getUser(), ReportTargetType.COMMENT, commentId, post.getId(), category, reason));
+		long reportCount = postReportRepository.countByTargetTypeAndTargetId(ReportTargetType.COMMENT, commentId);
+		comment.applyReportCount(reportCount);
+	}
 
-    void reportUser(UUID reporterId, UUID targetUserId, ReportCategory category, String reason) {
-        validateReason(category, reason);
-        if (reporterId.equals(targetUserId)) {
-            throw new SocialFeedForbiddenException("자기 자신은 신고할 수 없습니다.");
-        }
-        findUserOrThrow(targetUserId);
-        if (postReportRepository.existsByReporterIdAndTargetTypeAndTargetId(reporterId, ReportTargetType.USER, targetUserId)) {
-            throw new SocialFeedForbiddenException("이미 신고한 사용자입니다.");
-        }
-        UserAccount reporter = findUserOrThrow(reporterId);
-        postReportRepository.save(new PostReport(reporter, ReportTargetType.USER, targetUserId, category, reason));
-    }
+	void reportUser(UUID reporterId, UUID targetUserId, ReportCategory category, String reason) {
+		validateReason(category, reason);
+		if (reporterId.equals(targetUserId)) {
+			throw new SocialFeedForbiddenException("자기 자신은 신고할 수 없습니다.");
+		}
+		UserAccount reportedUser = findUserOrThrow(targetUserId);
+		if (postReportRepository.existsByReporterIdAndTargetTypeAndTargetId(reporterId, ReportTargetType.USER, targetUserId)) {
+			throw new SocialFeedForbiddenException("이미 신고한 사용자입니다.");
+		}
+		UserAccount reporter = findUserOrThrow(reporterId);
+		postReportRepository.save(
+			new PostReport(reporter, reportedUser, ReportTargetType.USER, targetUserId, null, category, reason));
+	}
 
-    private void validateReason(ReportCategory category, String reason) {
-        if (category == ReportCategory.OTHER && (reason == null || reason.isBlank())) {
-            throw new SocialFeedBadRequestException("기타 신고 사유는 상세 사유를 입력해야 합니다.");
-        }
-    }
+	private void validateReason(ReportCategory category, String reason) {
+		if (category == ReportCategory.OTHER && (reason == null || reason.isBlank())) {
+			throw new SocialFeedBadRequestException("기타 신고 사유는 상세 사유를 입력해야 합니다.");
+		}
+	}
 
-    private UserAccount findUserOrThrow(UUID userId) {
-        return userAccountRepository.findById(userId)
-            .orElseThrow(() -> new SocialFeedNotFoundException("사용자를 찾을 수 없습니다."));
-    }
+	private UserAccount findUserOrThrow(UUID userId) {
+		return userAccountRepository.findById(userId)
+			.orElseThrow(() -> new SocialFeedNotFoundException("사용자를 찾을 수 없습니다."));
+	}
+
+	private FeedPost findReportablePostOrThrow(UUID postId) {
+		FeedPost post = feedPostRepository.findById(postId)
+			.orElseThrow(() -> new SocialFeedNotFoundException("게시글을 찾을 수 없습니다."));
+		if (post.isDeleted() || post.isRemovedByModeration()) {
+			throw new SocialFeedNotFoundException("게시글을 찾을 수 없습니다.");
+		}
+		return post;
+	}
+
+	private PostComment findReportableCommentOrThrow(UUID postId, UUID commentId) {
+		PostComment comment = postCommentRepository.findById(commentId)
+			.orElseThrow(() -> new SocialFeedNotFoundException("댓글을 찾을 수 없습니다."));
+		if (!comment.getPost().getId().equals(postId) || comment.isDeleted() || comment.isRemovedByModeration()) {
+			throw new SocialFeedNotFoundException("댓글을 찾을 수 없습니다.");
+		}
+		return comment;
+	}
 }

--- a/src/main/java/com/sagongsa/backend/social/SocialPostService.java
+++ b/src/main/java/com/sagongsa/backend/social/SocialPostService.java
@@ -85,6 +85,9 @@ class SocialPostService {
 
 	PostResponse getPost(UUID userId, UUID postId) {
 		FeedPost post = findPostOrThrow(postId);
+		if (userId != null && blockedIdsFor(userId).contains(post.getUser().getId())) {
+			throw new SocialFeedNotFoundException("게시글을 찾을 수 없습니다.");
+		}
 		long commentCount = countVisibleCommentsByPostId(postId, blockedIdsFor(userId));
 		PostVoteType myVote = resolveMyVote(userId, postId);
 		String authorNickname = userProfileRepository.findByUserId(post.getUser().getId()).isPresent()
@@ -133,7 +136,7 @@ class SocialPostService {
 	FeedPost findPostOrThrow(UUID postId) {
 		FeedPost post = feedPostRepository.findById(postId)
 			.orElseThrow(() -> new SocialFeedNotFoundException("게시글을 찾을 수 없습니다."));
-		if (post.isDeleted()) {
+		if (!post.isVisible()) {
 			throw new SocialFeedNotFoundException("게시글을 찾을 수 없습니다.");
 		}
 		return post;

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
@@ -455,6 +455,7 @@ public class WishlistService {
 					where fp.item_id = si.id
 					  and fp.user_id = si.user_id
 					  and fp.deleted_at is null
+					  and fp.moderation_status = 'ACTIVE'
 				) as selected,
 				si.status,
 				si.created_at,

--- a/src/main/resources/db/migration/V17__add_report_moderation_and_sanctions.sql
+++ b/src/main/resources/db/migration/V17__add_report_moderation_and_sanctions.sql
@@ -1,0 +1,96 @@
+do $$
+declare
+    v_constraint_name text;
+begin
+    select conname into v_constraint_name
+    from pg_constraint
+    where conrelid = 'users'::regclass
+      and contype = 'c'
+      and pg_get_constraintdef(oid) like '%ACTIVE%'
+      and pg_get_constraintdef(oid) like '%SUSPENDED%'
+      and pg_get_constraintdef(oid) like '%WITHDRAWN%';
+
+    if v_constraint_name is not null then
+        execute 'alter table users drop constraint ' || quote_ident(v_constraint_name);
+    end if;
+end $$;
+
+alter table users
+    add constraint chk_users_status
+        check (status in ('ACTIVE', 'SUSPENDED', 'BANNED', 'WITHDRAWN')),
+    add column suspended_until timestamptz,
+    add column banned_at timestamptz;
+
+alter table post_reports
+    add column reported_user_id uuid,
+    add column post_id uuid;
+
+update post_reports pr
+set reported_user_id = fp.user_id,
+    post_id = fp.id
+from feed_posts fp
+where pr.target_type = 'POST'
+  and pr.target_id = fp.id;
+
+update post_reports pr
+set reported_user_id = pc.user_id,
+    post_id = pc.post_id
+from post_comments pc
+where pr.target_type = 'COMMENT'
+  and pr.target_id = pc.id;
+
+update post_reports
+set reported_user_id = target_id
+where target_type = 'USER';
+
+alter table post_reports
+    alter column reported_user_id set not null,
+    alter column report_category type varchar(30),
+    add constraint fk_post_reports_reported_user foreign key (reported_user_id) references users(id),
+    add constraint fk_post_reports_post foreign key (post_id) references feed_posts(id),
+    add constraint chk_post_reports_content_post_id check (
+        (target_type = 'USER' and post_id is null)
+        or (target_type in ('POST', 'COMMENT') and post_id is not null)
+    );
+
+create index idx_post_reports_target_count on post_reports(target_type, target_id, created_at);
+create index idx_post_reports_reported_user on post_reports(reported_user_id, created_at desc);
+create index idx_post_reports_post on post_reports(post_id, created_at desc);
+
+alter table feed_posts
+    add column moderation_status varchar(20) not null default 'ACTIVE',
+    add column moderation_status_updated_at timestamptz,
+    add constraint chk_feed_posts_moderation_status
+        check (moderation_status in ('ACTIVE', 'BLINDED', 'REVIEW_PENDING', 'REMOVED'));
+
+alter table post_comments
+    add column moderation_status varchar(20) not null default 'ACTIVE',
+    add column moderation_status_updated_at timestamptz,
+    add constraint chk_post_comments_moderation_status
+        check (moderation_status in ('ACTIVE', 'BLINDED', 'REVIEW_PENDING', 'REMOVED'));
+
+create index idx_feed_posts_active_created on feed_posts(created_at desc)
+    where deleted_at is null and moderation_status = 'ACTIVE';
+
+create index idx_post_comments_active_post_created on post_comments(post_id, created_at)
+    where deleted_at is null and moderation_status = 'ACTIVE';
+
+create table user_sanctions (
+    id uuid primary key,
+    user_id uuid not null,
+    target_type varchar(10) check (target_type in ('POST', 'COMMENT', 'USER')),
+    target_id uuid,
+    sanction_type varchar(20) not null check (sanction_type in ('WARNING', 'SUSPENSION', 'PERMANENT_BAN')),
+    reason varchar(255),
+    starts_at timestamptz not null,
+    ends_at timestamptz,
+    created_at timestamptz not null,
+    updated_at timestamptz not null,
+    constraint fk_user_sanctions_user foreign key (user_id) references users(id),
+    constraint chk_user_sanctions_period check (
+        (sanction_type = 'SUSPENSION' and ends_at is not null)
+        or (sanction_type <> 'SUSPENSION' and ends_at is null)
+    )
+);
+
+create index idx_user_sanctions_user_created on user_sanctions(user_id, created_at desc);

--- a/src/test/java/com/sagongsa/backend/auth/CurrentUserIdArgumentResolverTest.java
+++ b/src/test/java/com/sagongsa/backend/auth/CurrentUserIdArgumentResolverTest.java
@@ -97,7 +97,7 @@ class CurrentUserIdArgumentResolverTest {
 	private static CurrentUserIdArgumentResolver resolver(boolean trustedHeaderEnabled, String activeProfile) {
 		MockEnvironment environment = new MockEnvironment();
 		environment.setActiveProfiles(activeProfile);
-		return new CurrentUserIdArgumentResolver(trustedHeaderEnabled, "X-User-Id", environment);
+		return new CurrentUserIdArgumentResolver(trustedHeaderEnabled, "X-User-Id", environment, mock(UserAccessService.class));
 	}
 
 	private static NativeWebRequest request(Principal principal, String headerValue) {

--- a/src/test/java/com/sagongsa/backend/auth/JwtTokenServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/auth/JwtTokenServiceTest.java
@@ -63,6 +63,48 @@ class JwtTokenServiceTest extends PostgreSqlContainerTest {
 			.isInstanceOf(BadCredentialsException.class);
 	}
 
+	@Test
+	void issueTokenPairRejectsRestrictedUser() {
+		UUID userId = UUID.fromString("10000000-0000-0000-0000-000000000003");
+		insertUser(userId);
+		suspendUser(userId);
+
+		assertThatThrownBy(() -> jwtTokenService.issueTokenPair(
+			profile(userId),
+			List.of(new SimpleGrantedAuthority("ROLE_USER"))
+		)).isInstanceOf(BadCredentialsException.class);
+	}
+
+	@Test
+	void refreshRejectsRestrictedUser() {
+		UUID userId = UUID.fromString("10000000-0000-0000-0000-000000000004");
+		insertUser(userId);
+		JwtTokenService.TokenPair issued = jwtTokenService.issueTokenPair(
+			profile(userId),
+			List.of(new SimpleGrantedAuthority("ROLE_USER"))
+		);
+		suspendUser(userId);
+
+		assertThatThrownBy(() -> jwtTokenService.refresh(issued.refreshToken()))
+			.isInstanceOf(BadCredentialsException.class);
+	}
+
+	@Test
+	void issueTokenPairRestoresExpiredSuspension() {
+		UUID userId = UUID.fromString("10000000-0000-0000-0000-000000000005");
+		insertUser(userId);
+		suspendUserUntil(userId, OffsetDateTime.now(ZoneOffset.UTC).minusDays(1));
+
+		JwtTokenService.TokenPair issued = jwtTokenService.issueTokenPair(
+			profile(userId),
+			List.of(new SimpleGrantedAuthority("ROLE_USER"))
+		);
+
+		assertThat(issued.profile().userId()).isEqualTo(userId);
+		assertThat(queryString("select status from users where id = ?", userId)).isEqualTo("ACTIVE");
+		assertThat(queryBoolean("select suspended_until is null from users where id = ?", userId)).isTrue();
+	}
+
 	private void insertUser(UUID userId) {
 		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
 		jdbcTemplate.update(
@@ -74,6 +116,33 @@ class JwtTokenServiceTest extends PostgreSqlContainerTest {
 			now,
 			now
 		);
+	}
+
+	private void suspendUser(UUID userId) {
+		suspendUserUntil(userId, OffsetDateTime.now(ZoneOffset.UTC).plusDays(7));
+	}
+
+	private void suspendUserUntil(UUID userId, OffsetDateTime suspendedUntil) {
+		jdbcTemplate.update(
+			"""
+			update users
+			set status = 'SUSPENDED',
+			    suspended_until = ?,
+			    updated_at = ?
+			where id = ?
+			""",
+			suspendedUntil,
+			OffsetDateTime.now(ZoneOffset.UTC),
+			userId
+		);
+	}
+
+	private String queryString(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(sql, String.class, args);
+	}
+
+	private Boolean queryBoolean(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(sql, Boolean.class, args);
 	}
 
 	private SocialUserProfile profile(UUID userId) {

--- a/src/test/java/com/sagongsa/backend/auth/SocialAccountLinkServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/auth/SocialAccountLinkServiceTest.java
@@ -1,6 +1,7 @@
 package com.sagongsa.backend.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.sagongsa.backend.domain.auth.SocialAccountRepository;
 import com.sagongsa.backend.domain.auth.UserAccountRepository;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.authentication.DisabledException;
 
 @SpringBootTest
 class SocialAccountLinkServiceTest extends PostgreSqlContainerTest {
@@ -125,7 +127,59 @@ class SocialAccountLinkServiceTest extends PostgreSqlContainerTest {
 		assertThat(queryString("select onboarding_status from users where id = ?", secondLogin.userId())).isEqualTo("NOT_STARTED");
 	}
 
+	@Test
+	void rejectsExistingLoginWhenSuspensionIsActive() {
+		SocialUserProfile firstLogin = socialAccountLinkService.linkOrCreateUser(profile("restricted-google-123"));
+		suspendUserUntil(firstLogin.userId(), OffsetDateTime.now(ZoneOffset.UTC).plusDays(7));
+
+		assertThatThrownBy(() -> socialAccountLinkService.linkOrCreateUser(profile("restricted-google-123")))
+			.isInstanceOf(DisabledException.class);
+	}
+
+	@Test
+	void reusesExistingLoginAndRestoresUserWhenSuspensionExpired() {
+		SocialUserProfile firstLogin = socialAccountLinkService.linkOrCreateUser(profile("expired-google-123"));
+		suspendUserUntil(firstLogin.userId(), OffsetDateTime.now(ZoneOffset.UTC).minusDays(1));
+
+		SocialUserProfile secondLogin = socialAccountLinkService.linkOrCreateUser(profile("expired-google-123"));
+
+		assertThat(secondLogin.userId()).isEqualTo(firstLogin.userId());
+		assertThat(queryString("select status from users where id = ?", firstLogin.userId())).isEqualTo("ACTIVE");
+		assertThat(queryBoolean("select suspended_until is null from users where id = ?", firstLogin.userId())).isTrue();
+	}
+
+	private SocialUserProfile profile(String providerUserId) {
+		return new SocialUserProfile(
+			"google",
+			providerUserId,
+			"Google Tester",
+			providerUserId + "@test.dev",
+			"https://example.com/" + providerUserId + ".png",
+			java.util.Map.of(),
+			null
+		);
+	}
+
+	private void suspendUserUntil(java.util.UUID userId, OffsetDateTime suspendedUntil) {
+		jdbcTemplate.update(
+			"""
+			update users
+			set status = 'SUSPENDED',
+			    suspended_until = ?,
+			    updated_at = ?
+			where id = ?
+			""",
+			suspendedUntil,
+			OffsetDateTime.now(ZoneOffset.UTC),
+			userId
+		);
+	}
+
 	private String queryString(String sql, Object... args) {
 		return jdbcTemplate.queryForObject(sql, String.class, args);
+	}
+
+	private Boolean queryBoolean(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(sql, Boolean.class, args);
 	}
 }

--- a/src/test/java/com/sagongsa/backend/domain/DomainSchemaSmokeTest.java
+++ b/src/test/java/com/sagongsa/backend/domain/DomainSchemaSmokeTest.java
@@ -46,6 +46,9 @@ class DomainSchemaSmokeTest extends PostgreSqlContainerTest {
 			"feed_posts",
 			"post_votes",
 			"post_comments",
+			"post_reports",
+			"user_blocks",
+			"user_sanctions",
 			"share_tokens",
 			"terms_versions",
 			"user_terms_agreements",
@@ -88,10 +91,28 @@ class DomainSchemaSmokeTest extends PostgreSqlContainerTest {
 			"cancel_reason"
 		);
 		assertColumns(
+			"users",
+			"suspended_until",
+			"banned_at"
+		);
+		assertColumns(
 			"feed_posts",
 			"go_count",
 			"stop_count",
-			"deleted_at"
+			"deleted_at",
+			"moderation_status",
+			"moderation_status_updated_at"
+		);
+		assertColumns(
+			"post_comments",
+			"moderation_status",
+			"moderation_status_updated_at"
+		);
+		assertColumns(
+			"post_reports",
+			"reported_user_id",
+			"post_id",
+			"report_category"
 		);
 		assertColumns(
 			"share_tokens",
@@ -125,6 +146,8 @@ class DomainSchemaSmokeTest extends PostgreSqlContainerTest {
 		assertPartialIndex("uk_post_votes_post_user_active", "canceled_at is null");
 		assertPartialIndex("idx_post_votes_post_type_active", "canceled_at is null");
 		assertPartialIndex("idx_post_comments_post_created_visible", "deleted_at is null");
+		assertPartialIndex("idx_feed_posts_active_created", "moderation_status", "'active'");
+		assertPartialIndex("idx_post_comments_active_post_created", "moderation_status", "'active'");
 		assertTrigger("trg_post_votes_sync_feed_counts", "post_votes");
 		assertTrigger("trg_self_check_matches_decision", "self_check_response_sets");
 		assertNoTrigger("trg_prevent_self_check_response_set_delete", "self_check_response_sets");
@@ -135,6 +158,14 @@ class DomainSchemaSmokeTest extends PostgreSqlContainerTest {
 
 	@Test
 	void includesPlanningDrivenConstraints() {
+		assertConstraint(
+			"users",
+			"chk_users_status",
+			"active",
+			"suspended",
+			"banned",
+			"withdrawn"
+		);
 		assertConstraint(
 			"users",
 			"chk_users_withdrawn_state",
@@ -276,6 +307,25 @@ class DomainSchemaSmokeTest extends PostgreSqlContainerTest {
 			"is null"
 		);
 		assertConstraint("feed_posts", "chk_feed_posts_vote_counts", "go_count", "stop_count", ">= 0");
+		assertConstraint(
+			"feed_posts",
+			"chk_feed_posts_moderation_status",
+			"active",
+			"blinded",
+			"review_pending",
+			"removed"
+		);
+		assertConstraint(
+			"post_comments",
+			"chk_post_comments_moderation_status",
+			"active",
+			"blinded",
+			"review_pending",
+			"removed"
+		);
+		assertConstraint("post_reports", "chk_post_reports_target_type", "post", "comment", "user");
+		assertConstraint("post_reports", "chk_post_reports_content_post_id", "target_type", "post_id", "user");
+		assertConstraint("user_sanctions", "chk_user_sanctions_period", "suspension", "ends_at");
 	}
 
 	@Test

--- a/src/test/java/com/sagongsa/backend/onboarding/OnboardingCompleteIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/onboarding/OnboardingCompleteIntegrationTest.java
@@ -131,8 +131,7 @@ class OnboardingCompleteIntegrationTest extends PostgreSqlContainerTest {
 				.header("X-User-Id", userId.toString())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(onboardingRequestBody()))
-			.andExpect(status().isForbidden())
-			.andExpect(jsonPath("$.code").value("FORBIDDEN"));
+			.andExpect(status().isForbidden());
 
 		assertThat(countRows("user_profiles", userId)).isZero();
 	}

--- a/src/test/java/com/sagongsa/backend/social/ReportServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/social/ReportServiceTest.java
@@ -25,6 +25,9 @@ class ReportServiceTest extends PostgreSqlContainerTest {
 	private CommentService commentService;
 
 	@Autowired
+	private SocialPostService socialPostService;
+
+	@Autowired
 	private JdbcTemplate jdbcTemplate;
 
 	@BeforeEach
@@ -59,6 +62,59 @@ class ReportServiceTest extends PostgreSqlContainerTest {
 			postId
 		);
 		assertThat(category).isEqualTo("ILLEGAL_INFORMATION");
+	}
+
+	@Test
+	void 게시글_신고는_피신고자와_게시글_ID를_저장() {
+		UUID reporter = insertUser();
+		UUID author = insertUser();
+		UUID postId = insertPost(author);
+
+		reportService.reportPost(reporter, postId, ReportCategory.DEFAMATION, "명예훼손 내용");
+
+		UUID reportedUserId = jdbcTemplate.queryForObject(
+			"select reported_user_id from post_reports where reporter_user_id = ? and target_id = ?",
+			UUID.class,
+			reporter,
+			postId
+		);
+		UUID storedPostId = jdbcTemplate.queryForObject(
+			"select post_id from post_reports where reporter_user_id = ? and target_id = ?",
+			UUID.class,
+			reporter,
+			postId
+		);
+		assertThat(reportedUserId).isEqualTo(author);
+		assertThat(storedPostId).isEqualTo(postId);
+	}
+
+	@Test
+	void 게시글_신고_3회면_블라인드되어_피드에서_제외() {
+		UUID viewer = insertUser();
+		UUID author = insertUser();
+		UUID postId = insertPost(author);
+
+		reportService.reportPost(insertUser(), postId, ReportCategory.SPAM, null);
+		reportService.reportPost(insertUser(), postId, ReportCategory.OBSCENE, null);
+		reportService.reportPost(insertUser(), postId, ReportCategory.ADVERTISING, null);
+
+		assertThat(queryString("select moderation_status from feed_posts where id = ?", postId))
+			.isEqualTo("BLINDED");
+		assertThat(socialPostService.getPosts(viewer, null, 20).posts())
+			.noneMatch(post -> post.id().equals(postId));
+	}
+
+	@Test
+	void 게시글_신고_5회면_관리자_검토대기_상태() {
+		UUID author = insertUser();
+		UUID postId = insertPost(author);
+
+		for (int i = 0; i < 5; i++) {
+			reportService.reportPost(insertUser(), postId, ReportCategory.PROFANITY, null);
+		}
+
+		assertThat(queryString("select moderation_status from feed_posts where id = ?", postId))
+			.isEqualTo("REVIEW_PENDING");
 	}
 
 	@Test
@@ -123,6 +179,48 @@ class ReportServiceTest extends PostgreSqlContainerTest {
 		assertThatNoException().isThrownBy(() ->
 			reportService.reportComment(reporter, postId, comment.id(), ReportCategory.OBSCENE, "부적절한 내용")
 		);
+	}
+
+	@Test
+	void 댓글_신고는_피신고자와_원_게시글_ID를_저장() {
+		UUID reporter = insertUser();
+		UUID author = insertUser();
+		UUID postId = insertPost(author);
+		CommentResponse comment = commentService.createComment(author, postId, new CreateCommentRequest("댓글"));
+
+		reportService.reportComment(reporter, postId, comment.id(), ReportCategory.ADVERTISING, "광고 댓글");
+
+		UUID reportedUserId = jdbcTemplate.queryForObject(
+			"select reported_user_id from post_reports where reporter_user_id = ? and target_id = ?",
+			UUID.class,
+			reporter,
+			comment.id()
+		);
+		UUID storedPostId = jdbcTemplate.queryForObject(
+			"select post_id from post_reports where reporter_user_id = ? and target_id = ?",
+			UUID.class,
+			reporter,
+			comment.id()
+		);
+		assertThat(reportedUserId).isEqualTo(author);
+		assertThat(storedPostId).isEqualTo(postId);
+	}
+
+	@Test
+	void 댓글_신고_3회면_블라인드되어_댓글_목록에서_제외() {
+		UUID viewer = insertUser();
+		UUID author = insertUser();
+		UUID postId = insertPost(author);
+		CommentResponse comment = commentService.createComment(author, postId, new CreateCommentRequest("댓글"));
+
+		reportService.reportComment(insertUser(), postId, comment.id(), ReportCategory.PROFANITY, null);
+		reportService.reportComment(insertUser(), postId, comment.id(), ReportCategory.OBSCENE, null);
+		reportService.reportComment(insertUser(), postId, comment.id(), ReportCategory.SPAM, null);
+
+		assertThat(queryString("select moderation_status from post_comments where id = ?", comment.id()))
+			.isEqualTo("BLINDED");
+		assertThat(commentService.getComments(viewer, postId, 1, 20).comments()).isEmpty();
+		assertThat(socialPostService.getPost(viewer, postId).commentCount()).isZero();
 	}
 
 	@Test
@@ -242,5 +340,9 @@ class ReportServiceTest extends PostgreSqlContainerTest {
 			"INSERT INTO feed_posts (id, user_id, title, body, go_count, stop_count, created_at, updated_at) VALUES (?, ?, '테스트 게시글', '내용', 0, 0, ?, ?)",
 			postId, userId, now, now);
 		return postId;
+	}
+
+	private String queryString(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(sql, String.class, args);
 	}
 }

--- a/src/test/java/com/sagongsa/backend/social/SocialFeedApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/social/SocialFeedApiIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.sagongsa.backend.social;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -99,6 +100,38 @@ class SocialFeedApiIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.posts").isEmpty())
 			.andExpect(jsonPath("$.hasMore").value(false));
+	}
+
+	@Test
+	void 정지된_유저는_피드_API_접근_403() throws Exception {
+		UUID userId = insertUser();
+		jdbcTemplate.update(
+			"UPDATE users SET status = 'SUSPENDED', suspended_until = ?, updated_at = ? WHERE id = ?",
+			OffsetDateTime.now(ZoneOffset.UTC).plusDays(7),
+			OffsetDateTime.now(ZoneOffset.UTC),
+			userId
+		);
+
+		mockMvc.perform(get("/api/v1/social/posts")
+				.header("X-User-Id", userId))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	void 정지기간_만료_유저는_피드_API_접근_가능하고_ACTIVE로_복구() throws Exception {
+		UUID userId = insertUser();
+		jdbcTemplate.update(
+			"UPDATE users SET status = 'SUSPENDED', suspended_until = ?, updated_at = ? WHERE id = ?",
+			OffsetDateTime.now(ZoneOffset.UTC).minusDays(1),
+			OffsetDateTime.now(ZoneOffset.UTC),
+			userId
+		);
+
+		mockMvc.perform(get("/api/v1/social/posts")
+				.header("X-User-Id", userId))
+			.andExpect(status().isOk());
+
+		assertThat(queryString("select status from users where id = ?", userId)).isEqualTo("ACTIVE");
 	}
 
 	// ── GET /api/v1/social/posts/{postId} ────────────────────────────────────
@@ -417,5 +450,9 @@ class SocialFeedApiIntegrationTest extends PostgreSqlContainerTest {
 			"INSERT INTO post_comments (id, post_id, user_id, body, created_at, updated_at) VALUES (?, ?, ?, '테스트 댓글', ?, ?)",
 			commentId, postId, userId, now, now);
 		return commentId;
+	}
+
+	private String queryString(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(sql, String.class, args);
 	}
 }


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-65`
- Jira: https://parkjaehong.atlassian.net/browse/NF-65
- GitHub: Related #151
- GitHub: Closes #151

> PR 제목: `NF-65 신고/차단 모더레이션 처리 추가`
> 브랜치: `feat/NF-65-report-block-moderation`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #151의 1/1 단계
- 선행 PR: 없음
- 후속 PR: 데모데이 이후 어드민 화면/관리자 조치 API는 별도 작업

### 이 PR에서 변경한 것
- 신고 데이터에 피신고자 ID, 원 게시글 ID, 확장 신고 카테고리, 직접 입력 사유 저장 구조를 반영했습니다.
- 게시글/댓글 신고 누적 3회는 `BLINDED`, 5회는 `REVIEW_PENDING`으로 상태 전환되도록 했습니다.
- 피드/단건/댓글/마이페이지/위시 선택 상태 조회에서 블라인드 및 검토 대기 콘텐츠가 노출되지 않도록 필터링했습니다.
- 유저 제재 이력 테이블과 `SUSPENDED`/`BANNED` 접근 제어에 필요한 계정 상태 컬럼을 추가했습니다.
- 정지/차단 계정의 API 접근, 토큰 발급, refresh, 소셜 로그인 재진입을 차단했습니다.

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
- AC1: 신고 row에 신고자, 피신고자, 타겟, 원 게시글, 카테고리, 직접 입력 사유가 저장된다.
- AC2: 게시글/댓글 신고 누적 3회 시 자동 블라인드되고 사용자 응답에서 제외된다.
- AC3: 게시글/댓글 신고 누적 5회 시 관리자 검토 대기 상태로 식별된다.
- AC4: 정지/영구 차단 유저의 API 접근 및 로그인/토큰 발급을 제어할 수 있다.

### Not covered (후속 작업)
- 관리자 화면: 데모데이 이후 별도 이슈에서 진행
- 관리자 수동 삭제/복구 API: MVP 단계에서는 DB 직접 조회/수정 기준이라 제외

---

## 🧪 테스트 결과 (필수)
### 로컬
```
./gradlew test
```
- ✅ 결과: BUILD SUCCESSFUL

### CI
- 자동 첨부

### Smoke 테스트
- 시나리오: 신고 3회/5회 상태 전환, 블라인드 콘텐츠 미노출, 정지 유저 API/토큰 접근 차단
- 결과: ✅ 관련 통합/서비스 테스트 및 전체 테스트 통과

---

## 🧭 영향 범위 체크 (필수)
- [x] API 변경 (요약: 신고 카테고리 확장, 제한 계정 접근 차단, 블라인드 콘텐츠 미노출)
- [x] DB 변경 (마이그레이션: `V17__add_report_moderation_and_sanctions.sql`)
- [ ] 설정 변경 (항목: )
- [ ] Breaking change (무엇: )

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인: `ReportService`, `FeedPost`/`PostComment` moderation status, `V17__add_report_moderation_and_sanctions.sql`, `CurrentUserIdArgumentResolver`, `JwtTokenService`
- 트레이드오프/대안: 3회 블라인드 후에도 누적 5회 관리자 검토 상태로 전환 가능하도록 `BLINDED` 콘텐츠의 추가 신고는 허용하고, `REMOVED`만 신고 불가로 처리했습니다.