### PR TITLE
[fix] NF-69 홈 말풍선 BE 계약 보완

### DIFF
--- a/src/main/java/com/sagongsa/backend/home/HomeSummaryController.java
+++ b/src/main/java/com/sagongsa/backend/home/HomeSummaryController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -43,5 +44,11 @@ public class HomeSummaryController {
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public void markBudgetExhaustionBubbleSeen(@CurrentUserId UUID userId) {
 		homeSummaryService.markBubbleSeen(userId);
+	}
+
+	@PostMapping("/bubbles/{type}/seen")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void markBubbleSeen(@CurrentUserId UUID userId, @PathVariable String type) {
+		homeSummaryService.markBubbleSeen(userId, type);
 	}
 }

--- a/src/main/java/com/sagongsa/backend/home/HomeSummaryResponse.java
+++ b/src/main/java/com/sagongsa/backend/home/HomeSummaryResponse.java
@@ -9,6 +9,7 @@ public record HomeSummaryResponse(
 	UserProfileSummary userProfile,
 	MascotSummary mascot,
 	BudgetSummary budget,
+	BubbleSummary bubble,
 	NotificationsSummary notifications,
 	BigDecimal rationalChoiceRate
 ) {
@@ -36,6 +37,15 @@ public record HomeSummaryResponse(
 		BigDecimal warningThresholdRate,
 		boolean exhausted,
 		boolean showBudgetExhaustionBubble
+	) {
+	}
+
+	public record BubbleSummary(
+		String type,
+		String message,
+		int priority,
+		boolean shouldShow,
+		String seenEndpoint
 	) {
 	}
 

--- a/src/main/java/com/sagongsa/backend/home/HomeSummaryService.java
+++ b/src/main/java/com/sagongsa/backend/home/HomeSummaryService.java
@@ -1,6 +1,7 @@
 package com.sagongsa.backend.home;
 
 import com.sagongsa.backend.home.HomeSummaryResponse.BudgetSummary;
+import com.sagongsa.backend.home.HomeSummaryResponse.BubbleSummary;
 import com.sagongsa.backend.home.HomeSummaryResponse.MascotSummary;
 import com.sagongsa.backend.home.HomeSummaryResponse.NotificationSummary;
 import com.sagongsa.backend.home.HomeSummaryResponse.NotificationsSummary;
@@ -18,6 +19,7 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
@@ -27,6 +29,31 @@ public class HomeSummaryService {
 	private static final ZoneId DEFAULT_ZONE_ID = ZoneId.of("Asia/Seoul");
 	private static final int LATEST_NOTIFICATION_LIMIT = 3;
 	private static final int NOTIFICATION_RETENTION_MONTHS = 1;
+	static final List<String> BUDGET_NEGATIVE_BUBBLE_MESSAGES = List.of(
+		"이번 달 예산을 넘었어요. 잠깐 멈춰볼까요?",
+		"예산보다 더 썼어요. 오늘은 소비를 쉬어가도 좋아요.",
+		"예산이 마이너스예요. 다음 위시는 조금만 더 고민해봐요."
+	);
+	static final List<String> BUDGET_ZERO_BUBBLE_MESSAGES = List.of(
+		"이번 달 예산을 다 썼어요. 남은 기간은 신중하게 가봐요.",
+		"예산이 0원이 되었어요. 오늘은 장바구니를 잠시 닫아볼까요?",
+		"남은 예산이 없어요. 다음 소비는 한 번 더 생각해봐요."
+	);
+	static final List<String> PENDING_WISHLIST_BUBBLE_MESSAGES = List.of(
+		"아직 결정하지 않은 위시템이 있어요.",
+		"담아둔 위시템을 다시 한번 살펴볼까요?",
+		"고민 중인 위시템을 하나 골라 결정해봐요."
+	);
+	static final List<String> VOTE_WAITING_BUBBLE_MESSAGES = List.of(
+		"내 위시템에 투표가 들어왔어요.",
+		"친구들의 투표 결과를 확인해볼까요?",
+		"투표가 모였어요. 이제 결정할 차례예요."
+	);
+	static final List<String> DEFAULT_BUBBLE_MESSAGES = List.of(
+		"오늘도 현명한 소비를 도와드릴게요.",
+		"갖고 싶은 게 생기면 같이 천천히 고민해봐요.",
+		"소비하기 전 한 번 더 생각하면 좋아요."
+	);
 
 	private final JdbcTemplate jdbcTemplate;
 
@@ -46,11 +73,14 @@ public class HomeSummaryService {
 			.orElseGet(() -> new UserProfileSummary(null, null, null));
 		ZoneId zoneId = resolveZoneId(userProfile.timezone());
 		String currentYearMonth = YearMonth.now(zoneId).toString();
+		MascotSummary mascot = findMascotSummary(userId).orElseGet(HomeSummaryService::defaultMascotSummary);
+		BudgetSummary budget = findBudgetSummary(userId, currentYearMonth).orElseGet(() -> defaultBudgetSummary(currentYearMonth));
 
 		return new HomeSummaryResponse(
 			userProfile,
-			findMascotSummary(userId).orElseGet(HomeSummaryService::defaultMascotSummary),
-			findBudgetSummary(userId, currentYearMonth).orElseGet(() -> defaultBudgetSummary(currentYearMonth)),
+			mascot,
+			budget,
+			homeBubble(userId, mascot, budget),
 			new NotificationsSummary(countUnreadNotifications(userId), findLatestNotifications(userId)),
 			findRationalChoiceRate(userId, currentYearMonth, zoneId)
 		);
@@ -153,6 +183,24 @@ public class HomeSummaryService {
 
 	@org.springframework.transaction.annotation.Transactional
 	public void markBubbleSeen(UUID userId) {
+		markBudgetExhaustionBubbleSeen(userId);
+	}
+
+	@org.springframework.transaction.annotation.Transactional
+	public void markBubbleSeen(UUID userId, String type) {
+		if (type == null || type.isBlank()) {
+			return;
+		}
+		switch (type.toUpperCase(java.util.Locale.ROOT)) {
+			case "WELCOME" -> markWelcomeBubbleSeen(userId);
+			case "BUDGET_NEGATIVE", "BUDGET_ZERO" -> markBudgetExhaustionBubbleSeen(userId);
+			case "DECISION_REACTION" -> clearDecisionReactionBubble(userId);
+			default -> {
+			}
+		}
+	}
+
+	private void markBudgetExhaustionBubbleSeen(UUID userId) {
 		String timezone = jdbcTemplate.query(
 				"select timezone from user_profiles where user_id = ?",
 				(rs, rowNum) -> rs.getString("timezone"),
@@ -173,6 +221,112 @@ public class HomeSummaryService {
 			userId,
 			currentYearMonth
 		);
+	}
+
+	private void markWelcomeBubbleSeen(UUID userId) {
+		jdbcTemplate.update(
+			"""
+			update mascot_profiles
+			   set welcome_bubble_seen = true,
+			       updated_at = now()
+			 where user_id = ?
+			""",
+			userId
+		);
+	}
+
+	private void clearDecisionReactionBubble(UUID userId) {
+		jdbcTemplate.update(
+			"""
+			update mascot_profiles
+			   set last_reaction_message = null,
+			       reaction_expires_at = null,
+			       updated_at = now()
+			 where user_id = ?
+			""",
+			userId
+		);
+	}
+
+	private BubbleSummary homeBubble(UUID userId, MascotSummary mascot, BudgetSummary budget) {
+		if (budget.showBudgetExhaustionBubble()) {
+			if (budget.spentAmount() > budget.monthlyBudgetAmount()) {
+				return bubble("BUDGET_NEGATIVE", randomValue(BUDGET_NEGATIVE_BUBBLE_MESSAGES), 100);
+			}
+			return bubble("BUDGET_ZERO", randomValue(BUDGET_ZERO_BUBBLE_MESSAGES), 90);
+		}
+		if (mascot.lastReactionMessage() != null && !mascot.lastReactionMessage().isBlank()) {
+			return bubble("DECISION_REACTION", mascot.lastReactionMessage(), 80);
+		}
+		if (welcomeBubblePending(userId)) {
+			return bubble("WELCOME", "반가워요! 같이 현명한 소비해봐요", 70);
+		}
+		if (hasPendingWishlist(userId)) {
+			return bubble("PENDING_WISHLIST", randomValue(PENDING_WISHLIST_BUBBLE_MESSAGES), 50);
+		}
+		if (hasVoteWaiting(userId)) {
+			return bubble("VOTE_WAITING", randomValue(VOTE_WAITING_BUBBLE_MESSAGES), 40);
+		}
+		return bubble("DEFAULT", randomValue(DEFAULT_BUBBLE_MESSAGES), 10);
+	}
+
+	private BubbleSummary bubble(String type, String message, int priority) {
+		return new BubbleSummary(type, message, priority, true, "/api/v1/home/bubbles/" + type + "/seen");
+	}
+
+	private String randomValue(List<String> values) {
+		return values.get(ThreadLocalRandom.current().nextInt(values.size()));
+	}
+
+	private boolean welcomeBubblePending(UUID userId) {
+		Boolean pending = jdbcTemplate.queryForObject(
+			"""
+			select exists(
+				select 1
+				from mascot_profiles
+				where user_id = ?
+				  and welcome_bubble_seen = false
+			)
+			""",
+			Boolean.class,
+			userId
+		);
+		return Boolean.TRUE.equals(pending);
+	}
+
+	private boolean hasPendingWishlist(UUID userId) {
+		Boolean exists = jdbcTemplate.queryForObject(
+			"""
+			select exists(
+				select 1
+				from saved_items
+				where user_id = ?
+				  and status = 'SAVED'
+			)
+			""",
+			Boolean.class,
+			userId
+		);
+		return Boolean.TRUE.equals(exists);
+	}
+
+	private boolean hasVoteWaiting(UUID userId) {
+		Boolean exists = jdbcTemplate.queryForObject(
+			"""
+			select exists(
+				select 1
+				from feed_posts fp
+				join post_votes pv on pv.post_id = fp.id
+				where fp.user_id = ?
+				  and fp.deleted_at is null
+				  and fp.moderation_status = 'ACTIVE'
+				  and pv.canceled_at is null
+			)
+			""",
+			Boolean.class,
+			userId
+		);
+		return Boolean.TRUE.equals(exists);
 	}
 
 	private long countUnreadNotifications(UUID userId) {

--- a/src/main/java/com/sagongsa/backend/home/HomeSummaryService.java
+++ b/src/main/java/com/sagongsa/backend/home/HomeSummaryService.java
@@ -262,16 +262,20 @@ public class HomeSummaryService {
 			return bubble("WELCOME", "반가워요! 같이 현명한 소비해봐요", 70);
 		}
 		if (hasPendingWishlist(userId)) {
-			return bubble("PENDING_WISHLIST", randomValue(PENDING_WISHLIST_BUBBLE_MESSAGES), 50);
+			return passiveBubble("PENDING_WISHLIST", randomValue(PENDING_WISHLIST_BUBBLE_MESSAGES), 50);
 		}
 		if (hasVoteWaiting(userId)) {
-			return bubble("VOTE_WAITING", randomValue(VOTE_WAITING_BUBBLE_MESSAGES), 40);
+			return passiveBubble("VOTE_WAITING", randomValue(VOTE_WAITING_BUBBLE_MESSAGES), 40);
 		}
-		return bubble("DEFAULT", randomValue(DEFAULT_BUBBLE_MESSAGES), 10);
+		return passiveBubble("DEFAULT", randomValue(DEFAULT_BUBBLE_MESSAGES), 10);
 	}
 
 	private BubbleSummary bubble(String type, String message, int priority) {
 		return new BubbleSummary(type, message, priority, true, "/api/v1/home/bubbles/" + type + "/seen");
+	}
+
+	private BubbleSummary passiveBubble(String type, String message, int priority) {
+		return new BubbleSummary(type, message, priority, true, null);
 	}
 
 	private String randomValue(List<String> values) {

--- a/src/main/resources/db/migration/V19__add_home_welcome_bubble_seen.sql
+++ b/src/main/resources/db/migration/V19__add_home_welcome_bubble_seen.sql
@@ -1,0 +1,2 @@
+alter table mascot_profiles
+    add column welcome_bubble_seen boolean not null default false;

--- a/src/main/resources/db/migration/V19__add_home_welcome_bubble_seen.sql
+++ b/src/main/resources/db/migration/V19__add_home_welcome_bubble_seen.sql
@@ -1,2 +1,10 @@
 alter table mascot_profiles
-    add column welcome_bubble_seen boolean not null default false;
+    add column welcome_bubble_seen boolean;
+
+update mascot_profiles
+set welcome_bubble_seen = true
+where welcome_bubble_seen is null;
+
+alter table mascot_profiles
+    alter column welcome_bubble_seen set default false,
+    alter column welcome_bubble_seen set not null;

--- a/src/test/java/com/sagongsa/backend/domain/DomainSchemaSmokeTest.java
+++ b/src/test/java/com/sagongsa/backend/domain/DomainSchemaSmokeTest.java
@@ -82,7 +82,8 @@ class DomainSchemaSmokeTest extends PostgreSqlContainerTest {
 			"mascot_profiles",
 			"mascot_state",
 			"last_reaction_message",
-			"reaction_expires_at"
+			"reaction_expires_at",
+			"welcome_bubble_seen"
 		);
 		assertColumns(
 			"reminder_schedules",

--- a/src/test/java/com/sagongsa/backend/home/HomeSummaryIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/home/HomeSummaryIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.sagongsa.backend.home;
 
+import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -71,6 +72,10 @@ class HomeSummaryIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(jsonPath("$.userProfile.timezone").value("Asia/Seoul"))
 			.andExpect(jsonPath("$.mascot.state").value("SMILE"))
 			.andExpect(jsonPath("$.mascot.lastReactionMessage").value("Nice choice"))
+			.andExpect(jsonPath("$.bubble.type").value("DECISION_REACTION"))
+			.andExpect(jsonPath("$.bubble.message").value("Nice choice"))
+			.andExpect(jsonPath("$.bubble.priority").value(80))
+			.andExpect(jsonPath("$.bubble.shouldShow").value(true))
 			.andExpect(jsonPath("$.budget.yearMonth").value(yearMonth))
 			.andExpect(jsonPath("$.budget.monthlyBudgetAmount").value(500_000))
 			.andExpect(jsonPath("$.budget.spentAmount").value(125_000))
@@ -100,6 +105,9 @@ class HomeSummaryIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(jsonPath("$.userProfile.timezone").value(nullValue()))
 			.andExpect(jsonPath("$.mascot.state").value("DEFAULT"))
 			.andExpect(jsonPath("$.mascot.lastReactionMessage").value(nullValue()))
+			.andExpect(jsonPath("$.bubble.type").value("DEFAULT"))
+			.andExpect(jsonPath("$.bubble.message").value(isIn(HomeSummaryService.DEFAULT_BUBBLE_MESSAGES)))
+			.andExpect(jsonPath("$.bubble.priority").value(10))
 			.andExpect(jsonPath("$.budget.yearMonth").value(yearMonth))
 			.andExpect(jsonPath("$.budget.monthlyBudgetAmount").value(0))
 			.andExpect(jsonPath("$.budget.spentAmount").value(0))
@@ -145,7 +153,10 @@ class HomeSummaryIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(jsonPath("$.budget.spentAmount").value(100_000))
 			.andExpect(jsonPath("$.budget.remainingAmount").value(0))
 			.andExpect(jsonPath("$.budget.exhausted").value(true))
-			.andExpect(jsonPath("$.budget.showBudgetExhaustionBubble").value(true));
+			.andExpect(jsonPath("$.budget.showBudgetExhaustionBubble").value(true))
+			.andExpect(jsonPath("$.bubble.type").value("BUDGET_ZERO"))
+			.andExpect(jsonPath("$.bubble.message").value(isIn(HomeSummaryService.BUDGET_ZERO_BUBBLE_MESSAGES)))
+			.andExpect(jsonPath("$.bubble.priority").value(90));
 	}
 
 	@Test
@@ -159,7 +170,10 @@ class HomeSummaryIntegrationTest extends PostgreSqlContainerTest {
 		mockMvc.perform(get("/api/v1/home/summary").header("X-User-Id", userId))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.budget.remainingAmount").value(0))
-			.andExpect(jsonPath("$.budget.exhausted").value(true));
+			.andExpect(jsonPath("$.budget.exhausted").value(true))
+			.andExpect(jsonPath("$.bubble.type").value("BUDGET_NEGATIVE"))
+			.andExpect(jsonPath("$.bubble.message").value(isIn(HomeSummaryService.BUDGET_NEGATIVE_BUBBLE_MESSAGES)))
+			.andExpect(jsonPath("$.bubble.priority").value(100));
 	}
 
 	@Test
@@ -213,6 +227,122 @@ class HomeSummaryIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.mascot.state").value("DEFAULT"))
 			.andExpect(jsonPath("$.mascot.lastReactionMessage").value(nullValue()));
+	}
+
+	@Test
+	void returnsWelcomeBubbleUntilMarkedSeen() throws Exception {
+		UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000120");
+		insertUser(userId);
+		insertMascotProfile(userId, "DEFAULT", null, BASE_TIME, null);
+
+		mockMvc.perform(get("/api/v1/home/summary").header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.bubble.type").value("WELCOME"))
+			.andExpect(jsonPath("$.bubble.message").value("반가워요! 같이 현명한 소비해봐요"))
+			.andExpect(jsonPath("$.bubble.priority").value(70))
+			.andExpect(jsonPath("$.bubble.seenEndpoint").value("/api/v1/home/bubbles/WELCOME/seen"));
+
+		mockMvc.perform(post("/api/v1/home/bubbles/WELCOME/seen").header("X-User-Id", userId))
+			.andExpect(status().isNoContent());
+
+		mockMvc.perform(get("/api/v1/home/summary").header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.bubble.type").value("DEFAULT"))
+			.andExpect(jsonPath("$.bubble.message").value(isIn(HomeSummaryService.DEFAULT_BUBBLE_MESSAGES)))
+			.andExpect(jsonPath("$.bubble.priority").value(10));
+	}
+
+	@Test
+	void returnsDecisionReactionBubbleAndClearsMessageWhenSeen() throws Exception {
+		UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000121");
+		insertUser(userId);
+		insertMascotProfile(userId, "SMILE", "합리적으로 잘 결정했어요", BASE_TIME.plusSeconds(10), null);
+
+		mockMvc.perform(get("/api/v1/home/summary").header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.bubble.type").value("DECISION_REACTION"))
+			.andExpect(jsonPath("$.bubble.message").value("합리적으로 잘 결정했어요"));
+
+		mockMvc.perform(post("/api/v1/home/bubbles/DECISION_REACTION/seen").header("X-User-Id", userId))
+			.andExpect(status().isNoContent());
+
+		mockMvc.perform(get("/api/v1/home/summary").header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.mascot.state").value("SMILE"))
+			.andExpect(jsonPath("$.mascot.lastReactionMessage").value(nullValue()))
+			.andExpect(jsonPath("$.bubble.type").value("WELCOME"));
+	}
+
+	@Test
+	void returnsBudgetNegativeBubbleBeforePendingWishlist() throws Exception {
+		UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000122");
+		String yearMonth = YearMonth.now(SEOUL_ZONE).toString();
+
+		insertUser(userId);
+		insertBudgetCycle(userId, yearMonth, 100_000, 120_000, new BigDecimal("80.00"));
+		insertSavedItem(userId, "마이너스보다 낮은 우선순위 위시", "SAVED");
+
+		mockMvc.perform(get("/api/v1/home/summary").header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.bubble.type").value("BUDGET_NEGATIVE"))
+			.andExpect(jsonPath("$.bubble.priority").value(100));
+	}
+
+	@Test
+	void returnsBudgetZeroBubbleBeforeVoteWaiting() throws Exception {
+		UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000123");
+		UUID voterId = UUID.fromString("00000000-0000-0000-0000-000000000124");
+		String yearMonth = YearMonth.now(SEOUL_ZONE).toString();
+
+		insertUser(userId);
+		insertUser(voterId);
+		insertBudgetCycle(userId, yearMonth, 100_000, 100_000, new BigDecimal("80.00"));
+		UUID postId = insertFeedPost(userId);
+		insertPostVote(postId, voterId);
+
+		mockMvc.perform(get("/api/v1/home/summary").header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.bubble.type").value("BUDGET_ZERO"))
+			.andExpect(jsonPath("$.bubble.priority").value(90));
+	}
+
+	@Test
+	void returnsPendingWishlistBubbleBeforeVoteWaitingAndDefault() throws Exception {
+		UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000125");
+		UUID voterId = UUID.fromString("00000000-0000-0000-0000-000000000126");
+
+		insertUser(userId);
+		insertUser(voterId);
+		insertMascotProfile(userId, "DEFAULT", null, BASE_TIME, null);
+		markWelcomeSeen(userId);
+		insertSavedItem(userId, "결정 대기 위시", "SAVED");
+		UUID postId = insertFeedPost(userId);
+		insertPostVote(postId, voterId);
+
+		mockMvc.perform(get("/api/v1/home/summary").header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.bubble.type").value("PENDING_WISHLIST"))
+			.andExpect(jsonPath("$.bubble.message").value(isIn(HomeSummaryService.PENDING_WISHLIST_BUBBLE_MESSAGES)))
+			.andExpect(jsonPath("$.bubble.priority").value(50));
+	}
+
+	@Test
+	void returnsVoteWaitingBubbleWhenNoHigherPriorityBubbleExists() throws Exception {
+		UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000127");
+		UUID voterId = UUID.fromString("00000000-0000-0000-0000-000000000128");
+
+		insertUser(userId);
+		insertUser(voterId);
+		insertMascotProfile(userId, "DEFAULT", null, BASE_TIME, null);
+		markWelcomeSeen(userId);
+		UUID postId = insertFeedPost(userId);
+		insertPostVote(postId, voterId);
+
+		mockMvc.perform(get("/api/v1/home/summary").header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.bubble.type").value("VOTE_WAITING"))
+			.andExpect(jsonPath("$.bubble.message").value(isIn(HomeSummaryService.VOTE_WAITING_BUBBLE_MESSAGES)))
+			.andExpect(jsonPath("$.bubble.priority").value(40));
 	}
 
 	@Test
@@ -433,6 +563,85 @@ class HomeSummaryIntegrationTest extends PostgreSqlContainerTest {
 			timestamp(readAt),
 			timestamp(createdAt),
 			timestamp(createdAt)
+		);
+	}
+
+	private void markWelcomeSeen(UUID userId) {
+		jdbcTemplate.update(
+			"update mascot_profiles set welcome_bubble_seen = true where user_id = ?",
+			userId
+		);
+	}
+
+	private UUID insertSavedItem(UUID userId, String title, String status) {
+		UUID itemId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into saved_items (
+				id,
+				user_id,
+				input_source,
+				title,
+				category,
+				category_locked_by_user,
+				status,
+				created_at,
+				updated_at
+			)
+			values (?, ?, 'DIRECT_INPUT', ?, 'ETC', false, ?, ?, ?)
+			""",
+			itemId,
+			userId,
+			title,
+			status,
+			timestamp(BASE_TIME),
+			timestamp(BASE_TIME)
+		);
+		return itemId;
+	}
+
+	private UUID insertFeedPost(UUID userId) {
+		UUID postId = UUID.randomUUID();
+		jdbcTemplate.update(
+			"""
+			insert into feed_posts (
+				id,
+				user_id,
+				title,
+				body,
+				go_count,
+				stop_count,
+				created_at,
+				updated_at
+			)
+			values (?, ?, '투표 대기 게시글', '본문', 0, 0, ?, ?)
+			""",
+			postId,
+			userId,
+			timestamp(BASE_TIME),
+			timestamp(BASE_TIME)
+		);
+		return postId;
+	}
+
+	private void insertPostVote(UUID postId, UUID voterId) {
+		jdbcTemplate.update(
+			"""
+			insert into post_votes (
+				id,
+				post_id,
+				user_id,
+				vote_type,
+				created_at,
+				updated_at
+			)
+			values (?, ?, ?, 'GO', ?, ?)
+			""",
+			UUID.randomUUID(),
+			postId,
+			voterId,
+			timestamp(BASE_TIME),
+			timestamp(BASE_TIME)
 		);
 	}
 

--- a/src/test/java/com/sagongsa/backend/home/HomeSummaryIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/home/HomeSummaryIntegrationTest.java
@@ -76,6 +76,7 @@ class HomeSummaryIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(jsonPath("$.bubble.message").value("Nice choice"))
 			.andExpect(jsonPath("$.bubble.priority").value(80))
 			.andExpect(jsonPath("$.bubble.shouldShow").value(true))
+			.andExpect(jsonPath("$.bubble.seenEndpoint").value("/api/v1/home/bubbles/DECISION_REACTION/seen"))
 			.andExpect(jsonPath("$.budget.yearMonth").value(yearMonth))
 			.andExpect(jsonPath("$.budget.monthlyBudgetAmount").value(500_000))
 			.andExpect(jsonPath("$.budget.spentAmount").value(125_000))
@@ -108,6 +109,7 @@ class HomeSummaryIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(jsonPath("$.bubble.type").value("DEFAULT"))
 			.andExpect(jsonPath("$.bubble.message").value(isIn(HomeSummaryService.DEFAULT_BUBBLE_MESSAGES)))
 			.andExpect(jsonPath("$.bubble.priority").value(10))
+			.andExpect(jsonPath("$.bubble.seenEndpoint").value(nullValue()))
 			.andExpect(jsonPath("$.budget.yearMonth").value(yearMonth))
 			.andExpect(jsonPath("$.budget.monthlyBudgetAmount").value(0))
 			.andExpect(jsonPath("$.budget.spentAmount").value(0))
@@ -156,7 +158,8 @@ class HomeSummaryIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(jsonPath("$.budget.showBudgetExhaustionBubble").value(true))
 			.andExpect(jsonPath("$.bubble.type").value("BUDGET_ZERO"))
 			.andExpect(jsonPath("$.bubble.message").value(isIn(HomeSummaryService.BUDGET_ZERO_BUBBLE_MESSAGES)))
-			.andExpect(jsonPath("$.bubble.priority").value(90));
+			.andExpect(jsonPath("$.bubble.priority").value(90))
+			.andExpect(jsonPath("$.bubble.seenEndpoint").value("/api/v1/home/bubbles/BUDGET_ZERO/seen"));
 	}
 
 	@Test
@@ -173,7 +176,8 @@ class HomeSummaryIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(jsonPath("$.budget.exhausted").value(true))
 			.andExpect(jsonPath("$.bubble.type").value("BUDGET_NEGATIVE"))
 			.andExpect(jsonPath("$.bubble.message").value(isIn(HomeSummaryService.BUDGET_NEGATIVE_BUBBLE_MESSAGES)))
-			.andExpect(jsonPath("$.bubble.priority").value(100));
+			.andExpect(jsonPath("$.bubble.priority").value(100))
+			.andExpect(jsonPath("$.bubble.seenEndpoint").value("/api/v1/home/bubbles/BUDGET_NEGATIVE/seen"));
 	}
 
 	@Test
@@ -249,7 +253,8 @@ class HomeSummaryIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.bubble.type").value("DEFAULT"))
 			.andExpect(jsonPath("$.bubble.message").value(isIn(HomeSummaryService.DEFAULT_BUBBLE_MESSAGES)))
-			.andExpect(jsonPath("$.bubble.priority").value(10));
+			.andExpect(jsonPath("$.bubble.priority").value(10))
+			.andExpect(jsonPath("$.bubble.seenEndpoint").value(nullValue()));
 	}
 
 	@Test
@@ -261,7 +266,8 @@ class HomeSummaryIntegrationTest extends PostgreSqlContainerTest {
 		mockMvc.perform(get("/api/v1/home/summary").header("X-User-Id", userId))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.bubble.type").value("DECISION_REACTION"))
-			.andExpect(jsonPath("$.bubble.message").value("합리적으로 잘 결정했어요"));
+			.andExpect(jsonPath("$.bubble.message").value("합리적으로 잘 결정했어요"))
+			.andExpect(jsonPath("$.bubble.seenEndpoint").value("/api/v1/home/bubbles/DECISION_REACTION/seen"));
 
 		mockMvc.perform(post("/api/v1/home/bubbles/DECISION_REACTION/seen").header("X-User-Id", userId))
 			.andExpect(status().isNoContent());
@@ -323,7 +329,8 @@ class HomeSummaryIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.bubble.type").value("PENDING_WISHLIST"))
 			.andExpect(jsonPath("$.bubble.message").value(isIn(HomeSummaryService.PENDING_WISHLIST_BUBBLE_MESSAGES)))
-			.andExpect(jsonPath("$.bubble.priority").value(50));
+			.andExpect(jsonPath("$.bubble.priority").value(50))
+			.andExpect(jsonPath("$.bubble.seenEndpoint").value(nullValue()));
 	}
 
 	@Test
@@ -342,7 +349,8 @@ class HomeSummaryIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.bubble.type").value("VOTE_WAITING"))
 			.andExpect(jsonPath("$.bubble.message").value(isIn(HomeSummaryService.VOTE_WAITING_BUBBLE_MESSAGES)))
-			.andExpect(jsonPath("$.bubble.priority").value(40));
+			.andExpect(jsonPath("$.bubble.priority").value(40))
+			.andExpect(jsonPath("$.bubble.seenEndpoint").value(nullValue()));
 	}
 
 	@Test


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-69**
- Jira: 없음

> PR 제목: `[fix] NF-69 홈 말풍선 BE 계약 보완`
> 브랜치: `fix/NF-69-home-bubble-contract`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #159

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- 홈 말풍선 QA에서 FE가 표시할 최종 말풍선 타입/문구/우선순위를 BE 응답만으로 확정하기 어려웠습니다.

### 왜 발생했나? (Root Cause)
- `/api/v1/home/summary`가 예산 소진 여부와 마스코트 반응 메시지만 내려주고, 홈 화면 단일 말풍선 계약은 제공하지 않았습니다.
- 최초 홈 진입 말풍선 seen 상태도 별도 저장소가 없어 반복 노출 제어가 어려웠습니다.

### 어떻게 고쳤나?
- 홈 요약 응답에 `bubble` 객체를 추가해 `type`, `message`, `priority`, `shouldShow`, `seenEndpoint`를 내려줍니다.
- 예산 마이너스, 예산 0원, 구매 결정 반응, 첫 홈, 미결정 위시, 투표 대기, 기본 말풍선 우선순위를 BE에서 결정합니다.
- `POST /api/v1/home/bubbles/{type}/seen`로 웰컴/예산/구매 결정 반응 말풍선 seen 처리를 지원합니다.
- 닫기 처리가 없는 미결정 위시/투표 대기/기본 말풍선은 `seenEndpoint=null`로 내려줍니다.
- `mascot_profiles.welcome_bubble_seen` 컬럼을 추가하고, 기존 마스코트 프로필은 seen 처리된 상태로 백필합니다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법(가능하면)
- Steps:
  1. 홈 진입 시 `/api/v1/home/summary` 호출
  2. 예산/마스코트/위시/투표 상태에 따라 말풍선 표시
- 기대 결과: API 응답의 `bubble`만 보고 표시할 말풍선을 확정할 수 있음
- 실제 결과: 기존에는 FE가 여러 필드를 조합해 추론해야 했음

### 재발 방지(있다면)
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [ ] 런북/문서 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] AC1: 홈 요약 응답에 표시할 단일 말풍선 계약이 포함된다.
- [x] AC2: 예산 마이너스/0원 조건이 미결정 위시/투표 대기보다 우선한다.
- [x] AC3: 첫 홈 웰컴 말풍선과 seen 처리 후 기본 말풍선 전환을 검증한다.
- [x] AC4: 닫기 처리가 없는 말풍선에는 no-op endpoint를 노출하지 않는다.

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew test --tests com.sagongsa.backend.home.HomeSummaryIntegrationTest --tests com.sagongsa.backend.domain.DomainSchemaSmokeTest`
- Result: 성공
- Command: `./gradlew test`
- Result: 성공
- Command: `git diff --check`
- Result: 성공

### CI
- 링크/결과: PR 체크에서 확인

### Smoke / 수동 검증
- 시나리오: 홈 요약 통합 테스트로 말풍선 타입/문구 후보/우선순위/seen endpoint 검증
- 결과: 성공

### 테스트 공백(있다면 이유 필수)
- 없음

---

## 🧭 영향 범위 (필수)
- [ ] API 스펙 변경 없음
- [x] API 스펙 변경 있음 (요약: `HomeSummaryResponse.bubble` 추가, `POST /api/v1/home/bubbles/{type}/seen` 추가)
- [ ] DB 스키마 변경 없음
- [x] DB 스키마 변경 있음 (마이그레이션/락/시간: `V19__add_home_welcome_bubble_seen.sql`, 기존 행 true 백필 후 boolean not null default false 컬럼 확정)
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음 (항목: )
- [x] 캐시/큐/외부 연동 영향 없음
- [ ] 캐시/큐/외부 연동 영향 있음 (요약: )

---

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음
- [ ] Breaking change 있음 → 무엇이 깨지는지 / 마이그레이션 / 롤아웃 전략:

---

## 🚀 배포/릴리즈 (해당 시 필수)
### Feature Flag
- [x] 사용 안함
- [ ] 사용함 → Flag/기본값/롤아웃:

### 모니터링/알림
- 확인할 대시보드/지표: 홈 요약 API 5xx, DB 마이그레이션 성공 여부
- 에러/로그 키워드: `/api/v1/home/summary`, `/api/v1/home/bubbles/{type}/seen`

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- `bubble` 필드는 응답 추가라 기존 클라이언트 호환성 영향은 낮습니다.
- 기존 마스코트 프로필은 `welcome_bubble_seen=true`로 백필되어 배포 직후 웰컴 말풍선이 일괄 노출되지 않습니다.

### 롤백
- [ ] 플래그/설정으로 우회 가능
- [x] 배포 롤백(이전 태그/이미지) 가능
- [x] 데이터 롤백/역마이그레이션 필요 (절차: 배포 롤백 후 `mascot_profiles.welcome_bubble_seen` 컬럼 제거)

---

## 📸 증빙 (선택)
- 스크린샷/로그/메트릭 링크:
- 전/후 비교(가능하면):

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직: `HomeSummaryService#homeBubble`, `HomeSummaryResponse.BubbleSummary`, `V19__add_home_welcome_bubble_seen.sql`
- 트레이드오프/대안: FE 추론 대신 BE에서 단일 우선순위 계약을 내려주도록 선택했습니다.
- 성능/보안/호환성 영향: 홈 요약 조회에 exists 쿼리 3개가 추가되며, 모두 사용자 단위 조건입니다.
