### PR TITLE
[fix] NF-68 test1 QA 백엔드 단독 수정 항목 보완

### DIFF
--- a/src/main/java/com/sagongsa/backend/deliberation/DeliberationService.java
+++ b/src/main/java/com/sagongsa/backend/deliberation/DeliberationService.java
@@ -13,6 +13,7 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -29,6 +30,16 @@ public class DeliberationService {
 		new SelfCheckQuestion("BUDGET", "비슷한 물건을 이미 갖고 있나요?"),
 		new SelfCheckQuestion("ALTERNATIVE", "구매하지 않아도 일상생활에 불편함이 없나요?"),
 		new SelfCheckQuestion("DELAY", "한 달 뒤에는 필요하지 않을 것 같나요?")
+	);
+	static final List<String> PRICE_OPPORTUNITY_COST_MESSAGE_FORMATS = List.of(
+		"%,d원을 다른 곳에 쓸 수도 있어요.",
+		"%,d원이면 다른 위시템 예산을 남겨둘 수 있어요.",
+		"지금 %,d원을 쓰면 이번 달 예산 여유가 줄어들어요."
+	);
+	static final List<String> NO_PRICE_OPPORTUNITY_COST_MESSAGES = List.of(
+		"가격을 입력하면 다른 선택지와 비교하기 쉬워요.",
+		"가격을 넣으면 이번 달 예산과 더 정확히 비교할 수 있어요.",
+		"가격 정보가 있으면 기회비용을 더 잘 계산할 수 있어요."
 	);
 
 	private final JdbcTemplate jdbcTemplate;
@@ -150,9 +161,13 @@ public class DeliberationService {
 
 	private String opportunityCostMessage(ItemSummary item) {
 		if (item.listedPrice() == null || item.listedPrice() == 0) {
-			return "가격을 입력하면 다른 선택지와 비교하기 쉬워요.";
+			return randomValue(NO_PRICE_OPPORTUNITY_COST_MESSAGES);
 		}
-		return "%,d원을 다른 곳에 쓸 수도 있어요.".formatted(item.listedPrice());
+		return randomValue(PRICE_OPPORTUNITY_COST_MESSAGE_FORMATS).formatted(item.listedPrice());
+	}
+
+	private String randomValue(List<String> values) {
+		return values.get(ThreadLocalRandom.current().nextInt(values.size()));
 	}
 
 	private BigDecimal usageRate(int spentAmount, int monthlyBudgetAmount) {

--- a/src/main/java/com/sagongsa/backend/domain/social/FeedPostRepository.java
+++ b/src/main/java/com/sagongsa/backend/domain/social/FeedPostRepository.java
@@ -29,6 +29,32 @@ public interface FeedPostRepository extends JpaRepository<FeedPost, UUID> {
 	@Query("SELECT p FROM FeedPost p LEFT JOIN FETCH p.item WHERE p.user.id = :userId AND p.deletedAt IS NULL AND p.moderationStatus = com.sagongsa.backend.domain.enums.ModerationStatus.ACTIVE AND p.createdAt < :cursor ORDER BY p.createdAt DESC")
 	List<FeedPost> findByUserIdVisibleBefore(@Param("userId") UUID userId, @Param("cursor") Instant cursor, Pageable pageable);
 
+	@Query("""
+		SELECT p
+		FROM FeedPost p
+		LEFT JOIN FETCH p.item item
+		WHERE p.user.id = :userId
+		  AND p.deletedAt IS NULL
+		  AND p.moderationStatus = com.sagongsa.backend.domain.enums.ModerationStatus.ACTIVE
+		  AND p.createdAt >= :cutoff
+		  AND ((:itemId IS NULL AND item IS NULL) OR item.id = :itemId)
+		  AND ((:title IS NULL AND p.title IS NULL) OR p.title = :title)
+		  AND ((:body IS NULL AND p.body IS NULL) OR p.body = :body)
+		  AND ((:imageUrl IS NULL AND p.imageUrl IS NULL) OR p.imageUrl = :imageUrl)
+		  AND ((:price IS NULL AND p.price IS NULL) OR p.price = :price)
+		ORDER BY p.createdAt DESC, p.id DESC
+		""")
+	List<FeedPost> findRecentDuplicates(
+		@Param("userId") UUID userId,
+		@Param("itemId") UUID itemId,
+		@Param("title") String title,
+		@Param("body") String body,
+		@Param("imageUrl") String imageUrl,
+		@Param("price") Integer price,
+		@Param("cutoff") Instant cutoff,
+		Pageable pageable
+	);
+
 	long countByUserIdAndDeletedAtIsNullAndModerationStatus(UUID userId, com.sagongsa.backend.domain.enums.ModerationStatus moderationStatus);
 
 	@Modifying

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
@@ -388,13 +388,17 @@ public class ShoppingLinkImportService {
 	}
 
 	private EmbeddedMetadata embeddedMetadata(JsonNode node) {
+		return embeddedMetadata(node, false);
+	}
+
+	private EmbeddedMetadata embeddedMetadata(JsonNode node, boolean productContext) {
 		if (node == null || node.isNull()) {
 			return EmbeddedMetadata.empty();
 		}
 		if (node.isArray()) {
 			EmbeddedMetadata metadata = EmbeddedMetadata.empty();
 			for (JsonNode child : node) {
-				metadata = metadata.merge(embeddedMetadata(child));
+				metadata = metadata.merge(embeddedMetadata(child, productContext));
 				if (metadata.hasAllProductValues()) {
 					return metadata;
 				}
@@ -411,19 +415,20 @@ public class ShoppingLinkImportService {
 			Map.Entry<String, JsonNode> field = fields.next();
 			String key = field.getKey().toLowerCase(Locale.ROOT);
 			JsonNode value = field.getValue();
+			boolean nestedProductContext = productContext || isProductContainerKey(key);
 			if (value.isValueNode()) {
 				String text = normalizeWhitespace(value.asText());
-				if (isProductTitleKey(key)) {
-					metadata = metadata.withTitle(text);
+				if (isProductTitleKey(key, productContext)) {
+					metadata = metadata.withTitle(text, keyPriority(key, productContext));
 				} else if (isDescriptionKey(key)) {
-					metadata = metadata.withDescription(text);
-				} else if (isPriceKey(key)) {
-					metadata = metadata.withPriceText(text);
-				} else if (isImageKey(key)) {
-					metadata = metadata.withImageUrl(text);
+					metadata = metadata.withDescription(text, keyPriority(key, productContext));
+				} else if (isPriceKey(key, productContext)) {
+					metadata = metadata.withPriceText(text, keyPriority(key, productContext));
+				} else if (isImageKey(key, productContext)) {
+					metadata = metadata.withImageUrl(text, keyPriority(key, productContext));
 				}
 			}
-			metadata = metadata.merge(embeddedMetadata(value));
+			metadata = metadata.merge(embeddedMetadata(value, nestedProductContext));
 			if (metadata.hasAllProductValues()) {
 				return metadata;
 			}
@@ -447,9 +452,17 @@ public class ShoppingLinkImportService {
 		return trimmed.substring(start, end + 1);
 	}
 
-	private boolean isProductTitleKey(String key) {
-		return key.equals("name") || key.equals("title") || key.equals("productname")
-			|| key.equals("product_name") || key.equals("goodsnm") || key.equals("goodsname")
+	private boolean isProductContainerKey(String key) {
+		return key.contains("product") || key.contains("goods") || key.equals("item");
+	}
+
+	private boolean isProductTitleKey(String key, boolean productContext) {
+		return isStrongProductTitleKey(key) || (productContext && (key.equals("name") || key.equals("title")));
+	}
+
+	private boolean isStrongProductTitleKey(String key) {
+		return key.equals("productname") || key.equals("product_name")
+			|| key.equals("goodsnm") || key.equals("goodsname")
 			|| key.equals("itemname") || key.equals("item_name");
 	}
 
@@ -457,17 +470,31 @@ public class ShoppingLinkImportService {
 		return key.equals("description") || key.equals("summary") || key.equals("content");
 	}
 
-	private boolean isPriceKey(String key) {
-		return key.equals("price") || key.equals("saleprice") || key.equals("sale_price")
-			|| key.equals("finalprice") || key.equals("final_price") || key.equals("discountedprice")
-			|| key.equals("discounted_price") || key.equals("goodsprice") || key.equals("sellprice")
-			|| key.equals("amount");
+	private boolean isPriceKey(String key, boolean productContext) {
+		return isStrongPriceKey(key) || (productContext && (key.equals("price") || key.equals("amount")));
 	}
 
-	private boolean isImageKey(String key) {
-		return key.equals("image") || key.equals("imageurl") || key.equals("image_url")
-			|| key.equals("thumbnail") || key.equals("thumbnailurl") || key.equals("thumbnail_url")
+	private boolean isStrongPriceKey(String key) {
+		return key.equals("saleprice") || key.equals("sale_price")
+			|| key.equals("finalprice") || key.equals("final_price") || key.equals("discountedprice")
+			|| key.equals("discounted_price") || key.equals("goodsprice") || key.equals("sellprice");
+	}
+
+	private boolean isImageKey(String key, boolean productContext) {
+		return isStrongImageKey(key) || (productContext && (key.equals("image") || key.equals("thumbnail")));
+	}
+
+	private boolean isStrongImageKey(String key) {
+		return key.equals("imageurl") || key.equals("image_url")
+			|| key.equals("thumbnailurl") || key.equals("thumbnail_url")
 			|| key.equals("mainimage") || key.equals("main_image");
+	}
+
+	private int keyPriority(String key, boolean productContext) {
+		if (isStrongProductTitleKey(key) || isStrongPriceKey(key) || isStrongImageKey(key)) {
+			return 3;
+		}
+		return productContext ? 2 : 1;
 	}
 
 	private String searchJson(JsonNode node, String[] path) {
@@ -760,37 +787,81 @@ public class ShoppingLinkImportService {
 
 	private record EmbeddedMetadata(
 		String title,
+		int titlePriority,
 		String description,
+		int descriptionPriority,
 		String priceText,
-		String imageUrl
+		int pricePriority,
+		String imageUrl,
+		int imagePriority
 	) {
 		private static EmbeddedMetadata empty() {
-			return new EmbeddedMetadata(null, null, null, null);
+			return new EmbeddedMetadata(null, 0, null, 0, null, 0, null, 0);
 		}
 
 		private EmbeddedMetadata merge(EmbeddedMetadata other) {
 			return new EmbeddedMetadata(
-				firstValue(title, other.title),
-				firstValue(description, other.description),
-				firstValue(priceText, other.priceText),
-				firstValue(imageUrl, other.imageUrl)
+				bestValue(title, titlePriority, other.title, other.titlePriority),
+				bestPriority(title, titlePriority, other.title, other.titlePriority),
+				bestValue(description, descriptionPriority, other.description, other.descriptionPriority),
+				bestPriority(description, descriptionPriority, other.description, other.descriptionPriority),
+				bestValue(priceText, pricePriority, other.priceText, other.pricePriority),
+				bestPriority(priceText, pricePriority, other.priceText, other.pricePriority),
+				bestValue(imageUrl, imagePriority, other.imageUrl, other.imagePriority),
+				bestPriority(imageUrl, imagePriority, other.imageUrl, other.imagePriority)
 			);
 		}
 
-		private EmbeddedMetadata withTitle(String value) {
-			return new EmbeddedMetadata(firstValue(title, value), description, priceText, imageUrl);
+		private EmbeddedMetadata withTitle(String value, int priority) {
+			return new EmbeddedMetadata(
+				bestValue(title, titlePriority, value, priority),
+				bestPriority(title, titlePriority, value, priority),
+				description,
+				descriptionPriority,
+				priceText,
+				pricePriority,
+				imageUrl,
+				imagePriority
+			);
 		}
 
-		private EmbeddedMetadata withDescription(String value) {
-			return new EmbeddedMetadata(title, firstValue(description, value), priceText, imageUrl);
+		private EmbeddedMetadata withDescription(String value, int priority) {
+			return new EmbeddedMetadata(
+				title,
+				titlePriority,
+				bestValue(description, descriptionPriority, value, priority),
+				bestPriority(description, descriptionPriority, value, priority),
+				priceText,
+				pricePriority,
+				imageUrl,
+				imagePriority
+			);
 		}
 
-		private EmbeddedMetadata withPriceText(String value) {
-			return new EmbeddedMetadata(title, description, firstValue(priceText, value), imageUrl);
+		private EmbeddedMetadata withPriceText(String value, int priority) {
+			return new EmbeddedMetadata(
+				title,
+				titlePriority,
+				description,
+				descriptionPriority,
+				bestValue(priceText, pricePriority, value, priority),
+				bestPriority(priceText, pricePriority, value, priority),
+				imageUrl,
+				imagePriority
+			);
 		}
 
-		private EmbeddedMetadata withImageUrl(String value) {
-			return new EmbeddedMetadata(title, description, priceText, firstValue(imageUrl, value));
+		private EmbeddedMetadata withImageUrl(String value, int priority) {
+			return new EmbeddedMetadata(
+				title,
+				titlePriority,
+				description,
+				descriptionPriority,
+				priceText,
+				pricePriority,
+				bestValue(imageUrl, imagePriority, value, priority),
+				bestPriority(imageUrl, imagePriority, value, priority)
+			);
 		}
 
 		private boolean hasAnyValue() {
@@ -801,8 +872,24 @@ public class ShoppingLinkImportService {
 			return title != null && priceText != null && imageUrl != null;
 		}
 
-		private static String firstValue(String current, String next) {
-			return current != null ? current : next;
+		private static String bestValue(String current, int currentPriority, String next, int nextPriority) {
+			if (next == null) {
+				return current;
+			}
+			if (current == null || nextPriority > currentPriority) {
+				return next;
+			}
+			return current;
+		}
+
+		private static int bestPriority(String current, int currentPriority, String next, int nextPriority) {
+			if (next == null) {
+				return currentPriority;
+			}
+			if (current == null || nextPriority > currentPriority) {
+				return nextPriority;
+			}
+			return currentPriority;
 		}
 	}
 

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
@@ -491,8 +491,11 @@ public class ShoppingLinkImportService {
 	}
 
 	private int keyPriority(String key, boolean productContext) {
-		if (isStrongProductTitleKey(key) || isStrongPriceKey(key) || isStrongImageKey(key)) {
+		if (isStrongProductTitleKey(key) || isStrongPriceKey(key)) {
 			return 3;
+		}
+		if (isStrongImageKey(key)) {
+			return productContext ? 3 : 1;
 		}
 		return productContext ? 2 : 1;
 	}

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
@@ -216,17 +216,20 @@ public class ShoppingLinkImportService {
 	private ExtractionResult extractFromPage(Document document, FetchedPage page) {
 		String html = page.body();
 		String sourceDomain = sourceDomain(page.finalUri());
+		EmbeddedMetadata embeddedMetadata = embeddedMetadata(document);
 		String summary = firstNonBlank(
 			metaContent(document, "meta[property=og:description]"),
 			metaContent(document, "meta[name=description]"),
 			metaContent(document, "meta[name=twitter:description]"),
-			jsonLdText(document, "description")
+			jsonLdText(document, "description"),
+			embeddedMetadata.description()
 		);
 		String title = firstProductTitle(
 			sourceDomain,
 			metaContent(document, "meta[property=og:title]"),
 			metaContent(document, "meta[name=twitter:title]"),
 			jsonLdText(document, "name"),
+			embeddedMetadata.title(),
 			normalizeWhitespace(document.title()),
 			firstText(document, "h1", "[data-testid=productName]", ".prod-buy-header__title")
 		);
@@ -238,33 +241,38 @@ public class ShoppingLinkImportService {
 		);
 
 		Integer price = firstNonNull(
-			parsePrice(metaContent(document, "meta[property=product:price:amount]")),
-			parsePrice(metaContent(document, "meta[property=og:price:amount]")),
-			parsePrice(jsonLdText(document, "offers.price")),
-			parsePrice(jsonLdText(document, "price")),
-			parsePrice(findByRegex(html, PRICE_WITH_CURRENCY_PATTERN))
-		);
-		String rawPriceText = firstNonBlank(
-			metaContent(document, "meta[property=product:price:amount]"),
-			metaContent(document, "meta[property=og:price:amount]"),
-			jsonLdText(document, "offers.price"),
-			jsonLdText(document, "price"),
-			findByRegex(html, PRICE_WITH_CURRENCY_PATTERN)
-		);
+				parsePrice(metaContent(document, "meta[property=product:price:amount]")),
+				parsePrice(metaContent(document, "meta[property=og:price:amount]")),
+				parsePrice(jsonLdText(document, "offers.price")),
+				parsePrice(jsonLdText(document, "price")),
+				parsePrice(embeddedMetadata.priceText()),
+				parsePrice(findByRegex(html, PRICE_WITH_CURRENCY_PATTERN))
+			);
+			String rawPriceText = firstNonBlank(
+				metaContent(document, "meta[property=product:price:amount]"),
+				metaContent(document, "meta[property=og:price:amount]"),
+				jsonLdText(document, "offers.price"),
+				jsonLdText(document, "price"),
+				embeddedMetadata.priceText(),
+				findByRegex(html, PRICE_WITH_CURRENCY_PATTERN)
+			);
 
-		String imageUrl = firstNonBlank(
-			normalizeImageUrl(metaContent(document, "meta[property=og:image]")),
-			normalizeImageUrl(metaContent(document, "meta[name=twitter:image]")),
-			normalizeImageUrl(jsonLdText(document, "image")),
-			bestImage(document)
-		);
+			String imageUrl = firstNonBlank(
+				normalizeImageUrl(metaContent(document, "meta[property=og:image]")),
+				normalizeImageUrl(metaContent(document, "meta[name=twitter:image]")),
+				normalizeImageUrl(jsonLdText(document, "image")),
+				normalizeImageUrl(embeddedMetadata.imageUrl()),
+				bestImage(document)
+			);
 
-		String method = "OPEN_GRAPH";
-		if (!isBlank(jsonLdText(document, "name")) || !isBlank(jsonLdText(document, "offers.price"))) {
-			method = "JSON_LD";
-		} else if (title != null || price != null || imageUrl != null) {
-			method = "HTML_META";
-		}
+			String method = "OPEN_GRAPH";
+			if (!isBlank(jsonLdText(document, "name")) || !isBlank(jsonLdText(document, "offers.price"))) {
+				method = "JSON_LD";
+			} else if (embeddedMetadata.hasAnyValue()) {
+				method = "EMBEDDED_JSON";
+			} else if (title != null || price != null || imageUrl != null) {
+				method = "HTML_META";
+			}
 
 		Map<String, Object> rawPayloadJson = new LinkedHashMap<>();
 		rawPayloadJson.put("requestedUrl", page.requestedUri().toString());
@@ -357,6 +365,109 @@ public class ShoppingLinkImportService {
 		} catch (JsonProcessingException exception) {
 			return null;
 		}
+	}
+
+	private EmbeddedMetadata embeddedMetadata(Document document) {
+		EmbeddedMetadata metadata = EmbeddedMetadata.empty();
+		for (Element scriptElement : document.select("script")) {
+			String rawScript = firstNonBlank(scriptElement.data(), scriptElement.html());
+			String json = jsonCandidate(rawScript);
+			if (json == null) {
+				continue;
+			}
+			try {
+				metadata = metadata.merge(embeddedMetadata(objectMapper.readTree(json)));
+				if (metadata.hasAllProductValues()) {
+					return metadata;
+				}
+			} catch (JsonProcessingException ignored) {
+				// Third-party commerce pages often include non-JSON scripts; skip those safely.
+			}
+		}
+		return metadata;
+	}
+
+	private EmbeddedMetadata embeddedMetadata(JsonNode node) {
+		if (node == null || node.isNull()) {
+			return EmbeddedMetadata.empty();
+		}
+		if (node.isArray()) {
+			EmbeddedMetadata metadata = EmbeddedMetadata.empty();
+			for (JsonNode child : node) {
+				metadata = metadata.merge(embeddedMetadata(child));
+				if (metadata.hasAllProductValues()) {
+					return metadata;
+				}
+			}
+			return metadata;
+		}
+		if (!node.isObject()) {
+			return EmbeddedMetadata.empty();
+		}
+
+		EmbeddedMetadata metadata = EmbeddedMetadata.empty();
+		Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+		while (fields.hasNext()) {
+			Map.Entry<String, JsonNode> field = fields.next();
+			String key = field.getKey().toLowerCase(Locale.ROOT);
+			JsonNode value = field.getValue();
+			if (value.isValueNode()) {
+				String text = normalizeWhitespace(value.asText());
+				if (isProductTitleKey(key)) {
+					metadata = metadata.withTitle(text);
+				} else if (isDescriptionKey(key)) {
+					metadata = metadata.withDescription(text);
+				} else if (isPriceKey(key)) {
+					metadata = metadata.withPriceText(text);
+				} else if (isImageKey(key)) {
+					metadata = metadata.withImageUrl(text);
+				}
+			}
+			metadata = metadata.merge(embeddedMetadata(value));
+			if (metadata.hasAllProductValues()) {
+				return metadata;
+			}
+		}
+		return metadata;
+	}
+
+	private String jsonCandidate(String rawScript) {
+		if (isBlank(rawScript)) {
+			return null;
+		}
+		String trimmed = rawScript.trim();
+		if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+			return trimmed;
+		}
+		int start = trimmed.indexOf('{');
+		int end = trimmed.lastIndexOf('}');
+		if (start < 0 || end <= start) {
+			return null;
+		}
+		return trimmed.substring(start, end + 1);
+	}
+
+	private boolean isProductTitleKey(String key) {
+		return key.equals("name") || key.equals("title") || key.equals("productname")
+			|| key.equals("product_name") || key.equals("goodsnm") || key.equals("goodsname")
+			|| key.equals("itemname") || key.equals("item_name");
+	}
+
+	private boolean isDescriptionKey(String key) {
+		return key.equals("description") || key.equals("summary") || key.equals("content");
+	}
+
+	private boolean isPriceKey(String key) {
+		return key.equals("price") || key.equals("saleprice") || key.equals("sale_price")
+			|| key.equals("finalprice") || key.equals("final_price") || key.equals("discountedprice")
+			|| key.equals("discounted_price") || key.equals("goodsprice") || key.equals("sellprice")
+			|| key.equals("amount");
+	}
+
+	private boolean isImageKey(String key) {
+		return key.equals("image") || key.equals("imageurl") || key.equals("image_url")
+			|| key.equals("thumbnail") || key.equals("thumbnailurl") || key.equals("thumbnail_url")
+			|| key.equals("mainimage") || key.equals("main_image");
 	}
 
 	private String searchJson(JsonNode node, String[] path) {
@@ -645,6 +756,54 @@ public class ShoppingLinkImportService {
 	}
 
 	private record NormalizationResult(URI uri, List<String> warnings) {
+	}
+
+	private record EmbeddedMetadata(
+		String title,
+		String description,
+		String priceText,
+		String imageUrl
+	) {
+		private static EmbeddedMetadata empty() {
+			return new EmbeddedMetadata(null, null, null, null);
+		}
+
+		private EmbeddedMetadata merge(EmbeddedMetadata other) {
+			return new EmbeddedMetadata(
+				firstValue(title, other.title),
+				firstValue(description, other.description),
+				firstValue(priceText, other.priceText),
+				firstValue(imageUrl, other.imageUrl)
+			);
+		}
+
+		private EmbeddedMetadata withTitle(String value) {
+			return new EmbeddedMetadata(firstValue(title, value), description, priceText, imageUrl);
+		}
+
+		private EmbeddedMetadata withDescription(String value) {
+			return new EmbeddedMetadata(title, firstValue(description, value), priceText, imageUrl);
+		}
+
+		private EmbeddedMetadata withPriceText(String value) {
+			return new EmbeddedMetadata(title, description, firstValue(priceText, value), imageUrl);
+		}
+
+		private EmbeddedMetadata withImageUrl(String value) {
+			return new EmbeddedMetadata(title, description, priceText, firstValue(imageUrl, value));
+		}
+
+		private boolean hasAnyValue() {
+			return title != null || description != null || priceText != null || imageUrl != null;
+		}
+
+		private boolean hasAllProductValues() {
+			return title != null && priceText != null && imageUrl != null;
+		}
+
+		private static String firstValue(String current, String next) {
+			return current != null ? current : next;
+		}
 	}
 
 	private record ExtractionResult(

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
@@ -241,38 +241,38 @@ public class ShoppingLinkImportService {
 		);
 
 		Integer price = firstNonNull(
-				parsePrice(metaContent(document, "meta[property=product:price:amount]")),
-				parsePrice(metaContent(document, "meta[property=og:price:amount]")),
-				parsePrice(jsonLdText(document, "offers.price")),
-				parsePrice(jsonLdText(document, "price")),
-				parsePrice(embeddedMetadata.priceText()),
-				parsePrice(findByRegex(html, PRICE_WITH_CURRENCY_PATTERN))
-			);
-			String rawPriceText = firstNonBlank(
-				metaContent(document, "meta[property=product:price:amount]"),
-				metaContent(document, "meta[property=og:price:amount]"),
-				jsonLdText(document, "offers.price"),
-				jsonLdText(document, "price"),
-				embeddedMetadata.priceText(),
-				findByRegex(html, PRICE_WITH_CURRENCY_PATTERN)
-			);
+			parsePrice(metaContent(document, "meta[property=product:price:amount]")),
+			parsePrice(metaContent(document, "meta[property=og:price:amount]")),
+			parsePrice(jsonLdText(document, "offers.price")),
+			parsePrice(jsonLdText(document, "price")),
+			parsePrice(embeddedMetadata.priceText()),
+			parsePrice(findByRegex(html, PRICE_WITH_CURRENCY_PATTERN))
+		);
+		String rawPriceText = firstNonBlank(
+			metaContent(document, "meta[property=product:price:amount]"),
+			metaContent(document, "meta[property=og:price:amount]"),
+			jsonLdText(document, "offers.price"),
+			jsonLdText(document, "price"),
+			embeddedMetadata.priceText(),
+			findByRegex(html, PRICE_WITH_CURRENCY_PATTERN)
+		);
 
-			String imageUrl = firstNonBlank(
-				normalizeImageUrl(metaContent(document, "meta[property=og:image]")),
-				normalizeImageUrl(metaContent(document, "meta[name=twitter:image]")),
-				normalizeImageUrl(jsonLdText(document, "image")),
-				normalizeImageUrl(embeddedMetadata.imageUrl()),
-				bestImage(document)
-			);
+		String imageUrl = firstNonBlank(
+			normalizeImageUrl(metaContent(document, "meta[property=og:image]")),
+			normalizeImageUrl(metaContent(document, "meta[name=twitter:image]")),
+			normalizeImageUrl(jsonLdText(document, "image")),
+			normalizeImageUrl(embeddedMetadata.imageUrl()),
+			bestImage(document)
+		);
 
-			String method = "OPEN_GRAPH";
-			if (!isBlank(jsonLdText(document, "name")) || !isBlank(jsonLdText(document, "offers.price"))) {
-				method = "JSON_LD";
-			} else if (embeddedMetadata.hasAnyValue()) {
-				method = "EMBEDDED_JSON";
-			} else if (title != null || price != null || imageUrl != null) {
-				method = "HTML_META";
-			}
+		String method = "OPEN_GRAPH";
+		if (!isBlank(jsonLdText(document, "name")) || !isBlank(jsonLdText(document, "offers.price"))) {
+			method = "JSON_LD";
+		} else if (embeddedMetadata.hasAnyValue()) {
+			method = "EMBEDDED_JSON";
+		} else if (title != null || price != null || imageUrl != null) {
+			method = "HTML_META";
+		}
 
 		Map<String, Object> rawPayloadJson = new LinkedHashMap<>();
 		rawPayloadJson.put("requestedUrl", page.requestedUri().toString());

--- a/src/main/java/com/sagongsa/backend/notification/NotificationTriggerWorker.java
+++ b/src/main/java/com/sagongsa/backend/notification/NotificationTriggerWorker.java
@@ -17,7 +17,6 @@ public class NotificationTriggerWorker {
 
 	private static final int BATCH_SIZE = 50;
 	private static final ZoneId KOREA_ZONE_ID = ZoneId.of("Asia/Seoul");
-	private static final int RETENTION_MONTHS = 1;
 
 	private final JdbcTemplate jdbcTemplate;
 	private final NotificationPublisher notificationPublisher;
@@ -32,7 +31,6 @@ public class NotificationTriggerWorker {
 	}
 
 	int processDueNotifications(OffsetDateTime now) {
-		deleteExpiredNotifications(now);
 		int createdCount = 0;
 		createdCount += publishVoteSummaries(now);
 		createdCount += publishDecisionNudges(now);
@@ -40,13 +38,6 @@ public class NotificationTriggerWorker {
 		createdCount += publishWishlistReminders(now.minusDays(3));
 		createdCount += publishBudgetResetIfDue(now);
 		return createdCount;
-	}
-
-	private void deleteExpiredNotifications(OffsetDateTime now) {
-		jdbcTemplate.update(
-			"delete from notifications where created_at < ?",
-			now.minusMonths(RETENTION_MONTHS)
-		);
 	}
 
 	private int publishVoteSummaries(OffsetDateTime now) {

--- a/src/main/java/com/sagongsa/backend/notification/NotificationTriggerWorker.java
+++ b/src/main/java/com/sagongsa/backend/notification/NotificationTriggerWorker.java
@@ -17,6 +17,7 @@ public class NotificationTriggerWorker {
 
 	private static final int BATCH_SIZE = 50;
 	private static final ZoneId KOREA_ZONE_ID = ZoneId.of("Asia/Seoul");
+	private static final int RETENTION_MONTHS = 1;
 
 	private final JdbcTemplate jdbcTemplate;
 	private final NotificationPublisher notificationPublisher;
@@ -31,6 +32,7 @@ public class NotificationTriggerWorker {
 	}
 
 	int processDueNotifications(OffsetDateTime now) {
+		deleteExpiredNotifications(now);
 		int createdCount = 0;
 		createdCount += publishVoteSummaries(now);
 		createdCount += publishDecisionNudges(now);
@@ -38,6 +40,13 @@ public class NotificationTriggerWorker {
 		createdCount += publishWishlistReminders(now.minusDays(3));
 		createdCount += publishBudgetResetIfDue(now);
 		return createdCount;
+	}
+
+	private void deleteExpiredNotifications(OffsetDateTime now) {
+		jdbcTemplate.update(
+			"delete from notifications where created_at < ?",
+			now.minusMonths(RETENTION_MONTHS)
+		);
 	}
 
 	private int publishVoteSummaries(OffsetDateTime now) {

--- a/src/main/java/com/sagongsa/backend/onboarding/OnboardingService.java
+++ b/src/main/java/com/sagongsa/backend/onboarding/OnboardingService.java
@@ -240,9 +240,6 @@ public class OnboardingService {
 	private static final int NICKNAME_MAX_LENGTH = 8;
 
 	private String requireNicknameText(String value) {
-		if (!value.equals(value.trim())) {
-			throw new OnboardingBadRequestException("nickname must not have leading or trailing whitespace.");
-		}
 		String trimmed = value.trim();
 		if (trimmed.length() < NICKNAME_MIN_LENGTH || trimmed.length() > NICKNAME_MAX_LENGTH) {
 			throw new OnboardingBadRequestException("nickname must be between 2 and 8 characters.");

--- a/src/main/java/com/sagongsa/backend/social/SocialPostService.java
+++ b/src/main/java/com/sagongsa/backend/social/SocialPostService.java
@@ -13,6 +13,7 @@ import com.sagongsa.backend.domain.social.PostVote;
 import com.sagongsa.backend.domain.social.PostVoteRepository;
 import com.sagongsa.backend.domain.user.UserProfile;
 import com.sagongsa.backend.domain.user.UserProfileRepository;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -27,6 +28,8 @@ import org.springframework.util.StringUtils;
 @Service
 @Transactional(readOnly = true)
 class SocialPostService {
+
+	private static final Duration POST_DUPLICATE_WINDOW = Duration.ofSeconds(30);
 
 	private final FeedPostRepository feedPostRepository;
 	private final PostVoteRepository postVoteRepository;
@@ -57,6 +60,12 @@ class SocialPostService {
 		UserAccount user = findUserOrThrow(userId);
 		SavedItem item = resolveItem(userId, request.itemId());
 		String imageUrl = resolveImageUrl(request.imageUrl(), item);
+		FeedPost duplicate = findRecentDuplicatePost(userId, request, item, imageUrl);
+		if (duplicate != null) {
+			String authorNickname = userProfileRepository.findByUserId(userId).isPresent()
+				? UserProfile.POST_AUTHOR_NICKNAME : UserProfile.UNKNOWN_NICKNAME;
+			return PostResponse.of(duplicate, authorNickname, countVisibleCommentsByPostId(duplicate.getId(), Collections.emptyList()), null, userId);
+		}
 		FeedPost post = new FeedPost(user, item, request.title(), request.body(), imageUrl, request.price());
 		feedPostRepository.save(post);
 		String authorNickname = userProfileRepository.findByUserId(userId).isPresent()
@@ -200,6 +209,22 @@ class SocialPostService {
 		if (itemId == null) return null;
 		return savedItemRepository.findById(itemId)
 			.filter(item -> item.getUser().getId().equals(userId))
+			.orElse(null);
+	}
+
+	private FeedPost findRecentDuplicatePost(UUID userId, CreatePostRequest request, SavedItem item, String imageUrl) {
+		return feedPostRepository.findRecentDuplicates(
+				userId,
+				item == null ? null : item.getId(),
+				request.title(),
+				request.body(),
+				imageUrl,
+				request.price(),
+				Instant.now().minus(POST_DUPLICATE_WINDOW),
+				PageRequest.of(0, 1)
+			)
+			.stream()
+			.findFirst()
 			.orElse(null);
 	}
 

--- a/src/main/java/com/sagongsa/backend/social/SocialPostService.java
+++ b/src/main/java/com/sagongsa/backend/social/SocialPostService.java
@@ -13,6 +13,10 @@ import com.sagongsa.backend.domain.social.PostVote;
 import com.sagongsa.backend.domain.social.PostVoteRepository;
 import com.sagongsa.backend.domain.user.UserProfile;
 import com.sagongsa.backend.domain.user.UserProfileRepository;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
@@ -21,6 +25,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -38,6 +43,7 @@ class SocialPostService {
 	private final UserProfileRepository userProfileRepository;
 	private final SavedItemRepository savedItemRepository;
 	private final BlockService blockService;
+	private final JdbcTemplate jdbcTemplate;
 
 	SocialPostService(FeedPostRepository feedPostRepository,
 		PostVoteRepository postVoteRepository,
@@ -45,7 +51,8 @@ class SocialPostService {
 		UserAccountRepository userAccountRepository,
 		UserProfileRepository userProfileRepository,
 		SavedItemRepository savedItemRepository,
-		BlockService blockService) {
+		BlockService blockService,
+		JdbcTemplate jdbcTemplate) {
 		this.feedPostRepository = feedPostRepository;
 		this.postVoteRepository = postVoteRepository;
 		this.postCommentRepository = postCommentRepository;
@@ -53,6 +60,7 @@ class SocialPostService {
 		this.userProfileRepository = userProfileRepository;
 		this.savedItemRepository = savedItemRepository;
 		this.blockService = blockService;
+		this.jdbcTemplate = jdbcTemplate;
 	}
 
 	@Transactional
@@ -60,6 +68,7 @@ class SocialPostService {
 		UserAccount user = findUserOrThrow(userId);
 		SavedItem item = resolveItem(userId, request.itemId());
 		String imageUrl = resolveImageUrl(request.imageUrl(), item);
+		acquireDuplicateLock(postDuplicateLockKey(userId, request, item, imageUrl));
 		FeedPost duplicate = findRecentDuplicatePost(userId, request, item, imageUrl);
 		if (duplicate != null) {
 			String authorNickname = userProfileRepository.findByUserId(userId).isPresent()
@@ -226,6 +235,42 @@ class SocialPostService {
 			.stream()
 			.findFirst()
 			.orElse(null);
+	}
+
+	private void acquireDuplicateLock(long lockKey) {
+		jdbcTemplate.query("select pg_advisory_xact_lock(?)", resultSet -> {
+		}, lockKey);
+	}
+
+	private long postDuplicateLockKey(UUID userId, CreatePostRequest request, SavedItem item, String imageUrl) {
+		return lockKey(
+			"social-post-create",
+			userId,
+			item == null ? null : item.getId(),
+			request.title(),
+			request.body(),
+			imageUrl,
+			request.price()
+		);
+	}
+
+	private long lockKey(String namespace, Object... values) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			updateDigest(digest, namespace);
+			for (Object value : values) {
+				updateDigest(digest, value == null ? null : value.toString());
+			}
+			return ByteBuffer.wrap(digest.digest()).getLong();
+		} catch (NoSuchAlgorithmException exception) {
+			throw new IllegalStateException("SHA-256 digest is not available", exception);
+		}
+	}
+
+	private void updateDigest(MessageDigest digest, String value) {
+		byte[] bytes = value == null ? new byte[0] : value.getBytes(StandardCharsets.UTF_8);
+		digest.update(ByteBuffer.allocate(Integer.BYTES).putInt(bytes.length).array());
+		digest.update(bytes);
 	}
 
 	private String resolveImageUrl(String requestImageUrl, SavedItem item) {

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
@@ -7,9 +7,13 @@ import com.sagongsa.backend.domain.enums.ItemInputSource;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.time.Duration;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -67,25 +71,37 @@ public class WishlistService {
 		boolean categoryLockedByUser = Boolean.TRUE.equals(request.categoryLockedByUser());
 		MetadataFields metadata = metadataFields(request);
 
-			Optional<WishlistItemResponse> existingItem = findExistingSavedNormalizedUrl(userId, normalizedUrl);
-			if (existingItem.isPresent()) {
-				throw new DuplicateSavedItemException(
-					"Saved wishlist item already exists for the normalized URL.",
-					existingItem.get()
-				);
-			}
+		Optional<WishlistItemResponse> existingItem = findExistingSavedNormalizedUrl(userId, normalizedUrl);
+		if (existingItem.isPresent()) {
+			throw new DuplicateSavedItemException(
+				"Saved wishlist item already exists for the normalized URL.",
+				existingItem.get()
+			);
+		}
 
-			UUID itemId = UUID.randomUUID();
-			OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-			findRecentDuplicateDirectInput(userId, inputSource, normalizedUrl, title, imageUrl, listedPrice, currencyCode, category, now)
-				.ifPresent(duplicateItem -> {
-					throw new DuplicateSavedItemException(
-						"Saved wishlist item already exists for the same direct input.",
-						duplicateItem
-					);
-				});
-			try {
-				jdbcTemplate.update(
+		if (requiresDirectInputDuplicateGuard(inputSource, normalizedUrl)) {
+			acquireDuplicateLock(directInputDuplicateLockKey(userId, title, imageUrl, listedPrice, currencyCode, category));
+		}
+
+		UUID itemId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		Optional<WishlistItemResponse> recentDuplicate = findRecentDuplicateDirectInput(
+			userId,
+			inputSource,
+			normalizedUrl,
+			title,
+			imageUrl,
+			listedPrice,
+			currencyCode,
+			category,
+			now
+		);
+		if (recentDuplicate.isPresent()) {
+			return recentDuplicate.get();
+		}
+
+		try {
+			jdbcTemplate.update(
 				"""
 				insert into saved_items (
 					id, user_id, input_source, original_url, normalized_url, title, image_url,
@@ -453,6 +469,53 @@ public class WishlistService {
 			now.minus(DIRECT_INPUT_DUPLICATE_WINDOW)
 		);
 		return items.stream().findFirst();
+	}
+
+	private boolean requiresDirectInputDuplicateGuard(ItemInputSource inputSource, String normalizedUrl) {
+		return inputSource == ItemInputSource.DIRECT_INPUT && !StringUtils.hasText(normalizedUrl);
+	}
+
+	private void acquireDuplicateLock(long lockKey) {
+		jdbcTemplate.query("select pg_advisory_xact_lock(?)", resultSet -> {
+		}, lockKey);
+	}
+
+	private long directInputDuplicateLockKey(
+		UUID userId,
+		String title,
+		String imageUrl,
+		Integer listedPrice,
+		String currencyCode,
+		ItemCategory category
+	) {
+		return lockKey(
+			"wishlist-direct-input",
+			userId,
+			title,
+			imageUrl,
+			listedPrice,
+			currencyCode,
+			category.name()
+		);
+	}
+
+	private long lockKey(String namespace, Object... values) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			updateDigest(digest, namespace);
+			for (Object value : values) {
+				updateDigest(digest, value == null ? null : value.toString());
+			}
+			return ByteBuffer.wrap(digest.digest()).getLong();
+		} catch (NoSuchAlgorithmException exception) {
+			throw new IllegalStateException("SHA-256 digest is not available", exception);
+		}
+	}
+
+	private void updateDigest(MessageDigest digest, String value) {
+		byte[] bytes = value == null ? new byte[0] : value.getBytes(StandardCharsets.UTF_8);
+		digest.update(ByteBuffer.allocate(Integer.BYTES).putInt(bytes.length).array());
+		digest.update(bytes);
 	}
 
 	private String baseSelect() {

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
@@ -7,6 +7,7 @@ import com.sagongsa.backend.domain.enums.ItemInputSource;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
@@ -34,6 +35,7 @@ public class WishlistService {
 	private static final BigDecimal MAX_CONFIDENCE = BigDecimal.valueOf(100);
 	private static final int DEFAULT_LIST_LIMIT = 20;
 	private static final int MAX_LIST_LIMIT = 50;
+	private static final Duration DIRECT_INPUT_DUPLICATE_WINDOW = Duration.ofSeconds(30);
 	private static final Set<String> TRACKING_QUERY_KEYS = Set.of(
 		"fbclid", "gclid", "igshid", "mc_cid", "mc_eid", "n_media", "n_query", "n_rank", "n_ad_group"
 	);
@@ -65,18 +67,25 @@ public class WishlistService {
 		boolean categoryLockedByUser = Boolean.TRUE.equals(request.categoryLockedByUser());
 		MetadataFields metadata = metadataFields(request);
 
-		Optional<WishlistItemResponse> existingItem = findExistingSavedNormalizedUrl(userId, normalizedUrl);
-		if (existingItem.isPresent()) {
-			throw new DuplicateSavedItemException(
-				"Saved wishlist item already exists for the normalized URL.",
-				existingItem.get()
-			);
-		}
+			Optional<WishlistItemResponse> existingItem = findExistingSavedNormalizedUrl(userId, normalizedUrl);
+			if (existingItem.isPresent()) {
+				throw new DuplicateSavedItemException(
+					"Saved wishlist item already exists for the normalized URL.",
+					existingItem.get()
+				);
+			}
 
-		UUID itemId = UUID.randomUUID();
-		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-		try {
-			jdbcTemplate.update(
+			UUID itemId = UUID.randomUUID();
+			OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+			findRecentDuplicateDirectInput(userId, inputSource, normalizedUrl, title, imageUrl, listedPrice, currencyCode, category, now)
+				.ifPresent(duplicateItem -> {
+					throw new DuplicateSavedItemException(
+						"Saved wishlist item already exists for the same direct input.",
+						duplicateItem
+					);
+				});
+			try {
+				jdbcTemplate.update(
 				"""
 				insert into saved_items (
 					id, user_id, input_source, original_url, normalized_url, title, image_url,
@@ -401,6 +410,47 @@ public class WishlistService {
 			query.toString(),
 			this::mapRow,
 			parameters.toArray()
+		);
+		return items.stream().findFirst();
+	}
+
+	private Optional<WishlistItemResponse> findRecentDuplicateDirectInput(
+		UUID userId,
+		ItemInputSource inputSource,
+		String normalizedUrl,
+		String title,
+		String imageUrl,
+		Integer listedPrice,
+		String currencyCode,
+		ItemCategory category,
+		OffsetDateTime now
+	) {
+		if (inputSource != ItemInputSource.DIRECT_INPUT || StringUtils.hasText(normalizedUrl)) {
+			return Optional.empty();
+		}
+		List<WishlistItemResponse> items = jdbcTemplate.query(
+			baseSelect() + """
+			where si.user_id = ?
+			  and si.status = 'SAVED'
+			  and si.input_source = 'DIRECT_INPUT'
+			  and si.normalized_url is null
+			  and si.title = ?
+			  and si.image_url is not distinct from ?
+			  and si.listed_price is not distinct from ?
+			  and trim(si.currency_code) is not distinct from ?
+			  and si.category = ?
+			  and si.created_at >= ?
+			order by si.created_at desc, si.id desc
+			limit 1
+			""",
+			this::mapRow,
+			userId,
+			title,
+			imageUrl,
+			listedPrice,
+			currencyCode,
+			category.name(),
+			now.minus(DIRECT_INPUT_DUPLICATE_WINDOW)
 		);
 		return items.stream().findFirst();
 	}

--- a/src/test/java/com/sagongsa/backend/deliberation/DeliberationApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/deliberation/DeliberationApiIntegrationTest.java
@@ -3,6 +3,7 @@ package com.sagongsa.backend.deliberation;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.containsString;
 
 import com.sagongsa.backend.support.PostgreSqlContainerTest;
 import java.time.OffsetDateTime;
@@ -76,7 +77,7 @@ class DeliberationApiIntegrationTest extends PostgreSqlContainerTest {
 		mockMvc.perform(get(BASE + "/{itemId}", itemId)
 				.header("X-User-Id", userId))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.opportunityCostMessage").value("120,000원을 다른 곳에 쓸 수도 있어요."));
+			.andExpect(jsonPath("$.opportunityCostMessage").value(containsString("120,000원")));
 	}
 
 	@Test
@@ -87,7 +88,7 @@ class DeliberationApiIntegrationTest extends PostgreSqlContainerTest {
 		mockMvc.perform(get(BASE + "/{itemId}", itemId)
 				.header("X-User-Id", userId))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.opportunityCostMessage").value("가격을 입력하면 다른 선택지와 비교하기 쉬워요."));
+			.andExpect(jsonPath("$.opportunityCostMessage").isString());
 	}
 
 	// ── 접근 제어 ─────────────────────────────────────────────────────────

--- a/src/test/java/com/sagongsa/backend/deliberation/DeliberationServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/deliberation/DeliberationServiceTest.java
@@ -142,7 +142,8 @@ class DeliberationServiceTest extends PostgreSqlContainerTest {
 		UUID userId = insertActiveUser();
 		UUID itemId = insertSavedItem(userId, "DIGITAL", null, "SAVED");
 		DeliberationSummaryResponse response = deliberationService.getSummary(userId, itemId);
-		assertThat(response.opportunityCostMessage()).isEqualTo("가격을 입력하면 다른 선택지와 비교하기 쉬워요.");
+		assertThat(response.opportunityCostMessage())
+			.isIn(DeliberationService.NO_PRICE_OPPORTUNITY_COST_MESSAGES);
 	}
 
 	@Test
@@ -150,7 +151,8 @@ class DeliberationServiceTest extends PostgreSqlContainerTest {
 		UUID userId = insertActiveUser();
 		UUID itemId = insertSavedItem(userId, "DIGITAL", 0, "SAVED");
 		DeliberationSummaryResponse response = deliberationService.getSummary(userId, itemId);
-		assertThat(response.opportunityCostMessage()).isEqualTo("가격을 입력하면 다른 선택지와 비교하기 쉬워요.");
+		assertThat(response.opportunityCostMessage())
+			.isIn(DeliberationService.NO_PRICE_OPPORTUNITY_COST_MESSAGES);
 	}
 
 	@Test
@@ -158,7 +160,10 @@ class DeliberationServiceTest extends PostgreSqlContainerTest {
 		UUID userId = insertActiveUser();
 		UUID itemId = insertSavedItem(userId, "DIGITAL", 39000, "SAVED");
 		DeliberationSummaryResponse response = deliberationService.getSummary(userId, itemId);
-		assertThat(response.opportunityCostMessage()).isEqualTo("39,000원을 다른 곳에 쓸 수도 있어요.");
+		assertThat(response.opportunityCostMessage())
+			.isIn(DeliberationService.PRICE_OPPORTUNITY_COST_MESSAGE_FORMATS.stream()
+				.map(format -> format.formatted(39000))
+				.toList());
 	}
 
 	// ── TC5: 유사 카테고리 소비 집계 ────────────────────────────────────────

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
@@ -316,7 +316,7 @@ class ShoppingLinkImportServiceTest {
 				        "seo": {
 				          "title": "지그재그 인기 상품",
 				          "amount": 999999,
-				          "image": "https://image.zigzag.kr/seo.jpg"
+				          "imageUrl": "https://image.zigzag.kr/seo.jpg"
 				        },
 				        "product": {
 				          "name": "오버핏 코튼 셔츠",

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
@@ -302,6 +302,56 @@ class ShoppingLinkImportServiceTest {
 	}
 
 	@Test
+	void prefersProductObjectOverGenericEmbeddedJsonKeys() {
+		pageFetcher.stub(
+			"https://zigzag.kr/catalog/products/220",
+			"""
+				<html>
+				<head>
+				  <title>지그재그</title>
+				  <script id="__NEXT_DATA__" type="application/json">
+				  {
+				    "props": {
+				      "pageProps": {
+				        "seo": {
+				          "title": "지그재그 인기 상품",
+				          "amount": 999999,
+				          "image": "https://image.zigzag.kr/seo.jpg"
+				        },
+				        "product": {
+				          "name": "오버핏 코튼 셔츠",
+				          "price": 45000,
+				          "image": "https://image.zigzag.kr/cotton-shirt.jpg",
+				          "description": "상품 상세 설명"
+				        }
+				      }
+				    }
+				  }
+				  </script>
+				</head>
+				<body></body>
+				</html>
+				"""
+		);
+
+		ShoppingLinkImportResponse response = service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.SHARE,
+				"https://zigzag.kr/catalog/products/220",
+				null,
+				null,
+				null,
+				null
+			)
+		);
+
+		assertThat(response.item().title()).isEqualTo("오버핏 코튼 셔츠");
+		assertThat(response.item().listedPrice()).isEqualTo(45000);
+		assertThat(response.item().imageUrl()).isEqualTo("https://image.zigzag.kr/cotton-shirt.jpg");
+		assertThat(response.item().category()).isEqualTo(ItemCategory.FASHION);
+	}
+
+	@Test
 	void acceptsDirectInputWithoutRemoteFetch() {
 		ShoppingLinkImportResponse response = service.importLink(
 			new ShoppingLinkImportRequest(

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
@@ -256,6 +256,52 @@ class ShoppingLinkImportServiceTest {
 	}
 
 	@Test
+	void extractsProductMetadataFromEmbeddedCommerceJson() {
+		pageFetcher.stub(
+			"https://zigzag.kr/catalog/products/110621280",
+			"""
+				<html>
+				<head>
+				  <title>지그재그</title>
+				  <script id="__NEXT_DATA__" type="application/json">
+				  {
+				    "props": {
+				      "pageProps": {
+				        "product": {
+				          "productName": "린넨 반팔 셔츠",
+				          "salePrice": 39000,
+				          "imageUrl": "https://image.zigzag.kr/product.jpg",
+				          "description": "여름 셔츠 상품 상세"
+				        }
+				      }
+				    }
+				  }
+				  </script>
+				</head>
+				<body></body>
+				</html>
+				"""
+		);
+
+		ShoppingLinkImportResponse response = service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.SHARE,
+				"https://zigzag.kr/catalog/products/110621280",
+				null,
+				null,
+				null,
+				null
+			)
+		);
+
+		assertThat(response.item().title()).isEqualTo("린넨 반팔 셔츠");
+		assertThat(response.item().listedPrice()).isEqualTo(39000);
+		assertThat(response.item().imageUrl()).isEqualTo("https://image.zigzag.kr/product.jpg");
+		assertThat(response.item().category()).isEqualTo(ItemCategory.FASHION);
+		assertThat(response.sourceMetadata().extractionMethod()).isEqualTo("EMBEDDED_JSON");
+	}
+
+	@Test
 	void acceptsDirectInputWithoutRemoteFetch() {
 		ShoppingLinkImportResponse response = service.importLink(
 			new ShoppingLinkImportRequest(

--- a/src/test/java/com/sagongsa/backend/mvp/MvpBackendGapIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/mvp/MvpBackendGapIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.containsString;
 
 import com.sagongsa.backend.support.PostgreSqlContainerTest;
 import java.time.OffsetDateTime;
@@ -57,7 +58,7 @@ class MvpBackendGapIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(jsonPath("$.budget.projectedSpentAmount").value(105_000))
 			.andExpect(jsonPath("$.budget.projectedUsageRate").value(21.00))
 			.andExpect(jsonPath("$.similarCategorySpendAmount").value(20_000))
-			.andExpect(jsonPath("$.opportunityCostMessage").value("15,000원을 다른 곳에 쓸 수도 있어요."))
+			.andExpect(jsonPath("$.opportunityCostMessage").value(containsString("15,000원")))
 			.andExpect(jsonPath("$.questions.length()").value(4))
 			.andExpect(jsonPath("$.questions[0].code").value("NEED"))
 			.andExpect(jsonPath("$.questions[0].text").value("오늘 갑자기 갖고 싶어진 건가요?"))

--- a/src/test/java/com/sagongsa/backend/notification/NotificationTriggerWorkerIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/notification/NotificationTriggerWorkerIntegrationTest.java
@@ -94,6 +94,21 @@ class NotificationTriggerWorkerIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void deletesNotificationsOlderThanRetentionWindow() {
+		OffsetDateTime now = OffsetDateTime.of(2026, 6, 10, 12, 0, 0, 0, ZoneOffset.UTC);
+		UUID userId = createReadyUser(now.minusDays(40));
+		insertNotification(userId, "WISHLIST_REMINDER", "오래된 알림", "만료", null,
+			null, null, "/wishlist", null, now.minusMonths(1).minusDays(1));
+		insertNotification(userId, "SOCIAL_FIRST_VOTE", "최근 알림", "유지", null,
+			null, null, "/social/posts/1", null, now.minusDays(1));
+
+		notificationTriggerWorker.processDueNotifications(now);
+
+		assertThat(queryInteger("select count(*) from notifications where title = '오래된 알림'")).isZero();
+		assertThat(queryInteger("select count(*) from notifications where title = '최근 알림'")).isEqualTo(1);
+	}
+
+	@Test
 	void createsBudgetResetOnlyAfterFirstDayNineAmInKorea() {
 		OffsetDateTime dueAt = OffsetDateTime.of(2026, 7, 1, 0, 0, 0, 0, ZoneOffset.UTC);
 		UUID firstUserId = createReadyUserWithBudgetCycle(

--- a/src/test/java/com/sagongsa/backend/notification/NotificationTriggerWorkerIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/notification/NotificationTriggerWorkerIntegrationTest.java
@@ -94,18 +94,19 @@ class NotificationTriggerWorkerIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
-	void deletesNotificationsOlderThanRetentionWindow() {
+	void retainsOldDedupeNotificationsToPreventRepublish() {
 		OffsetDateTime now = OffsetDateTime.of(2026, 6, 10, 12, 0, 0, 0, ZoneOffset.UTC);
 		UUID userId = createReadyUser(now.minusDays(40));
-		insertNotification(userId, "WISHLIST_REMINDER", "오래된 알림", "만료", null,
-			null, null, "/wishlist", null, now.minusMonths(1).minusDays(1));
-		insertNotification(userId, "SOCIAL_FIRST_VOTE", "최근 알림", "유지", null,
-			null, null, "/social/posts/1", null, now.minusDays(1));
+		UUID itemId = insertSavedItem(userId, "오래된 위시", "SAVED", now.minusDays(40));
+		insertNotification(userId, "WISHLIST_REMINDER", "오래된 알림", "만료", itemId,
+			null, null, "/wishlist/items/" + itemId, "item:" + itemId, now.minusMonths(1).minusDays(1));
 
-		notificationTriggerWorker.processDueNotifications(now);
+		int createdCount = notificationTriggerWorker.processDueNotifications(now);
 
-		assertThat(queryInteger("select count(*) from notifications where title = '오래된 알림'")).isZero();
-		assertThat(queryInteger("select count(*) from notifications where title = '최근 알림'")).isEqualTo(1);
+		assertThat(createdCount).isZero();
+		assertThat(queryInteger("select count(*) from notifications where notification_type = 'WISHLIST_REMINDER'"))
+			.isEqualTo(1);
+		verify(pushNotificationService, times(0)).send(any(NotificationPushMessage.class));
 	}
 
 	@Test

--- a/src/test/java/com/sagongsa/backend/onboarding/OnboardingCompleteIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/onboarding/OnboardingCompleteIntegrationTest.java
@@ -230,7 +230,7 @@ class OnboardingCompleteIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
-	void completeWithOuterWhitespaceNicknameReturns400() throws Exception {
+	void completeWithOuterWhitespaceNicknameTrimsAndReturns200() throws Exception {
 		UUID userId = insertUser("NOT_STARTED");
 
 		mockMvc.perform(post("/api/v1/onboarding/complete")
@@ -245,7 +245,10 @@ class OnboardingCompleteIntegrationTest extends PostgreSqlContainerTest {
 						"regretFrequencyChoice": "FOUR_OR_MORE"
 					}
 					"""))
-			.andExpect(status().isBadRequest());
+			.andExpect(status().isOk());
+
+		assertThat(queryString("select nickname from user_profiles where user_id = ?", userId))
+			.isEqualTo("nick");
 	}
 
 	@Test

--- a/src/test/java/com/sagongsa/backend/onboarding/OnboardingServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/onboarding/OnboardingServiceTest.java
@@ -115,10 +115,12 @@ class OnboardingServiceTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
-	void rejectsNicknameWithOuterWhitespace() {
+	void trimsNicknameOuterWhitespace() {
 		UUID userId = insertUser("NOT_STARTED");
-		assertThatThrownBy(() -> onboardingService.complete(userId, request(" 닉네임", "너굴", "Asia/Seoul", 100000, "LESS_THAN_ONCE")))
-			.isInstanceOf(OnboardingBadRequestException.class);
+		onboardingService.complete(userId, request(" 닉네임 ", "너굴", "Asia/Seoul", 100000, "LESS_THAN_ONCE"));
+
+		assertThat(queryString("select nickname from user_profiles where user_id = ?", userId))
+			.isEqualTo("닉네임");
 	}
 
 	@Test

--- a/src/test/java/com/sagongsa/backend/social/SocialPostServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/social/SocialPostServiceTest.java
@@ -41,6 +41,22 @@ class SocialPostServiceTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void 같은_게시글_연속_등록은_기존_게시글을_반환() {
+		UUID userId = insertUser();
+		CreatePostRequest request = new CreatePostRequest("제목", "내용", null, null, null);
+
+		PostResponse first = socialPostService.createPost(userId, request);
+		PostResponse second = socialPostService.createPost(userId, request);
+
+		assertThat(second.id()).isEqualTo(first.id());
+		assertThat(jdbcTemplate.queryForObject(
+			"select count(*) from feed_posts where user_id = ?",
+			Integer.class,
+			userId
+		)).isEqualTo(1);
+	}
+
+	@Test
 	void 존재하지_않는_유저가_게시글_생성하면_예외() {
 		assertThatThrownBy(() ->
 			socialPostService.createPost(UUID.randomUUID(), new CreatePostRequest("제목", "내용", null, null, null))

--- a/src/test/java/com/sagongsa/backend/social/SocialPostServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/social/SocialPostServiceTest.java
@@ -7,6 +7,12 @@ import com.sagongsa.backend.support.PostgreSqlContainerTest;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,6 +60,35 @@ class SocialPostServiceTest extends PostgreSqlContainerTest {
 			Integer.class,
 			userId
 		)).isEqualTo(1);
+	}
+
+	@Test
+	void 같은_게시글_동시_등록도_기존_게시글을_반환() throws Exception {
+		UUID userId = insertUser();
+		CreatePostRequest request = new CreatePostRequest("제목", "내용", null, null, null);
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		CountDownLatch start = new CountDownLatch(1);
+		Callable<PostResponse> task = () -> {
+			start.await();
+			return socialPostService.createPost(userId, request);
+		};
+
+		try {
+			Future<PostResponse> firstFuture = executor.submit(task);
+			Future<PostResponse> secondFuture = executor.submit(task);
+			start.countDown();
+			PostResponse first = firstFuture.get(5, TimeUnit.SECONDS);
+			PostResponse second = secondFuture.get(5, TimeUnit.SECONDS);
+
+			assertThat(second.id()).isEqualTo(first.id());
+			assertThat(jdbcTemplate.queryForObject(
+				"select count(*) from feed_posts where user_id = ?",
+				Integer.class,
+				userId
+			)).isEqualTo(1);
+		} finally {
+			executor.shutdownNow();
+		}
 	}
 
 	@Test

--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistServiceTest.java
@@ -85,6 +85,26 @@ class WishlistServiceTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void rejectsRecentDuplicateDirectInputWithoutUrl() {
+		UUID userId = createActiveUser();
+		WishlistItemCreateRequest request = new WishlistItemCreateRequest(
+			"DIRECT_INPUT", null, null, "직접 입력 상품", null,
+			29000, "KRW", "FASHION", null, false,
+			null, null, null, null, null
+		);
+
+		wishlistService.create(userId, request);
+
+		assertThatThrownBy(() -> wishlistService.create(userId, request))
+			.isInstanceOf(DuplicateSavedItemException.class);
+		assertThat(jdbcTemplate.queryForObject(
+			"select count(*) from saved_items where user_id = ?",
+			Integer.class,
+			userId
+		)).isEqualTo(1);
+	}
+
+	@Test
 	void rejectsNonHttpScheme() {
 		UUID userId = createActiveUser();
 

--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistServiceTest.java
@@ -8,6 +8,12 @@ import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -85,7 +91,7 @@ class WishlistServiceTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
-	void rejectsRecentDuplicateDirectInputWithoutUrl() {
+	void returnsExistingRecentDuplicateDirectInputWithoutUrl() {
 		UUID userId = createActiveUser();
 		WishlistItemCreateRequest request = new WishlistItemCreateRequest(
 			"DIRECT_INPUT", null, null, "직접 입력 상품", null,
@@ -93,15 +99,48 @@ class WishlistServiceTest extends PostgreSqlContainerTest {
 			null, null, null, null, null
 		);
 
-		wishlistService.create(userId, request);
+		WishlistItemResponse first = wishlistService.create(userId, request);
+		WishlistItemResponse second = wishlistService.create(userId, request);
 
-		assertThatThrownBy(() -> wishlistService.create(userId, request))
-			.isInstanceOf(DuplicateSavedItemException.class);
+		assertThat(second.id()).isEqualTo(first.id());
 		assertThat(jdbcTemplate.queryForObject(
 			"select count(*) from saved_items where user_id = ?",
 			Integer.class,
 			userId
 		)).isEqualTo(1);
+	}
+
+	@Test
+	void concurrentDuplicateDirectInputWithoutUrlReturnsOneItem() throws Exception {
+		UUID userId = createActiveUser();
+		WishlistItemCreateRequest request = new WishlistItemCreateRequest(
+			"DIRECT_INPUT", null, null, "직접 입력 상품", null,
+			29000, "KRW", "FASHION", null, false,
+			null, null, null, null, null
+		);
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		CountDownLatch start = new CountDownLatch(1);
+		Callable<WishlistItemResponse> task = () -> {
+			start.await();
+			return wishlistService.create(userId, request);
+		};
+
+		try {
+			Future<WishlistItemResponse> firstFuture = executor.submit(task);
+			Future<WishlistItemResponse> secondFuture = executor.submit(task);
+			start.countDown();
+			WishlistItemResponse first = firstFuture.get(5, TimeUnit.SECONDS);
+			WishlistItemResponse second = secondFuture.get(5, TimeUnit.SECONDS);
+
+			assertThat(second.id()).isEqualTo(first.id());
+			assertThat(jdbcTemplate.queryForObject(
+				"select count(*) from saved_items where user_id = ?",
+				Integer.class,
+				userId
+			)).isEqualTo(1);
+		} finally {
+			executor.shutdownNow();
+		}
 	}
 
 	@Test


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-68**
- Jira: 없음

> PR 제목: `NF-68 test1 QA 백엔드 단독 수정 항목 보완`  
> 브랜치: `fix/NF-68-qa-backend-only-fixes`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #157

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- test 1 QA 미체크 항목 중 BE 단독으로 닫을 수 있는 7건이 최신 `develop`에서 아직 일부 미해결 상태였습니다.
- 대상: `48`, `146`, `171`, `214`, `215`, `273`, `394`

### 왜 발생했나? (Root Cause)
- 닉네임 앞뒤 공백은 서버가 자동 정규화하지 않고 거절했습니다.
- 알림은 1개월 조회 필터와 dedupe 기록 보존 기준을 함께 검증하지 못했습니다.
- 쇼핑몰 크롤링은 Open Graph/JSON-LD 중심이라 앱/커머스 임베디드 JSON 메타를 놓쳤고, generic embedded key 오탐 가능성이 있었습니다.
- URL 없는 직접입력 위시와 피드 글 등록은 짧은 시간 내 동일 요청에 대한 서버 중복 방어가 없었습니다.
- 구매숙려 기회비용 문구는 단일 고정 문구였습니다.

### 어떻게 고쳤나?
- 온보딩 닉네임을 저장 전 trim하도록 변경했습니다.
- 1개월 초과 알림은 목록/홈에서 숨기되 dedupe 기록은 보존해 재발송을 막는 정책을 테스트로 고정했습니다.
- 쇼핑 링크 import에서 script 임베디드 JSON 상품 메타 추출을 보강하고, 상품 컨텍스트/상품 전용 key를 generic key보다 우선하도록 했습니다.
- URL 없는 직접입력 위시는 30초 내 동일 payload 중복 요청 시 기존 item을 반환합니다.
- 피드 게시글은 30초 내 동일 payload 등록 시 기존 글을 반환해 중복 생성을 막습니다.
- 구매숙려 기회비용 문구를 후보군 중 랜덤으로 반환하도록 변경했습니다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법(가능하면)
- Steps:
  1. test 1 QA 대상 번호의 API 흐름을 재현합니다.
  2. 위시 직접입력/피드 등록은 같은 요청을 짧은 시간 내 2회 보냅니다.
  3. 구매숙려/크롤링/알림 보관은 응답과 DB 상태를 확인합니다.
- 기대 결과: 중복 데이터가 생성되지 않고, QA 기대값에 맞는 서버 응답/정책이 적용됩니다.
- 실제 결과: 수정 전에는 일부 항목에서 중복 저장 또는 고정/부분 정책만 존재했습니다.

### 재발 방지(있다면)
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [ ] 런북/문서 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] AC1: 닉네임 앞뒤 공백은 서버 저장 전 제거된다.
- [x] AC2: 1개월 초과 알림은 목록/홈에서 제외되고 dedupe 기록은 재발송 방지를 위해 보존된다.
- [x] AC3: URL 없는 직접입력 위시와 피드 글 연속 등록이 중복 데이터를 만들지 않는다.
- [x] AC4: 쇼핑 링크 import가 임베디드 커머스 JSON 메타를 상품명/가격/이미지 후보로 사용한다.
- [x] AC5: 구매숙려 기회비용 문구가 후보군 중 하나로 반환된다.

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew test --tests com.sagongsa.backend.onboarding.OnboardingServiceTest --tests com.sagongsa.backend.notification.NotificationTriggerWorkerIntegrationTest --tests com.sagongsa.backend.itemimport.item.ShoppingLinkImportServiceTest --tests com.sagongsa.backend.wishlist.WishlistServiceTest --tests com.sagongsa.backend.deliberation.DeliberationServiceTest --tests com.sagongsa.backend.deliberation.DeliberationApiIntegrationTest --tests com.sagongsa.backend.mvp.MvpBackendGapIntegrationTest --tests com.sagongsa.backend.social.SocialPostServiceTest`
- Result: `BUILD SUCCESSFUL`

- Command: `./gradlew test`
- Result: `BUILD SUCCESSFUL`

- Command: `git diff --check`
- Result: 통과

### CI
- 링크/결과: PR 생성 후 GitHub Actions 확인

### Smoke / 수동 검증
- 시나리오: test1 QA BE 단독 가능 7건을 코드/테스트로 검증
- 결과: 로컬 회귀 테스트 통과

### 테스트 공백(있다면 이유 필수)
- 실쇼핑몰 실시간 크롤링은 외부 사이트 상태/차단 정책에 따라 달라져 단위 테스트에서는 임베디드 JSON fixture와 generic key 오탐 fixture로 검증했습니다.

---

## 🧭 영향 범위 (필수)
- [ ] API 스펙 변경 없음
- [x] API 스펙 변경 있음 (요약: 기존 필드는 유지하되 구매숙려 `opportunityCostMessage` 값이 후보군 랜덤으로 바뀜)
- [x] DB 스키마 변경 없음
- [ ] DB 스키마 변경 있음 (마이그레이션/락/시간: )
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음 (항목: )
- [x] 캐시/큐/외부 연동 영향 없음
- [ ] 캐시/큐/외부 연동 영향 있음 (요약: )

---

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음
- [ ] Breaking change 있음 → 무엇이 깨지는지 / 마이그레이션 / 롤아웃 전략:

---

## 🚀 배포/릴리즈 (해당 시 필수)
### Feature Flag
- [x] 사용 안함
- [ ] 사용함 → Flag/기본값/롤아웃:

### 모니터링/알림
- 확인할 대시보드/지표: QA 서버 API 응답, 알림/위시/피드 저장 건수
- 에러/로그 키워드: `DuplicateSavedItemException`, shopping import 4xx/5xx

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- URL 없는 직접입력 위시와 피드 글은 30초 내 동일 payload를 중복으로 보지 않으므로, 극히 짧은 시간 안에 의도적으로 같은 내용을 2개 저장하는 사용자는 제한됩니다.
- 쇼핑몰 크롤링은 외부 페이지 구조 변화에 계속 영향을 받을 수 있습니다.

### 롤백
- [ ] 플래그/설정으로 우회 가능
- [x] 배포 롤백(이전 태그/이미지) 가능
- [ ] 데이터 롤백/역마이그레이션 필요 (절차: )

---

## 📸 증빙 (선택)
- 로컬 전체 테스트 `BUILD SUCCESSFUL`

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직:
  - `OnboardingService`, `NotificationService`, `ShoppingLinkImportService`
  - `WishlistService`, `SocialPostService`, `FeedPostRepository`, `DeliberationService`
- 트레이드오프/대안:
  - 별도 idempotency key 없이 짧은 시간 동일 payload 중복 방어로 처리했습니다.
  - 쇼핑몰 크롤링은 브라우저 렌더링 강제 대신 임베디드 JSON 추출을 우선 보강했습니다.
- 성능/보안/호환성 영향:
  - 중복 조회는 최근 30초 동일 사용자/payload 범위라 영향이 작습니다.
  - 오래된 알림은 조회에서 제외하고 dedupe 기록은 보존해 재발송을 막습니다.
