### PR TITLE
[fix] NF-70 카카오 로그인 미설정 동의항목 요청 제거

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,7 +37,6 @@ spring:
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             scope:
               - profile_nickname
-              - profile_image
 
 server:
   servlet:

--- a/src/test/java/com/sagongsa/backend/config/KakaoOAuthScopeConfigTest.java
+++ b/src/test/java/com/sagongsa/backend/config/KakaoOAuthScopeConfigTest.java
@@ -1,0 +1,43 @@
+package com.sagongsa.backend.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.core.io.FileSystemResource;
+
+class KakaoOAuthScopeConfigTest {
+
+	private static final String KAKAO_SCOPE_PREFIX = "spring.security.oauth2.client.registration.kakao.scope[";
+
+	@Test
+	void kakaoLoginDoesNotRequestDisabledProfileImageConsentItem() {
+		assertKakaoScopes("src/main/resources/application.yml");
+		assertKakaoScopes("src/test/resources/application.yml");
+	}
+
+	private static void assertKakaoScopes(String path) {
+		Properties properties = loadProperties(path);
+		List<String> scopes = properties.stringPropertyNames().stream()
+			.filter(name -> name.startsWith(KAKAO_SCOPE_PREFIX))
+			.sorted()
+			.map(properties::getProperty)
+			.toList();
+
+		assertThat(scopes)
+			.as(path)
+			.containsExactly("profile_nickname")
+			.doesNotContain("profile_image");
+	}
+
+	private static Properties loadProperties(String path) {
+		YamlPropertiesFactoryBean factoryBean = new YamlPropertiesFactoryBean();
+		factoryBean.setResources(new FileSystemResource(path));
+
+		Properties properties = factoryBean.getObject();
+		assertThat(properties).as(path).isNotNull();
+		return properties;
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -30,7 +30,6 @@ spring:
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             scope:
               - profile_nickname
-              - profile_image
 
 app:
   auth:


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-70**
- Jira: 없음

> PR 제목: `NF-70 카카오 로그인 미설정 동의항목 요청 제거`  
> 브랜치: `fix/NF-70-kakao-login-scope`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #161

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- 카카오 로그인 인가 요청에 카카오 앱에서 설정하지 않은 `profile_image` 동의항목이 포함되어 `KOE205` 오류 화면이 노출되었습니다.

### 왜 발생했나? (Root Cause)
- 백엔드 OAuth2 client registration의 Kakao scope가 `profile_nickname`, `profile_image`를 함께 요청하고 있었습니다.
- 카카오 개발자 콘솔에서 프로필 이미지 동의항목을 요청 안 함으로 둔 환경에서는 `profile_image` scope가 invalid scope가 됩니다.

### 어떻게 고쳤나?
- 운영/테스트 OAuth 설정에서 Kakao scope를 `profile_nickname`만 요청하도록 변경했습니다.
- 설정 회귀 방지를 위해 main/test `application.yml`의 Kakao scope에 `profile_image`가 포함되지 않는지 검증하는 테스트를 추가했습니다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법(가능하면)
- Steps:
  1. `https://34-66-55-165.sslip.io/login.html`에서 카카오 로그인을 선택합니다.
  2. `/oauth2/authorization/kakao`가 카카오 인가 URL로 리다이렉트합니다.
- 기대 결과: 카카오 로그인/동의 화면으로 정상 진행
- 실제 결과: `KOE205`, 설정하지 않은 동의 항목 `profile_image` 오류 화면 노출

### 재발 방지(있다면)
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [ ] 런북/문서 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] AC1: Kakao OAuth scope에서 `profile_image`를 제거한다.
- [x] AC2: 테스트 설정도 운영 설정과 동일하게 `profile_nickname`만 요청한다.
- [x] AC3: `profile_image` scope가 다시 추가되면 테스트에서 잡히도록 한다.

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew test --tests com.sagongsa.backend.config.KakaoOAuthScopeConfigTest`
- Result: 성공
- Command: `./gradlew test`
- Result: 성공
- Command: `git diff --check`
- Result: 성공

### CI
- 링크/결과: GitHub Actions 자동 실행 예정

### Smoke / 수동 검증
- 시나리오: 라이브 카카오 인가 URL에 `scope=profile_nickname%20profile_image`가 포함되어 KOE205가 발생하는 것을 확인하고, 백엔드 설정에서 `profile_image` 요청을 제거했습니다.
- 결과: 배포 후 `/oauth2/authorization/kakao` 인가 URL에서 `profile_image`가 빠져야 합니다.

### 테스트 공백(있다면 이유 필수)
- 실제 카카오 계정 로그인 완료 및 배포 서버 smoke는 PR 배포/머지 이후 라이브 환경에서 확인해야 합니다.

---

## 🧭 영향 범위 (필수)
- [x] API 스펙 변경 없음
- [ ] API 스펙 변경 있음 (요약: )
- [x] DB 스키마 변경 없음
- [ ] DB 스키마 변경 있음 (마이그레이션/락/시간: )
- [ ] 설정/환경변수 변경 없음
- [x] 설정/환경변수 변경 있음 (항목: Kakao OAuth scope에서 profile_image 제거)
- [ ] 캐시/큐/외부 연동 영향 없음
- [x] 캐시/큐/외부 연동 영향 있음 (요약: 카카오 OAuth 인가 요청 scope에서 `profile_image` 제거)

---

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음
- [ ] Breaking change 있음 → 무엇이 깨지는지 / 마이그레이션 / 롤아웃 전략:

---

## 🚀 배포/릴리즈 (해당 시 필수)
### Feature Flag
- [x] 사용 안함
- [ ] 사용함 → Flag/기본값/롤아웃:

### 모니터링/알림
- 확인할 대시보드/지표: 카카오 로그인 실패율, `/login/oauth2/code/kakao` 실패 로그
- 에러/로그 키워드: `KOE205`, `invalid_scope`, `profile_image`, `oauth2_login_failed`

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 카카오 사용자 프로필 이미지가 더 이상 동의 scope로 요청되지 않으므로, 신규 로그인 사용자의 프로필 이미지 값은 없을 수 있습니다.
- 현재 서비스 코드는 프로필 이미지 누락을 허용하므로 로그인 자체에는 영향이 없습니다.

### 롤백
- [ ] 플래그/설정으로 우회 가능
- [x] 배포 롤백(이전 태그/이미지) 가능
- [ ] 데이터 롤백/역마이그레이션 필요 (절차: )

---

## 📸 증빙 (선택)
- 카카오 오류 화면: `KOE205`, 설정하지 않은 동의 항목 `profile_image`
- 라이브 인가 URL 확인: `scope=profile_nickname%20profile_image`

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직: `src/main/resources/application.yml`, `src/test/resources/application.yml`, `KakaoOAuthScopeConfigTest`
- 트레이드오프/대안: 카카오 콘솔에서 `profile_image`를 활성화하는 대신, 현재 정책에 맞춰 백엔드 요청 scope에서 제외했습니다.
- 성능/보안/호환성 영향: 성능/보안 영향 없음. 카카오 OAuth 동의항목 설정과의 호환성 개선.

