### PR TITLE
[feat] NF-66 CBT 서버 대응 기반 추가

### DIFF
--- a/docs/CBT_SERVER_RESPONSE_RUNBOOK.md
+++ b/docs/CBT_SERVER_RESPONSE_RUNBOOK.md
@@ -1,0 +1,73 @@
+# CBT 서버 대응 runbook
+
+## 목적
+
+안드로이드 비공개 테스트 중 서버 상태를 빠르게 확인하고, 사용자 제보를 서버 로그와 연결하기 위한 최소 절차다.
+
+## 헬스체크
+
+```bash
+curl -i https://<QA_API_HOST>/health
+```
+
+정상 기준:
+
+- HTTP `200`
+- 응답 body의 `status`가 `UP`
+- 응답 header에 `X-Request-Id`가 존재
+
+## Request ID 확인
+
+서버는 모든 응답에 `X-Request-Id`를 내려준다.
+클라이언트가 `X-Request-Id`를 보내면 안전한 값에 한해 그대로 재사용하고, 없거나 안전하지 않은 값이면 서버가 UUID를 생성한다.
+
+테스터 제보를 받을 때 최소한 아래 정보를 함께 받는다.
+
+- 발생 시각
+- 화면/행동
+- 로그인 계정 또는 userId
+- `X-Request-Id`
+- 증상 설명과 스크린샷
+
+## 서버 로그 확인
+
+QA 서버에 접속한 뒤 최근 로그를 확인한다.
+
+```bash
+ssh <GCP_VM_USER>@<GCP_VM_HOST>
+sudo journalctl -u wigul-backend -n 200 --no-pager
+sudo journalctl -u wigul-backend --since "30 minutes ago" --no-pager
+```
+
+특정 제보의 `requestId`가 있으면 해당 값으로 검색한다.
+
+```bash
+sudo journalctl -u wigul-backend --since "2 hours ago" --no-pager | grep "<X-Request-Id>"
+```
+
+로그 패턴에는 `requestId`와 가능한 경우 `userId`가 포함된다.
+
+## 서비스 상태 확인
+
+```bash
+systemctl status wigul-backend --no-pager
+```
+
+## 수동 재시작
+
+자동 배포 workflow와 같은 서비스명을 사용한다.
+
+```bash
+sudo -n systemctl restart wigul-backend
+systemctl status wigul-backend --no-pager
+curl -i https://<QA_API_HOST>/health
+```
+
+`sudo -n`이 비밀번호 요구로 실패하면 배포 계정의 sudoers 설정을 먼저 확인한다.
+
+## 범위 밖
+
+- Android Crashlytics/Sentry 연동
+- 치명 오류 알림 자동화
+- 상세 모니터링 대시보드
+- 자동 롤백/복구

--- a/src/main/java/com/sagongsa/backend/config/SecurityConfig.java
+++ b/src/main/java/com/sagongsa/backend/config/SecurityConfig.java
@@ -69,6 +69,7 @@ public class SecurityConfig {
 				auth
 					.requestMatchers("/", "/index.html", "/login.html", "/app.html",
 						"/deliberation.html", "/test-mypage.html", "/test-nickname.html", "/test-consumption.html", "/favicon.ico", "/error").permitAll()
+					.requestMatchers("/health", "/api/health").permitAll()
 					.requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
 					.requestMatchers("/api/auth/token/refresh").permitAll()
 					.requestMatchers(HttpMethod.POST, "/api/auth/reviewer-token").permitAll()

--- a/src/main/java/com/sagongsa/backend/health/HealthController.java
+++ b/src/main/java/com/sagongsa/backend/health/HealthController.java
@@ -1,0 +1,50 @@
+package com.sagongsa.backend.health;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+
+	private final String serviceName;
+	private final Environment environment;
+
+	public HealthController(
+		@Value("${spring.application.name:wigul-backend}") String serviceName,
+		Environment environment
+	) {
+		this.serviceName = serviceName;
+		this.environment = environment;
+	}
+
+	@GetMapping({"/health", "/api/health"})
+	public ResponseEntity<HealthResponse> health() {
+		return ResponseEntity.ok(new HealthResponse(
+			"UP",
+			serviceName,
+			activeProfiles(),
+			OffsetDateTime.now(ZoneOffset.UTC)
+		));
+	}
+
+	private List<String> activeProfiles() {
+		return Arrays.stream(environment.getActiveProfiles())
+			.sorted()
+			.toList();
+	}
+
+	public record HealthResponse(
+		String status,
+		String service,
+		List<String> profiles,
+		OffsetDateTime time
+	) {
+	}
+}

--- a/src/main/java/com/sagongsa/backend/observability/RequestTraceFilter.java
+++ b/src/main/java/com/sagongsa/backend/observability/RequestTraceFilter.java
@@ -1,0 +1,77 @@
+package com.sagongsa.backend.observability;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RequestTraceFilter extends OncePerRequestFilter {
+
+	public static final String REQUEST_ID_HEADER = "X-Request-Id";
+	static final String MDC_REQUEST_ID_KEY = "requestId";
+	static final String MDC_USER_ID_KEY = "userId";
+
+	private static final Logger log = LoggerFactory.getLogger(RequestTraceFilter.class);
+	private static final Pattern SAFE_REQUEST_ID = Pattern.compile("[A-Za-z0-9._:-]{1,100}");
+
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain
+	) throws ServletException, IOException {
+		long startedAt = System.nanoTime();
+		String requestId = resolveRequestId(request.getHeader(REQUEST_ID_HEADER));
+		MDC.put(MDC_REQUEST_ID_KEY, requestId);
+		response.setHeader(REQUEST_ID_HEADER, requestId);
+
+		try {
+			filterChain.doFilter(request, response);
+		}
+		finally {
+			logCompletedRequest(request, response, startedAt);
+			MDC.remove(MDC_USER_ID_KEY);
+			MDC.remove(MDC_REQUEST_ID_KEY);
+		}
+	}
+
+	private String resolveRequestId(String rawRequestId) {
+		if (StringUtils.hasText(rawRequestId)) {
+			String trimmed = rawRequestId.trim();
+			if (SAFE_REQUEST_ID.matcher(trimmed).matches()) {
+				return trimmed;
+			}
+		}
+		return UUID.randomUUID().toString();
+	}
+
+	private void logCompletedRequest(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		long startedAt
+	) {
+		long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
+		int status = response.getStatus();
+		if (status >= 500) {
+			log.warn("request completed method={} path={} status={} durationMs={}",
+				request.getMethod(), request.getRequestURI(), status, durationMs);
+			return;
+		}
+		log.info("request completed method={} path={} status={} durationMs={}",
+			request.getMethod(), request.getRequestURI(), status, durationMs);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/observability/RequestTraceInterceptor.java
+++ b/src/main/java/com/sagongsa/backend/observability/RequestTraceInterceptor.java
@@ -1,0 +1,77 @@
+package com.sagongsa.backend.observability;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.security.Principal;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+class RequestTraceInterceptor implements HandlerInterceptor {
+
+	private final String trustedHeaderName;
+	private final boolean trustedHeaderEnabled;
+
+	RequestTraceInterceptor(
+		@Value("${app.auth.trusted-user-id-header.name:X-User-Id}") String trustedHeaderName,
+		@Value("${app.auth.trusted-user-id-header.enabled:false}") boolean trustedHeaderEnabled,
+		Environment environment
+	) {
+		this.trustedHeaderName = trustedHeaderName;
+		this.trustedHeaderEnabled = trustedHeaderEnabled || !environment.acceptsProfiles(Profiles.of("prod"));
+	}
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+		String userId = resolveAuthenticatedUserId(request.getUserPrincipal());
+		if (!StringUtils.hasText(userId) && trustedHeaderEnabled) {
+			userId = resolveTrustedHeaderUserId(request.getHeader(trustedHeaderName));
+		}
+		if (StringUtils.hasText(userId)) {
+			MDC.put(RequestTraceFilter.MDC_USER_ID_KEY, userId);
+		}
+		return true;
+	}
+
+	private String resolveAuthenticatedUserId(Principal principal) {
+		if (principal instanceof Authentication authentication && authentication.getPrincipal() instanceof Jwt jwt) {
+			String claimUserId = jwt.getClaimAsString("userId");
+			if (isUuid(claimUserId)) {
+				return claimUserId.trim();
+			}
+			String subject = jwt.getSubject();
+			if (isUuid(subject)) {
+				return subject.trim();
+			}
+		}
+		if (principal != null && isUuid(principal.getName())) {
+			return principal.getName().trim();
+		}
+		return null;
+	}
+
+	private String resolveTrustedHeaderUserId(String rawUserId) {
+		return isUuid(rawUserId) ? rawUserId.trim() : null;
+	}
+
+	private boolean isUuid(String value) {
+		if (!StringUtils.hasText(value)) {
+			return false;
+		}
+		try {
+			UUID.fromString(value.trim());
+			return true;
+		}
+		catch (IllegalArgumentException exception) {
+			return false;
+		}
+	}
+}

--- a/src/main/java/com/sagongsa/backend/observability/RequestTraceWebMvcConfig.java
+++ b/src/main/java/com/sagongsa/backend/observability/RequestTraceWebMvcConfig.java
@@ -1,0 +1,20 @@
+package com.sagongsa.backend.observability;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+class RequestTraceWebMvcConfig implements WebMvcConfigurer {
+
+	private final RequestTraceInterceptor requestTraceInterceptor;
+
+	RequestTraceWebMvcConfig(RequestTraceInterceptor requestTraceInterceptor) {
+		this.requestTraceInterceptor = requestTraceInterceptor;
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(requestTraceInterceptor);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,10 @@ server:
       cookie:
         same-site: lax
 
+logging:
+  pattern:
+    console: "%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5level [%thread] [requestId=%X{requestId}] [userId=%X{userId}] %logger{36} - %msg%n"
+
 app:
   auth:
     issuer: 404-backend

--- a/src/test/java/com/sagongsa/backend/health/HealthControllerTest.java
+++ b/src/test/java/com/sagongsa/backend/health/HealthControllerTest.java
@@ -1,0 +1,59 @@
+package com.sagongsa.backend.health;
+
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sagongsa.backend.observability.RequestTraceFilter;
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class HealthControllerTest extends PostgreSqlContainerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void returnsPublicHealthStatus() throws Exception {
+		mockMvc.perform(get("/health"))
+			.andExpect(status().isOk())
+			.andExpect(header().string(RequestTraceFilter.REQUEST_ID_HEADER,
+				matchesPattern("[0-9a-fA-F-]{36}")))
+			.andExpect(jsonPath("$.status").value("UP"))
+			.andExpect(jsonPath("$.service").value("wigul-backend"))
+			.andExpect(jsonPath("$.time").exists());
+	}
+
+	@Test
+	void reusesSafeRequestIdHeader() throws Exception {
+		mockMvc.perform(get("/api/health")
+				.header(RequestTraceFilter.REQUEST_ID_HEADER, "cbt-test-001"))
+			.andExpect(status().isOk())
+			.andExpect(header().string(RequestTraceFilter.REQUEST_ID_HEADER, "cbt-test-001"));
+	}
+
+	@Test
+	void replacesUnsafeRequestIdHeader() throws Exception {
+		mockMvc.perform(get("/health")
+				.header(RequestTraceFilter.REQUEST_ID_HEADER, "bad id value"))
+			.andExpect(status().isOk())
+			.andExpect(header().string(RequestTraceFilter.REQUEST_ID_HEADER,
+				matchesPattern("[0-9a-fA-F-]{36}")));
+	}
+
+	@Test
+	void addsRequestIdHeaderToErrorResponses() throws Exception {
+		mockMvc.perform(get("/api/auth/me")
+				.header(RequestTraceFilter.REQUEST_ID_HEADER, "cbt-error-001"))
+			.andExpect(status().isUnauthorized())
+			.andExpect(header().string(RequestTraceFilter.REQUEST_ID_HEADER, "cbt-error-001"));
+	}
+}


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-66`
- Jira: https://parkjaehong.atlassian.net/browse/NF-66
- GitHub: Related #153
- GitHub: Closes #153

> PR 제목: `NF-66 CBT 서버 대응 기반 추가`
> 브랜치: `feat/NF-66-cbt-server-readiness`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #153의 1/1 단계
- 선행 PR: 없음
- 후속 PR: Android Crashlytics/Sentry 연동 및 실제 피드백 채널 개설은 별도 작업

### 이 PR에서 변경한 것
- 인증 없이 호출 가능한 `GET /health`, `GET /api/health`를 추가했습니다.
- 모든 응답에 `X-Request-Id`를 내려주고, 안전한 클라이언트 requestId는 재사용하도록 했습니다.
- 요청 완료 로그를 남기고 콘솔 로그 패턴에 `requestId`, 가능한 경우 `userId` MDC를 포함했습니다.
- QA 서버 로그 확인, requestId 검색, 수동 재시작, 재시작 후 헬스체크 절차를 runbook으로 문서화했습니다.

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
- AC1: 인증 없이 `GET /health` 또는 `GET /api/health`로 서버 상태를 확인할 수 있다.
- AC2: 모든 응답에 `X-Request-Id`가 포함되고, 안전한 클라이언트 requestId는 재사용된다.
- AC3: 서버 로그에서 requestId와 가능한 경우 userId를 확인할 수 있다.
- AC4: QA 서버 로그 확인, 헬스체크, 수동 재시작 절차가 문서화된다.

### Not covered (후속 작업)
- Android Crashlytics/Sentry 연동: 클라이언트 범위라 제외
- 실제 유저 피드백 채널 개설: 운영/기획 채널 결정 필요
- 치명 오류 알림 자동화 및 상세 모니터링: CBT 이후 고도화 범위

---

## 🧪 테스트 결과 (필수)
### 로컬
```
./gradlew test --tests com.sagongsa.backend.health.HealthControllerTest
./gradlew test
git diff --check
```
- ✅ 결과: BUILD SUCCESSFUL
- ✅ 결과: whitespace 문제 없음

### CI
- 자동 첨부

### Smoke 테스트
- 시나리오: `/health` 공개 호출, 안전한 `X-Request-Id` 재사용, 안전하지 않은 requestId 재생성, 401 에러 응답 requestId 헤더 확인
- 결과: ✅ `HealthControllerTest` 통과

---

## 🧭 영향 범위 체크 (필수)
- [x] API 변경 (요약: 공개 헬스체크 endpoint 추가)
- [ ] DB 변경 (마이그레이션: )
- [x] 설정 변경 (항목: 콘솔 로그 패턴)
- [ ] Breaking change (무엇: )

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인: `HealthController`, `RequestTraceFilter`, `RequestTraceInterceptor`, `application.yml`, `docs/CBT_SERVER_RESPONSE_RUNBOOK.md`
- 트레이드오프/대안: requestId는 모든 응답 헤더에 노출하고, 클라이언트 제공 값은 안전한 문자/길이만 재사용하도록 제한했습니다. `X-User-Id`는 prod에서 임의 헤더를 신뢰하지 않도록 non-prod 또는 명시 설정에서만 로그 보조값으로 사용합니다.
