### PR TITLE
[chore] NF-69 Firebase 서비스 계정 gitignore 범위 확장

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,23 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Local docs / agents ###
+LOCAL_OAUTH_KEYS.md
+AGENTS.md
+agent.md
+
+### Local secrets ###
+.env
+.env.*
+!.env.example
+!.env.template
+application-local.yml
+application-local.yaml
+application-secret.yml
+application-secret.yaml
+application-secrets.yml
+application-secrets.yaml
+*firebase-adminsdk*.json
+firebase-service-account*.json
+serviceAccountKey*.json


### PR DESCRIPTION
# 🧰 Chore PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-69**
- Jira: https://parkjaehong.atlassian.net/browse/NF-69

> PR 제목: `[chore] NF-69 Firebase 서비스 계정 gitignore 범위 확장`
> 브랜치: `chore/NF-69-gitignore-secret-scope`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #163

---

## 🧩 한눈에 요약 (필수)
### 무엇을 변경했나? (인프라/빌드/CI/의존성 등)
- [ ] 인프라
- [x] 설정파일
- [ ] 빌드 파일
- [ ] CI
- [ ] 의존성
- [x] 런타임/비즈니스 로직 리팩터링 없음 (있으면 Refactor PR 템플릿 사용)

### 왜 필요한가? (안정성/속도/보안/개발경험)
- Firebase Admin SDK 서비스 계정 JSON을 로컬에서 다루게 되면서, 비밀키와 로컬 설정 파일이 실수로 커밋되지 않도록 `.gitignore` 범위를 확장합니다.

### 범위(스코프)
- Included: `.env.*`, 로컬 Spring 설정 파일, Firebase Admin SDK JSON, 로컬 에이전트/키 문서 ignore 패턴 추가
- Not included: Firebase 연동 로직, 실제 서비스 계정 JSON, 빌드/런타임 설정 변경

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `git diff --check -- .gitignore`
- Result: 통과
- Command: `git check-ignore -v AGENTS.md agent.md wigul-d9245-firebase-adminsdk-fbsvc-7ccba777e0.json src/main/resources/wigul-d9245-firebase-adminsdk-fbsvc-7ccba777e0.json .env.properties application-secret.yml`
- Result: 대상 파일들이 의도한 `.gitignore` 규칙으로 차단됨

### CI
- 링크/결과: PR 생성 후 자동 확인

### Smoke / 수동 검증 (해당 시)
- 시나리오: Firebase Admin SDK JSON 파일명을 repo 루트와 `src/main/resources` 경로 기준으로 ignore 판정 확인
- 결과: `*firebase-adminsdk*.json` 패턴으로 ignore됨

### 테스트 공백(있다면 이유 필수)
- `.gitignore` 전용 변경이라 애플리케이션 테스트는 생략했습니다.

---

## 🧭 영향 범위 (필수)
- [ ] 설정/환경변수 변경 없음
- [x] 설정/환경변수 변경 있음 (항목: `.gitignore` ignore 패턴)
- [x] CI/빌드 파이프라인 영향 없음
- [ ] CI/빌드 파이프라인 영향 있음 (요약: )
- [x] 의존성(dependency) 변경 없음
- [ ] 의존성(dependency) 변경 있음 (패키지/버전/주요 변경점: )

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 일부 로컬 설정 파일명이 새 패턴에 걸려 `git status`에 보이지 않을 수 있습니다. 패턴은 secret/local 파일명 중심으로 제한했습니다.

### 롤백
- [x] 단순 revert로 가능
- [ ] 버전 pin/되돌리기 필요 (대상: , 방법: )
- [ ] 배포 롤백(이전 태그/이미지) 가능

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/설정: `.gitignore`
- 트레이드오프/대안: 특정 파일명만 ignore할 수도 있지만, Firebase 키 파일명이 환경마다 달라질 수 있어 Admin SDK 계열 패턴으로 방어했습니다.
- 성능/보안/호환성 영향: 런타임 영향은 없고, 비밀키 커밋 방지 목적의 보안성 개선입니다.
