### PR TITLE
NF-71 Docs: FCM 서버 운영 설정 문서화

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@
 ./gradlew test
 ```
 
+## Environment
+
+FCM 푸시 발송은 기본값에서 비활성화됩니다.
+QA/운영 서버에서 활성화하려면 Firebase 서비스 계정 JSON을 레포 밖에 두고 환경변수로 경로만 주입합니다.
+
+| Variable | Default | Note |
+| --- | --- | --- |
+| `APP_PUSH_FCM_ENABLED` | `false` | `true`일 때 실제 FCM sender를 사용합니다. |
+| `APP_PUSH_FCM_CREDENTIALS_LOCATION` | empty | 예: `file:/opt/wigul/secrets/firebase-adminsdk.json` |
+| `APP_ADMIN_NOTIFICATION_TOKEN` | empty | 관리자 공지/점검 알림 API의 `X-Admin-Token` 검증에 사용합니다. |
+
+상세 운영 절차는 `docs/FCM_PUSH_OPERATIONS.md`를 기준으로 합니다.
+
 ## Coverage
 
 JaCoCo 커버리지 리포트는 테스트 실행 후 생성됩니다.

--- a/docs/CBT_SERVER_RESPONSE_RUNBOOK.md
+++ b/docs/CBT_SERVER_RESPONSE_RUNBOOK.md
@@ -53,6 +53,34 @@ sudo journalctl -u wigul-backend --since "2 hours ago" --no-pager | grep "<X-Req
 systemctl status wigul-backend --no-pager
 ```
 
+## FCM 푸시 설정 확인
+
+푸시 발송이 필요한 QA/운영 서버에서는 FCM systemd drop-in과 VM-local credential이 있어야 한다.
+credential JSON은 레포에 커밋하지 않고 서버 로컬에서만 관리한다.
+
+```bash
+sudo systemctl status wigul-backend --no-pager
+sudo systemctl show wigul-backend -p Environment --no-pager
+sudo ls -l /opt/wigul/secrets/firebase-adminsdk.json
+sudo grep '"project_id"' /opt/wigul/secrets/firebase-adminsdk.json
+```
+
+정상 기준:
+
+- `wigul-backend`가 `active (running)`이다.
+- `Environment=`에 `APP_PUSH_FCM_ENABLED=true`가 있다.
+- `Environment=`에 `APP_PUSH_FCM_CREDENTIALS_LOCATION=file:/opt/wigul/secrets/firebase-adminsdk.json`가 있다.
+- credential 파일 권한이 `600` 형태다.
+- credential JSON의 `project_id`가 프론트 앱 등록 Firebase 프로젝트와 일치한다.
+
+최근 재시작 로그에서 credential 로드 실패가 없는지도 확인한다.
+
+```bash
+sudo journalctl -u wigul-backend --since "10 minutes ago" --no-pager
+```
+
+상세 설치/롤백 절차는 `docs/FCM_PUSH_OPERATIONS.md`를 따른다.
+
 ## 수동 재시작
 
 자동 배포 workflow와 같은 서비스명을 사용한다.

--- a/docs/FCM_PUSH_OPERATIONS.md
+++ b/docs/FCM_PUSH_OPERATIONS.md
@@ -1,0 +1,144 @@
+# FCM 푸시 운영 가이드
+
+## 목적
+
+백엔드에서 Firebase Cloud Messaging 푸시 알림을 발송하기 위해 필요한 서버 설정과 검증 절차를 정리한다.
+
+Firebase 서비스 계정 JSON은 비밀키다. 레포와 빌드 산출물 밖에서만 관리한다.
+
+## 런타임 설정
+
+백엔드는 아래 환경변수를 읽는다.
+
+| 환경변수 | 기본값 | 설명 |
+| --- | --- | --- |
+| `APP_PUSH_FCM_ENABLED` | `false` | `false`이면 FCM 발송 대신 no-op sender를 사용한다. |
+| `APP_PUSH_FCM_CREDENTIALS_LOCATION` | empty | Firebase 서비스 계정 JSON의 Spring resource 경로다. FCM 활성화 시 필수다. |
+| `APP_ADMIN_NOTIFICATION_TOKEN` | empty | 관리자 알림 API에서 `X-Admin-Token` 검증에 사용할 수 있는 선택 값이다. |
+
+`APP_PUSH_FCM_ENABLED=true`인데 `APP_PUSH_FCM_CREDENTIALS_LOCATION`이 비어 있거나 읽을 수 없으면 애플리케이션 부팅이 실패한다. 푸시가 반쯤 켜진 상태로 서버가 뜨는 것을 막기 위한 동작이다.
+
+## 비밀 정보 관리 원칙
+
+- Firebase 서비스 계정 JSON 파일은 커밋하지 않는다.
+- JSON 내용을 이슈, PR, 로그, 런북, 채팅에 붙여 넣지 않는다.
+- 실제 private key 필드, `private_key_id`, `client_email`, 다운로드된 로컬 파일명을 문서에 남기지 않는다.
+- JSON의 `project_id`가 프론트 앱 등록에 사용한 Firebase 프로젝트와 일치하는지만 확인한다. 프로젝트가 다르면 등록된 토큰 발송이 전부 실패할 수 있다.
+
+## VM 설정
+
+Firebase Admin SDK JSON은 승인된 SSH 경로로 VM에 업로드한다. 예를 들어 GCP 브라우저 SSH 업로드 또는 등록된 private key를 사용하는 `scp`를 사용할 수 있다.
+
+임시 업로드 경로 예시:
+
+```text
+/tmp/firebase-adminsdk.json
+```
+
+이후 파일을 백엔드 서비스 계정이 읽을 수 있는 secret 디렉토리로 설치한다.
+
+```bash
+SERVICE_USER=$(systemctl show -p User --value wigul-backend)
+[ -z "$SERVICE_USER" ] && SERVICE_USER=root
+SERVICE_GROUP=$(id -gn "$SERVICE_USER")
+
+sudo install -d -m 750 -o "$SERVICE_USER" -g "$SERVICE_GROUP" /opt/wigul/secrets
+
+sudo install -m 600 -o "$SERVICE_USER" -g "$SERVICE_GROUP" \
+  /tmp/firebase-adminsdk.json \
+  /opt/wigul/secrets/firebase-adminsdk.json
+
+rm -f /tmp/firebase-adminsdk.json
+```
+
+private key 내용은 출력하지 않고 `project_id`와 파일 권한만 확인한다.
+
+```bash
+sudo grep '"project_id"' /opt/wigul/secrets/firebase-adminsdk.json
+sudo ls -l /opt/wigul/secrets/firebase-adminsdk.json
+```
+
+권한 형태:
+
+```text
+-rw------- <service-user> <service-group> /opt/wigul/secrets/firebase-adminsdk.json
+```
+
+## systemd drop-in
+
+FCM 설정은 systemd drop-in으로 주입한다. 이렇게 하면 secret 경로가 jar와 레포 밖에 남는다.
+
+```bash
+sudo mkdir -p /etc/systemd/system/wigul-backend.service.d
+
+printf '%s\n' \
+'[Service]' \
+'Environment="APP_PUSH_FCM_ENABLED=true"' \
+'Environment="APP_PUSH_FCM_CREDENTIALS_LOCATION=file:/opt/wigul/secrets/firebase-adminsdk.json"' \
+| sudo tee /etc/systemd/system/wigul-backend.service.d/fcm.conf >/dev/null
+
+sudo systemctl daemon-reload
+sudo systemctl restart wigul-backend
+```
+
+drop-in이 로드됐고 서버가 정상 부팅됐는지 확인한다.
+
+```bash
+sudo systemctl status wigul-backend --no-pager
+sudo systemctl show wigul-backend -p Environment --no-pager
+sudo journalctl -u wigul-backend --since "10 minutes ago" --no-pager
+```
+
+정상 기준:
+
+- `wigul-backend`가 `active (running)`이다.
+- `Environment=`에 `APP_PUSH_FCM_ENABLED=true`가 있다.
+- `Environment=`에 `APP_PUSH_FCM_CREDENTIALS_LOCATION=file:/opt/wigul/secrets/firebase-adminsdk.json`가 있다.
+- startup 로그에 `Failed to load Firebase credentials`가 없다.
+
+## 배포와의 관계
+
+QA 배포 workflow는 jar를 빌드해서 VM에 업로드하고 `wigul-backend`를 재시작한다.
+
+Firebase 서비스 계정 JSON을 업로드하지 않고, systemd drop-in도 만들지 않는다. VM-local secret 파일과 drop-in은 일반적인 jar 배포와 서비스 재시작 후에도 유지된다. 다만 새 VM을 만들거나 서비스 유닛을 다시 구성하면 FCM 설정을 다시 provision해야 한다.
+
+## End-to-End 테스트 흐름
+
+1. 프론트가 같은 Firebase 프로젝트에서 FCM 토큰을 발급받는다.
+2. 프론트가 토큰을 등록한다.
+
+```http
+POST /api/v1/push-tokens
+```
+
+3. 백엔드가 스케줄 worker, reminder worker, 관리자 알림 API 중 하나로 알림을 생성한다.
+4. 백엔드는 인앱 알림을 저장하고 활성 device token으로 FCM을 발송한다.
+5. 프론트가 실기기에서 푸시 수신을 확인한다.
+
+서버에서는 토큰 등록과 알림 생성 여부를 확인할 수 있지만, 실제 푸시 수신 여부는 실기기에서 확인해야 한다.
+
+## 장애 확인 포인트
+
+| 증상 | 확인 |
+| --- | --- |
+| 서버는 뜨지만 푸시가 발송되지 않음 | `systemctl show`에서 `APP_PUSH_FCM_ENABLED=true`인지 확인한다. |
+| 재시작 시 서버 부팅 실패 | `APP_PUSH_FCM_CREDENTIALS_LOCATION`과 파일 권한을 확인한다. |
+| 토큰 등록 후 모든 발송 실패 | 프론트 앱 등록 Firebase 프로젝트와 서비스 계정 JSON의 프로젝트가 일치하는지 확인한다. |
+| 특정 기기만 푸시 수신 실패 | 토큰이 invalid 처리되어 비활성화됐는지 확인한다. |
+
+## 롤백
+
+credential 파일은 유지하고 FCM만 비활성화한다.
+
+```bash
+sudo rm -f /etc/systemd/system/wigul-backend.service.d/fcm.conf
+sudo systemctl daemon-reload
+sudo systemctl restart wigul-backend
+sudo systemctl show wigul-backend -p Environment --no-pager
+```
+
+credential 파일은 키 교체나 환경 폐기 시에만 삭제한다.
+
+```bash
+sudo rm -f /opt/wigul/secrets/firebase-adminsdk.json
+```


### PR DESCRIPTION
# 📝 Docs PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-71**
- Jira: https://parkjaehong.atlassian.net/browse/NF-71

> PR 제목: `NF-71 Docs: FCM 서버 운영 설정 문서화`  
> 브랜치: `docs/NF-71-fcm-push-operations`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #165

---

## 🧩 한눈에 요약 (필수)
### 무엇을 문서화/수정했나?
- FCM 서버 발송 활성화에 필요한 환경변수와 기본값을 README에 추가했습니다.
- Firebase 서비스 계정 JSON을 레포 밖 VM-local secret으로 관리하는 운영 가이드를 추가했습니다.
- CBT 서버 런북에 FCM 설정 확인 명령과 정상 기준을 추가했습니다.

### 왜 필요한가? (대상 독자 / 문제)
- 대상 독자: QA/운영 서버를 배포하거나 푸시 장애를 확인하는 백엔드 담당자
- 해결하는 문제: FCM이 활성화된 서버 상태에서 secret 파일, systemd drop-in, CD 범위가 문서화되지 않아 재배포/장애대응 시 설정 누락이 발생할 수 있음

### 범위(스코프)
- Included:
  - `APP_PUSH_FCM_ENABLED`
  - `APP_PUSH_FCM_CREDENTIALS_LOCATION`
  - `APP_ADMIN_NOTIFICATION_TOKEN`
  - VM-local credential 설치 예시
  - systemd drop-in 설정/검증/롤백
  - QA deploy workflow와 secret 관리 범위 구분
- Not included:
  - 실제 Firebase 서비스 계정 JSON
  - 실제 VM 주소, 계정, private key, 관리자 토큰
  - 코드 동작 변경

---

## ✅ Done 체크 (필수)
- [x] Done1: FCM 운영 가이드 문서 추가
- [x] Done2: README 환경변수 요약 추가
- [x] Done3: CBT 서버 런북에 FCM 설정 확인 절차 추가

---

## 🔍 검증 (필수)
- [x] 링크/앵커/목차 동작 확인
- [x] 예시 명령어/스크립트가 최신 상태인지 확인
- [x] 민감정보(토큰/내부 URL/개인정보/API 키) 포함 여부 점검
- [x] 용어/표현/정책 기준(있다면) 준수

### Preview / 확인 위치
- 문서 경로:
  - `docs/FCM_PUSH_OPERATIONS.md`
  - `docs/CBT_SERVER_RESPONSE_RUNBOOK.md`
  - `README.md`
- 주요 섹션 링크:
  - FCM 푸시 운영 가이드
  - CBT 서버 대응 runbook > FCM 푸시 설정 확인
  - README > Environment

---

## 🧭 영향 범위 (필수)
- [x] 코드/동작 변경 없음
- [ ] 운영 절차(런북) 변경 없음
- [x] 운영 절차(런북) 변경 있음 (요약: FCM 설정 확인/롤백 절차 추가)
- [ ] 외부 공개 문서 변경 없음
- [x] 외부 공개 문서 변경 있음 (요약: 공개 가능한 env/운영 절차만 문서화)
- [ ] 설정/환경변수 문서 변경 없음
- [x] 설정/환경변수 문서 변경 있음 (항목: `APP_PUSH_FCM_ENABLED`, `APP_PUSH_FCM_CREDENTIALS_LOCATION`, `APP_ADMIN_NOTIFICATION_TOKEN`)

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 잘못된 운영 명령이 문서화되면 서버 설정 확인/롤백 과정에서 혼동이 생길 수 있습니다.
- 공개 레포 문서이므로 실제 secret, 내부 주소, 개인 계정이 포함되지 않도록 제한했습니다.

### 롤백
- [x] 단순 revert로 가능
- [ ] 별도 안내/공지 필요 (대상: , 내용: )

---

## 📸 증빙 (선택)
- `git diff --cached --check`
- 민감정보 검색: 실제 Firebase 프로젝트 ID, VM 주소, 개인 계정, 다운로드 키 파일명, 토큰 패턴 미포함 확인

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 섹션/문서:
  - `docs/FCM_PUSH_OPERATIONS.md`
  - `docs/CBT_SERVER_RESPONSE_RUNBOOK.md`의 FCM 푸시 설정 확인
- 사실관계/절차/보안 관련 체크포인트:
  - systemd drop-in 설정 명령이 현재 서버 구성과 맞는지
  - CD가 secret 파일을 배포하지 않는다는 설명이 맞는지
  - 공개 레포에 남기면 안 되는 값이 포함되지 않았는지
