### PR TITLE
NF-72 Fix: 머지 후 기술 리뷰 후속 보완

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -27,6 +27,17 @@ jobs:
       - name: Build bootJar
         run: ./gradlew clean bootJar -x test --no-daemon
 
+      - name: Resolve bootJar path
+        id: bootjar
+        run: |
+          jar_path="$(find build/libs -maxdepth 1 -type f -name "*.jar" ! -name "*-plain.jar" | sort | head -n 1)"
+          if [ -z "$jar_path" ]; then
+            echo "No bootJar artifact found under build/libs" >&2
+            exit 1
+          fi
+          echo "path=$jar_path" >> "$GITHUB_OUTPUT"
+          echo "Resolved bootJar: $jar_path"
+
       - name: Prepare SSH
         run: |
           mkdir -p ~/.ssh
@@ -45,12 +56,22 @@ jobs:
         run: |
           scp -i ~/.ssh/deploy_key \
             -o IdentitiesOnly=yes \
-            build/libs/wigul-backend-0.0.1-SNAPSHOT.jar \
+            "${{ steps.bootjar.outputs.path }}" \
             ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }}:/home/${{ secrets.GCP_VM_USER }}/404_BE/build/libs/wigul-backend-0.0.1-SNAPSHOT.jar
 
       - name: Restart service
         run: |
           ssh -i ~/.ssh/deploy_key \
             -o IdentitiesOnly=yes \
-            ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }} \
-            "sudo -n systemctl restart wigul-backend && systemctl status wigul-backend --no-pager"
+            ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }} <<'REMOTE'
+          sudo -n systemctl restart wigul-backend
+          for attempt in {1..10}; do
+            if systemctl is-active --quiet wigul-backend; then
+              systemctl status wigul-backend --no-pager
+              exit 0
+            fi
+            sleep 2
+          done
+          systemctl status wigul-backend --no-pager
+          exit 1
+          REMOTE

--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -6,16 +6,24 @@ on:
       - develop
   workflow_dispatch:
 
+concurrency:
+  group: deploy-qa-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      SSH_HOST: ${{ secrets.GCP_VM_HOST }}
+      SSH_PORT: ${{ secrets.GCP_VM_PORT }}
+      SSH_USER: ${{ secrets.GCP_VM_USER }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
@@ -24,8 +32,8 @@ jobs:
       - name: Grant execute permission for Gradle
         run: chmod +x ./gradlew
 
-      - name: Build bootJar
-        run: ./gradlew clean bootJar -x test --no-daemon
+      - name: Test and build bootJar
+        run: ./gradlew clean test bootJar --no-daemon
 
       - name: Resolve bootJar path
         id: bootjar
@@ -40,38 +48,47 @@ jobs:
 
       - name: Prepare SSH
         run: |
+          : "${SSH_HOST:?GCP_VM_HOST secret is required}"
+          : "${SSH_USER:?GCP_VM_USER secret is required}"
           mkdir -p ~/.ssh
           echo "${{ secrets.GCP_VM_SSH_KEY_B64 }}" | base64 -d > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H "${{ secrets.GCP_VM_HOST }}" >> ~/.ssh/known_hosts
+          ssh-keyscan -p "${SSH_PORT:-22}" -H "$SSH_HOST" >> ~/.ssh/known_hosts
 
       - name: Test SSH connection
         run: |
           ssh -i ~/.ssh/deploy_key \
+            -p "${SSH_PORT:-22}" \
             -o IdentitiesOnly=yes \
-            ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }} \
+            "$SSH_USER@$SSH_HOST" \
             "whoami && hostname"
 
       - name: Upload jar
         run: |
           scp -i ~/.ssh/deploy_key \
+            -P "${SSH_PORT:-22}" \
             -o IdentitiesOnly=yes \
             "${{ steps.bootjar.outputs.path }}" \
-            ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }}:/home/${{ secrets.GCP_VM_USER }}/404_BE/build/libs/wigul-backend-0.0.1-SNAPSHOT.jar
+            "$SSH_USER@$SSH_HOST:/home/$SSH_USER/404_BE/build/libs/wigul-backend-0.0.1-SNAPSHOT.jar"
 
-      - name: Restart service
+      - name: Restart service and wait for health
         run: |
           ssh -i ~/.ssh/deploy_key \
+            -p "${SSH_PORT:-22}" \
             -o IdentitiesOnly=yes \
-            ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }} <<'REMOTE'
+            "$SSH_USER@$SSH_HOST" <<'REMOTE'
+          set -euo pipefail
           sudo -n systemctl restart wigul-backend
-          for attempt in {1..10}; do
-            if systemctl is-active --quiet wigul-backend; then
+          for attempt in {1..30}; do
+            if systemctl is-active --quiet wigul-backend \
+              && curl -fsS --max-time 2 http://127.0.0.1:8080/health >/tmp/wigul-health.json; then
               systemctl status wigul-backend --no-pager
+              cat /tmp/wigul-health.json
               exit 0
             fi
             sleep 2
           done
-          systemctl status wigul-backend --no-pager
+          systemctl status wigul-backend --no-pager || true
+          journalctl -u wigul-backend --since "2 minutes ago" --no-pager | tail -n 120 || true
           exit 1
           REMOTE

--- a/src/main/java/com/sagongsa/backend/auth/AppReviewerAccount.java
+++ b/src/main/java/com/sagongsa/backend/auth/AppReviewerAccount.java
@@ -1,0 +1,16 @@
+package com.sagongsa.backend.auth;
+
+import java.util.UUID;
+
+final class AppReviewerAccount {
+
+	static final UUID USER_ID = UUID.fromString("40400000-0000-0000-0000-000000000055");
+	static final String PROVIDER = "kakao";
+	static final String PROVIDER_DB_VALUE = "KAKAO";
+	static final String PROVIDER_USER_ID = "app-reviewer-fixed";
+	static final String NAME = "앱 심사 계정";
+	static final String EMAIL = "app-reviewer@sagongsa.dev";
+
+	private AppReviewerAccount() {
+	}
+}

--- a/src/main/java/com/sagongsa/backend/auth/AuthApiController.java
+++ b/src/main/java/com/sagongsa/backend/auth/AuthApiController.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -26,12 +25,6 @@ import org.springframework.web.server.ResponseStatusException;
 @RequestMapping("/api/auth")
 @Tag(name = "Auth", description = "OAuth login session and JWT refresh APIs")
 public class AuthApiController {
-
-	private static final UUID APP_REVIEWER_USER_ID = UUID.fromString("40400000-0000-0000-0000-000000000055");
-	private static final String APP_REVIEWER_PROVIDER = "kakao";
-	private static final String APP_REVIEWER_PROVIDER_USER_ID = "app-reviewer-fixed";
-	private static final String APP_REVIEWER_NAME = "앱 심사 계정";
-	private static final String APP_REVIEWER_EMAIL = "app-reviewer@sagongsa.dev";
 
 	private final JwtTokenService jwtTokenService;
 	private final UserAccountRepository userAccountRepository;
@@ -103,19 +96,19 @@ public class AuthApiController {
 		}
 	)
 	public TokenRefreshResponse issueReviewerToken() {
-		if (!userAccountRepository.existsById(APP_REVIEWER_USER_ID)) {
+		if (!userAccountRepository.existsById(AppReviewerAccount.USER_ID)) {
 			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "App reviewer account is not configured.");
 		}
 
 		JwtTokenService.TokenPair tokenPair = jwtTokenService.issueTokenPair(
 			new SocialUserProfile(
-				APP_REVIEWER_PROVIDER,
-				APP_REVIEWER_PROVIDER_USER_ID,
-				APP_REVIEWER_NAME,
-				APP_REVIEWER_EMAIL,
+				AppReviewerAccount.PROVIDER,
+				AppReviewerAccount.PROVIDER_USER_ID,
+				AppReviewerAccount.NAME,
+				AppReviewerAccount.EMAIL,
 				null,
 				Map.of("purpose", "app-review"),
-				APP_REVIEWER_USER_ID
+				AppReviewerAccount.USER_ID
 			),
 			List.of(new SimpleGrantedAuthority("ROLE_USER"))
 		);

--- a/src/main/java/com/sagongsa/backend/deliberation/DeliberationService.java
+++ b/src/main/java/com/sagongsa/backend/deliberation/DeliberationService.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.IntUnaryOperator;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -43,9 +45,16 @@ public class DeliberationService {
 	);
 
 	private final JdbcTemplate jdbcTemplate;
+	private final IntUnaryOperator randomIndexProvider;
 
+	@Autowired
 	public DeliberationService(JdbcTemplate jdbcTemplate) {
+		this(jdbcTemplate, bound -> ThreadLocalRandom.current().nextInt(bound));
+	}
+
+	DeliberationService(JdbcTemplate jdbcTemplate, IntUnaryOperator randomIndexProvider) {
 		this.jdbcTemplate = jdbcTemplate;
+		this.randomIndexProvider = randomIndexProvider;
 	}
 
 	public DeliberationSummaryResponse getSummary(UUID userId, UUID itemId) {
@@ -167,7 +176,7 @@ public class DeliberationService {
 	}
 
 	private String randomValue(List<String> values) {
-		return values.get(ThreadLocalRandom.current().nextInt(values.size()));
+		return values.get(randomIndexProvider.applyAsInt(values.size()));
 	}
 
 	private BigDecimal usageRate(int spentAmount, int monthlyBudgetAmount) {

--- a/src/main/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcher.java
@@ -73,8 +73,17 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 	private Browser browser() {
 		synchronized (browserLock) {
 			if (browser == null) {
-				playwright = Playwright.create();
-				browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true));
+				Playwright newPlaywright = null;
+				try {
+					newPlaywright = Playwright.create();
+					Browser newBrowser = newPlaywright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true));
+					playwright = newPlaywright;
+					browser = newBrowser;
+				}
+				catch (RuntimeException exception) {
+					closeQuietly(newPlaywright);
+					throw exception;
+				}
 			}
 			return browser;
 		}
@@ -93,7 +102,7 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 				ShoppingUrlSafety.validatePublicHost(requestUri);
 				route.resume();
 			}
-			catch (RuntimeException exception) {
+			catch (IllegalArgumentException | ResponseStatusException exception) {
 				route.abort();
 			}
 		});
@@ -152,6 +161,17 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 			return 0;
 		}
 		return duration.toMillis();
+	}
+
+	private void closeQuietly(Playwright playwright) {
+		if (playwright == null) {
+			return;
+		}
+		try {
+			playwright.close();
+		}
+		catch (RuntimeException ignored) {
+		}
 	}
 
 	@Override

--- a/src/main/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcher.java
@@ -7,6 +7,7 @@ import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
 import com.microsoft.playwright.PlaywrightException;
 import com.microsoft.playwright.Response;
+import com.microsoft.playwright.Route;
 import com.microsoft.playwright.options.LoadState;
 import com.microsoft.playwright.options.WaitUntilState;
 import jakarta.annotation.PreDestroy;
@@ -14,6 +15,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.function.Supplier;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -25,12 +27,18 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 			+ "(KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
 
 	private final ShoppingImportProperties.BrowserFetch properties;
+	private final Supplier<Playwright> playwrightFactory;
 	private final Object browserLock = new Object();
 	private Playwright playwright;
 	private Browser browser;
 
 	public BrowserPageFetcher(ShoppingImportProperties.BrowserFetch properties) {
+		this(properties, Playwright::create);
+	}
+
+	BrowserPageFetcher(ShoppingImportProperties.BrowserFetch properties, Supplier<Playwright> playwrightFactory) {
 		this.properties = properties;
+		this.playwrightFactory = playwrightFactory;
 	}
 
 	@Override
@@ -74,15 +82,18 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 		synchronized (browserLock) {
 			if (browser == null) {
 				Playwright newPlaywright = null;
+				boolean success = false;
 				try {
-					newPlaywright = Playwright.create();
+					newPlaywright = playwrightFactory.get();
 					Browser newBrowser = newPlaywright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true));
 					playwright = newPlaywright;
 					browser = newBrowser;
+					success = true;
 				}
-				catch (RuntimeException exception) {
-					closeQuietly(newPlaywright);
-					throw exception;
+				finally {
+					if (!success) {
+						closeQuietly(newPlaywright);
+					}
 				}
 			}
 			return browser;
@@ -90,22 +101,32 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 	}
 
 	private void installRequestSafetyGuard(BrowserContext context) {
-		context.route("**/*", route -> {
+		context.route("**/*", BrowserPageFetcher::guardRoute);
+	}
+
+	static void guardRoute(Route route) {
+		try {
 			String requestUrl = route.request().url();
-			try {
-				URI requestUri = URI.create(requestUrl);
-				String scheme = Optional.ofNullable(requestUri.getScheme()).orElse("").toLowerCase(Locale.ROOT);
-				if (!scheme.equals("http") && !scheme.equals("https")) {
-					route.resume();
-					return;
-				}
-				ShoppingUrlSafety.validatePublicHost(requestUri);
+			URI requestUri = URI.create(requestUrl);
+			String scheme = Optional.ofNullable(requestUri.getScheme()).orElse("").toLowerCase(Locale.ROOT);
+			if (!scheme.equals("http") && !scheme.equals("https")) {
 				route.resume();
+				return;
 			}
-			catch (IllegalArgumentException | ResponseStatusException exception) {
-				route.abort();
-			}
-		});
+			ShoppingUrlSafety.validatePublicHost(requestUri);
+			route.resume();
+		}
+		catch (IllegalArgumentException | ResponseStatusException | PlaywrightException exception) {
+			abortQuietly(route);
+		}
+	}
+
+	private static void abortQuietly(Route route) {
+		try {
+			route.abort();
+		}
+		catch (PlaywrightException ignored) {
+		}
 	}
 
 	private Browser.NewContextOptions contextOptions(URI uri) {
@@ -170,7 +191,8 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 		try {
 			playwright.close();
 		}
-		catch (RuntimeException ignored) {
+		catch (Throwable ignored) {
+			// Keep the original browser startup failure visible.
 		}
 	}
 

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
@@ -570,18 +570,27 @@ public class ShoppingLinkImportService {
 		String title = normalizeWhitespace(document.title());
 		String bodyText = normalizeWhitespace(document.body() == null ? null : document.body().text());
 		String html = page.body() == null ? "" : page.body().toLowerCase(Locale.ROOT);
-		return isBlockedPageText(title)
-			|| isBlockedPageText(bodyText)
-			|| isChallengeShell(title, bodyText, html);
+		return isChallengeShell(title, bodyText, html)
+			|| isBlockedNoticeShell(title, bodyText);
 	}
 
 	private boolean isChallengeShell(String title, String bodyText, String html) {
-		boolean hasChallengeMarker = html.contains("cf-mitigated")
+		return hasChallengeMarker(html)
+			&& (isBlank(title) || isBlockedPageText(title))
+			&& (isBlank(bodyText) || bodyText.length() < 80 || isBlockedPageText(bodyText));
+	}
+
+	private boolean isBlockedNoticeShell(String title, String bodyText) {
+		if (isBlockedPageText(title)) {
+			return isBlank(bodyText) || bodyText.length() < 120 || isBlockedPageText(bodyText);
+		}
+		return isBlank(title) && isBlockedPageText(bodyText) && bodyText.length() < 120;
+	}
+
+	private boolean hasChallengeMarker(String html) {
+		return html.contains("cf-mitigated")
 			|| html.contains("cf_chl")
 			|| html.contains("/cdn-cgi/challenge-platform");
-		return hasChallengeMarker
-			&& (isBlank(title) || isBlockedPageText(title))
-			&& (isBlank(bodyText) || bodyText.length() < 80);
 	}
 
 	private boolean isBlockedPageText(String text) {

--- a/src/main/java/com/sagongsa/backend/mypage/MypageService.java
+++ b/src/main/java/com/sagongsa/backend/mypage/MypageService.java
@@ -229,39 +229,7 @@ class MypageService {
 
 	private List<WishSummaryResponse> getWishSummaries(
 		UUID userId, ItemStatus status, Instant from, Instant to, int page, int size) {
-		if (status == null) {
-			return jdbcTemplate.query(
-				"""
-				SELECT si.id,
-				       pd.id AS decision_id,
-				       si.title,
-				       COALESCE(pd.final_price, si.listed_price) AS price,
-				       si.image_url,
-				       si.category,
-				       si.status,
-				       pr.satisfaction_score,
-				       pr.regret_level,
-				       pr.still_using,
-				       pr.reflection_note,
-				       pr.reflected_at
-				FROM purchase_decisions pd
-				JOIN saved_items si ON si.id = pd.item_id
-				LEFT JOIN purchase_reflections pr ON pr.decision_id = pd.id
-				WHERE pd.user_id = ?
-				  AND pd.decided_at >= ?
-				  AND pd.decided_at < ?
-				ORDER BY pd.decided_at DESC
-				LIMIT ? OFFSET ?
-				""",
-				this::mapWishSummary,
-				userId,
-				Timestamp.from(from),
-				Timestamp.from(to),
-				size,
-				page * size
-			);
-		}
-
+		String statusName = status == null ? null : status.name();
 		return jdbcTemplate.query(
 			"""
 			SELECT si.id,
@@ -280,7 +248,7 @@ class MypageService {
 			JOIN saved_items si ON si.id = pd.item_id
 			LEFT JOIN purchase_reflections pr ON pr.decision_id = pd.id
 			WHERE pd.user_id = ?
-			  AND si.status = ?
+			  AND (CAST(? AS varchar) IS NULL OR si.status = ?)
 			  AND pd.decided_at >= ?
 			  AND pd.decided_at < ?
 			ORDER BY pd.decided_at DESC
@@ -288,7 +256,8 @@ class MypageService {
 			""",
 			this::mapWishSummary,
 			userId,
-			status.name(),
+			statusName,
+			statusName,
 			Timestamp.from(from),
 			Timestamp.from(to),
 			size,
@@ -336,9 +305,9 @@ class MypageService {
 		return jdbcTemplate.queryForObject(
 			"""
 			SELECT COALESCE(SUM(CASE WHEN pd.result = 'GO'
-			           THEN COALESCE(pd.final_price, si.listed_price, 0) ELSE 0 END), 0)::integer AS spent_amount,
+			           THEN COALESCE(pd.final_price, si.listed_price, 0) ELSE 0 END), 0)::bigint AS spent_amount,
 			       COALESCE(SUM(CASE WHEN pd.result = 'STOP'
-			           THEN COALESCE(si.listed_price, 0) ELSE 0 END), 0)::integer AS restrained_amount,
+			           THEN COALESCE(si.listed_price, 0) ELSE 0 END), 0)::bigint AS restrained_amount,
 			       COUNT(*) FILTER (WHERE pd.result = 'GO') AS bought_count,
 			       COUNT(*) FILTER (WHERE pd.result = 'STOP') AS restrained_count,
 			       COUNT(*) AS decision_count,
@@ -356,8 +325,8 @@ class MypageService {
 					? null
 					: roundRate((double) rs.getLong("rational_count") / decisionCount * 100.0);
 				return new StatsAggregation(
-					rs.getInt("spent_amount"),
-					rs.getInt("restrained_amount"),
+					rs.getLong("spent_amount"),
+					rs.getLong("restrained_amount"),
 					rs.getLong("bought_count"),
 					rs.getLong("restrained_count"),
 					rationalChoiceRate,
@@ -374,7 +343,7 @@ class MypageService {
 		return jdbcTemplate.query(
 			"""
 			SELECT si.category,
-			       COALESCE(SUM(COALESCE(pd.final_price, si.listed_price, 0)), 0)::integer AS amount
+			       COALESCE(SUM(COALESCE(pd.final_price, si.listed_price, 0)), 0)::bigint AS amount
 			FROM purchase_decisions pd
 			JOIN saved_items si ON si.id = pd.item_id
 			WHERE pd.user_id = ?
@@ -386,7 +355,7 @@ class MypageService {
 			""",
 			(rs, rowNum) -> new CategorySpendAmountResponse(
 				ItemCategory.valueOf(rs.getString("category")),
-				rs.getInt("amount")
+				rs.getLong("amount")
 			),
 			userId,
 			Timestamp.from(from),
@@ -441,8 +410,8 @@ class MypageService {
 	}
 
 	private record StatsAggregation(
-		int spentAmount,
-		int restrainedAmount,
+		long spentAmount,
+		long restrainedAmount,
 		long boughtCount,
 		long restrainedCount,
 		Double rationalChoiceRate,

--- a/src/main/java/com/sagongsa/backend/mypage/StatsResponse.java
+++ b/src/main/java/com/sagongsa/backend/mypage/StatsResponse.java
@@ -6,8 +6,8 @@ import java.util.List;
 record StatsResponse(
 	String yearMonth,
 	Integer budgetAmount,
-	int spentAmount,
-	int restrainedAmount,
+	long spentAmount,
+	long restrainedAmount,
 	Double usageRate,
 	long boughtCount,
 	long restrainedCount,
@@ -18,5 +18,5 @@ record StatsResponse(
 
 record CategorySpendAmountResponse(
 	ItemCategory category,
-	int amount
+	long amount
 ) {}

--- a/src/test/java/com/sagongsa/backend/auth/AppReviewerAuthIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/auth/AppReviewerAuthIntegrationTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,7 +27,8 @@ import org.springframework.test.web.servlet.MvcResult;
 @AutoConfigureMockMvc
 class AppReviewerAuthIntegrationTest extends PostgreSqlContainerTest {
 
-	private static final UUID REVIEWER_USER_ID = UUID.fromString("40400000-0000-0000-0000-000000000055");
+	private static final UUID REVIEWER_USER_ID = AppReviewerAccount.USER_ID;
+	private static final UUID REVIEWER_SOCIAL_ACCOUNT_ID = UUID.fromString("40400000-0000-0000-0000-000000055001");
 
 	@Autowired
 	private MockMvc mockMvc;
@@ -54,15 +56,18 @@ class AppReviewerAuthIntegrationTest extends PostgreSqlContainerTest {
 		jdbcTemplate.update(
 			"""
 			insert into social_accounts (id, user_id, provider, provider_user_id, email, profile_image_url, created_at, updated_at)
-			values (?, ?, 'KAKAO', 'app-reviewer-fixed', 'app-reviewer@sagongsa.dev', null, now(), now())
+			values (?, ?, ?, ?, ?, null, now(), now())
 			on conflict on constraint uk_social_accounts_provider_user do update
 			set user_id = excluded.user_id,
 			    email = excluded.email,
 			    profile_image_url = excluded.profile_image_url,
 			    updated_at = now()
 			""",
-			UUID.fromString("40400000-0000-0000-0000-000000055001"),
-			REVIEWER_USER_ID
+			REVIEWER_SOCIAL_ACCOUNT_ID,
+			REVIEWER_USER_ID,
+			AppReviewerAccount.PROVIDER_DB_VALUE,
+			AppReviewerAccount.PROVIDER_USER_ID,
+			AppReviewerAccount.EMAIL
 		);
 		jdbcTemplate.update(
 			"""
@@ -98,8 +103,8 @@ class AppReviewerAuthIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.authenticated").value(true))
 			.andExpect(jsonPath("$.userId").value(REVIEWER_USER_ID.toString()))
-			.andExpect(jsonPath("$.provider").value("kakao"))
-			.andExpect(jsonPath("$.providerUserId").value("app-reviewer-fixed"));
+			.andExpect(jsonPath("$.provider").value(AppReviewerAccount.PROVIDER))
+			.andExpect(jsonPath("$.providerUserId").value(AppReviewerAccount.PROVIDER_USER_ID));
 
 		mockMvc.perform(get("/api/v1/users/me")
 			.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
@@ -115,6 +120,21 @@ class AppReviewerAuthIntegrationTest extends PostgreSqlContainerTest {
 		mockMvc.perform(get("/api/v1/users/me")
 			.header("X-User-Id", REVIEWER_USER_ID.toString()))
 			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	void reviewerSeedMigrationMatchesApplicationConstants() throws Exception {
+		try (var stream = getClass().getResourceAsStream("/db/migration/V13__seed_app_reviewer_user.sql")) {
+			assertThat(stream).isNotNull();
+			String migration = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+
+			assertThat(migration)
+				.contains(REVIEWER_USER_ID.toString())
+				.contains(REVIEWER_SOCIAL_ACCOUNT_ID.toString())
+				.contains(AppReviewerAccount.PROVIDER_DB_VALUE)
+				.contains(AppReviewerAccount.PROVIDER_USER_ID)
+				.contains(AppReviewerAccount.EMAIL);
+		}
 	}
 
 	private int countStoredRefreshTokens(String refreshToken) {

--- a/src/test/java/com/sagongsa/backend/deliberation/DeliberationServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/deliberation/DeliberationServiceTest.java
@@ -141,29 +141,30 @@ class DeliberationServiceTest extends PostgreSqlContainerTest {
 	void returnsPlaceholderMessageWhenPriceIsNull() {
 		UUID userId = insertActiveUser();
 		UUID itemId = insertSavedItem(userId, "DIGITAL", null, "SAVED");
-		DeliberationSummaryResponse response = deliberationService.getSummary(userId, itemId);
+		DeliberationSummaryResponse response = deliberationServiceWithMessageIndex(0).getSummary(userId, itemId);
+
 		assertThat(response.opportunityCostMessage())
-			.isIn(DeliberationService.NO_PRICE_OPPORTUNITY_COST_MESSAGES);
+			.isEqualTo(DeliberationService.NO_PRICE_OPPORTUNITY_COST_MESSAGES.get(0));
 	}
 
 	@Test
 	void returnsPlaceholderMessageWhenPriceIsZero() {
 		UUID userId = insertActiveUser();
 		UUID itemId = insertSavedItem(userId, "DIGITAL", 0, "SAVED");
-		DeliberationSummaryResponse response = deliberationService.getSummary(userId, itemId);
+		DeliberationSummaryResponse response = deliberationServiceWithMessageIndex(1).getSummary(userId, itemId);
+
 		assertThat(response.opportunityCostMessage())
-			.isIn(DeliberationService.NO_PRICE_OPPORTUNITY_COST_MESSAGES);
+			.isEqualTo(DeliberationService.NO_PRICE_OPPORTUNITY_COST_MESSAGES.get(1));
 	}
 
 	@Test
 	void returnsPriceFormattedMessageWhenPriceIsPositive() {
 		UUID userId = insertActiveUser();
 		UUID itemId = insertSavedItem(userId, "DIGITAL", 39000, "SAVED");
-		DeliberationSummaryResponse response = deliberationService.getSummary(userId, itemId);
+		DeliberationSummaryResponse response = deliberationServiceWithMessageIndex(2).getSummary(userId, itemId);
+
 		assertThat(response.opportunityCostMessage())
-			.isIn(DeliberationService.PRICE_OPPORTUNITY_COST_MESSAGE_FORMATS.stream()
-				.map(format -> format.formatted(39000))
-				.toList());
+			.isEqualTo(DeliberationService.PRICE_OPPORTUNITY_COST_MESSAGE_FORMATS.get(2).formatted(39000));
 	}
 
 	// ── TC5: 유사 카테고리 소비 집계 ────────────────────────────────────────
@@ -216,6 +217,10 @@ class DeliberationServiceTest extends PostgreSqlContainerTest {
 
 	private UUID insertActiveUser() {
 		return insertUser("ACTIVE", "COMPLETED");
+	}
+
+	private DeliberationService deliberationServiceWithMessageIndex(int index) {
+		return new DeliberationService(jdbcTemplate, bound -> index);
 	}
 
 	private UUID insertUser(String onboardingStatus) {

--- a/src/test/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcherTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcherTest.java
@@ -1,0 +1,61 @@
+package com.sagongsa.backend.itemimport.item;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.PlaywrightException;
+import com.microsoft.playwright.Request;
+import com.microsoft.playwright.Route;
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+
+class BrowserPageFetcherTest {
+
+	@Test
+	void closesPlaywrightWhenBrowserLaunchFailsWithThrowable() {
+		ShoppingImportProperties.BrowserFetch properties = new ShoppingImportProperties.BrowserFetch();
+		Playwright playwright = mock(Playwright.class);
+		BrowserType browserType = mock(BrowserType.class);
+		AssertionError failure = new AssertionError("launch failed");
+
+		when(playwright.chromium()).thenReturn(browserType);
+		when(browserType.launch(any(BrowserType.LaunchOptions.class))).thenThrow(failure);
+
+		BrowserPageFetcher fetcher = new BrowserPageFetcher(properties, () -> playwright);
+
+		assertThatThrownBy(() -> fetcher.fetch(URI.create("https://1.1.1.1/product")))
+			.isSameAs(failure);
+		verify(playwright).close();
+	}
+
+	@Test
+	void abortsRouteWhenRequestUrlCannotBeRead() {
+		Route route = mock(Route.class);
+		Request request = mock(Request.class);
+
+		when(route.request()).thenReturn(request);
+		when(request.url()).thenThrow(new PlaywrightException("context closed"));
+
+		BrowserPageFetcher.guardRoute(route);
+
+		verify(route).abort();
+	}
+
+	@Test
+	void abortsPrivateNetworkRoute() {
+		Route route = mock(Route.class);
+		Request request = mock(Request.class);
+
+		when(route.request()).thenReturn(request);
+		when(request.url()).thenReturn("http://127.0.0.1/internal");
+
+		BrowserPageFetcher.guardRoute(route);
+
+		verify(route).abort();
+	}
+}

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
@@ -183,6 +183,43 @@ class ShoppingLinkImportServiceTest {
 	}
 
 	@Test
+	void acceptsProductPageWhenBodyContainsWaitPhrase() {
+		pageFetcher.stub(
+			"https://shopping.example.com/products/waiting-note",
+			"""
+				<html>
+				<head>
+				  <title>기다림 노트 상품 상세</title>
+				  <meta property="og:title" content="기다림 노트 세트" />
+				  <meta property="og:image" content="https://cdn.example.com/waiting-note.jpg" />
+				  <meta property="product:price:amount" content="18000" />
+				</head>
+				<body>
+				  이 상품은 배송 전 잠시만 기다려 주세요 라는 안내 문구가 포함된 패키지입니다.
+				  실제 상품 상세, 사용 방법, 구성품, 교환 안내, 리뷰 요약까지 정상적으로 렌더링된 긴 본문입니다.
+				  차단 안내 페이지가 아니라 상품 설명 문장 안에 같은 표현이 포함된 케이스입니다.
+				</body>
+				</html>
+				"""
+		);
+
+		ShoppingLinkImportResponse response = service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.SHARE,
+				"https://shopping.example.com/products/waiting-note",
+				null,
+				null,
+				null,
+				null
+			)
+		);
+
+		assertThat(response.item().title()).isEqualTo("기다림 노트 세트");
+		assertThat(response.item().listedPrice()).isEqualTo(18000);
+		assertThat(response.item().imageUrl()).isEqualTo("https://cdn.example.com/waiting-note.jpg");
+	}
+
+	@Test
 	void acceptsRenderedProductPageWithCloudflareScriptMarker() {
 		pageFetcher.stub(
 			"https://www.musinsa.com/products/478021",

--- a/src/test/java/com/sagongsa/backend/mypage/MypageServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/mypage/MypageServiceTest.java
@@ -207,6 +207,21 @@ class MypageServiceTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void 통계_금액_합산은_Integer_범위를_넘어도_집계() {
+		UUID userId = insertUser("너굴이", "너구리");
+		String yearMonth = YearMonth.now(KST).toString();
+		insertDecision(userId, "GO", 1_500_000_000, yearMonth);
+		insertDecision(userId, "GO", 1_000_000_000, yearMonth);
+
+		StatsResponse response = mypageService.getStats(userId, yearMonth);
+
+		assertThat(response.spentAmount()).isEqualTo(2_500_000_000L);
+		assertThat(response.categorySpendAmounts()).containsExactly(
+			new CategorySpendAmountResponse(ItemCategory.DIGITAL, 2_500_000_000L)
+		);
+	}
+
+	@Test
 	void 통계_예산_사용률_계산() {
 		UUID userId = insertUser("너굴이", "너구리");
 		String yearMonth = YearMonth.now(KST).toString();

--- a/src/test/java/com/sagongsa/backend/social/ReportServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/social/ReportServiceTest.java
@@ -294,6 +294,25 @@ class ReportServiceTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void 유저_기타_신고는_상세_사유가_필수() {
+		UUID reporter = insertUser();
+		UUID target = insertUser();
+
+		assertThatThrownBy(() -> reportService.reportUser(reporter, target, ReportCategory.OTHER, " "))
+			.isInstanceOf(SocialFeedBadRequestException.class);
+	}
+
+	@Test
+	void 유저_기타_신고는_상세_사유가_있으면_성공() {
+		UUID reporter = insertUser();
+		UUID target = insertUser();
+
+		assertThatNoException().isThrownBy(() ->
+			reportService.reportUser(reporter, target, ReportCategory.OTHER, "기타 상세 사유")
+		);
+	}
+
+	@Test
 	void 자기_자신_신고하면_예외() {
 		UUID reporter = insertUser();
 


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-72**
- Jira: https://parkjaehong.atlassian.net/browse/NF-72

> PR 제목: `NF-72 Fix: 머지 후 기술 리뷰 후속 보완`  
> 브랜치: `fix/NF-72-post-merge-review-tech`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #167

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- 최근 머지 후 일반 PR 코멘트 중 정책 확인이 필요 없는 기술 후속이 흩어져 있었습니다.
- 범위: #118, #122, #128, #135, #145, #158 일부 기술 항목

### 왜 발생했나? (Root Cause)
- 브라우저 렌더링 초기화 실패 시 부분 생성된 Playwright 정리가 명확하지 않았습니다.
- 쇼핑 링크 차단 감지가 짧은 차단 안내 문구와 정상 상품 본문 문구를 충분히 구분하지 못했습니다.
- 마이페이지 금액 합산 쿼리가 `::integer` 캐스트에 의존했습니다.
- 기회비용 메시지 테스트가 랜덤 선택 결과를 고정하기 어려웠습니다.
- 앱 심사용 계정 값이 컨트롤러/마이그레이션 사이에서 드리프트할 수 있었습니다.
- QA 배포 워크플로우가 bootJar 파일명과 즉시 status 확인에 취약했습니다.

### 어떻게 고쳤나?
- `BrowserPageFetcher` 초기화 성공 전에는 필드에 반영하지 않고 실패 시 Playwright를 정리하도록 변경했습니다.
- 요청 안전 가드의 catch 범위를 URL/호스트 검증 예외로 좁혔습니다.
- 차단 페이지 판별을 challenge marker/짧은 안내 shell 중심으로 조정하고 오탐 회귀 테스트를 추가했습니다.
- 마이페이지 통계 합산을 BIGINT/long 기반으로 변경하고 21억 초과 합산 테스트를 추가했습니다.
- 랜덤 메시지 인덱스 선택을 테스트에서 주입 가능하게 바꾸고 결정적 검증으로 변경했습니다.
- 앱 심사용 계정 상수를 분리하고 마이그레이션 값과의 정합성 테스트를 추가했습니다.
- QA deploy에서 bootJar 산출물을 동적으로 찾고 `systemctl is-active` polling으로 재시작 확인을 보강했습니다.
- 유저 신고 `OTHER` 상세 사유 검증 회귀 테스트를 추가했습니다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법(가능하면)
- Steps:
  1. 머지 후 일반 코멘트 목록에서 정책 확인 불필요 기술 항목을 확인
  2. 현재 `develop` 기준으로 관련 코드 경로를 점검
  3. 각 항목별 회귀 테스트 또는 방어 로직을 적용
- 기대 결과: 기술 후속 항목이 코드/테스트/워크플로우에 반영됨
- 실제 결과: 본 PR에서 반영

### 재발 방지(있다면)
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [ ] 런북/문서 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] AC1: 브라우저 렌더링 초기화 실패/요청 가드 예외 범위가 안전하게 정리된다.
- [x] AC2: 쇼핑 링크 차단 감지가 정상 상품 본문 문구를 오탐하지 않는다.
- [x] AC3: 마이페이지 통계 합산/랜덤 메시지/심사 계정/신고 검증/QA 배포 후속이 테스트 또는 워크플로우로 고정된다.

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew test --tests 'com.sagongsa.backend.deliberation.DeliberationServiceTest' --no-daemon`
- Result: PASS (`BUILD SUCCESSFUL in 10m 42s`)
- Command: `./gradlew test --tests 'com.sagongsa.backend.itemimport.item.ShoppingLinkImportServiceTest' --tests 'com.sagongsa.backend.mypage.MypageServiceTest' --tests 'com.sagongsa.backend.social.ReportServiceTest' --tests 'com.sagongsa.backend.auth.AppReviewerAuthIntegrationTest' --no-daemon`
- Result: PASS (`BUILD SUCCESSFUL in 12m 39s`)
- Command: `./gradlew test --no-daemon`
- Result: PASS (`BUILD SUCCESSFUL in 23m 42s`)

### CI
- 링크/결과: PR 생성 후 확인

### Smoke / 수동 검증
- 시나리오: GitHub issue #167 생성 및 PR 연결
- 결과: `Closes #167`

### 테스트 공백(있다면 이유 필수)
- Playwright 브라우저 실제 launch 실패 경로는 로컬 환경 의존성이 커서 직접 실패 주입 테스트 대신 초기화 순서/정리 로직을 코드로 보강했습니다.

---

## 🧭 영향 범위 (필수)
- [ ] API 스펙 변경 없음
- [x] API 스펙 변경 있음 (요약: 마이페이지 통계 금액 응답의 서버 타입을 `int`에서 `long`으로 확장. JSON 필드명/의미는 동일)
- [x] DB 스키마 변경 없음
- [ ] DB 스키마 변경 있음 (마이그레이션/락/시간: )
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음 (항목: )
- [ ] 캐시/큐/외부 연동 영향 없음
- [x] 캐시/큐/외부 연동 영향 있음 (요약: QA 배포 GitHub Actions의 jar 탐색 및 서비스 active 확인 방식 변경)

---

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음
- [ ] Breaking change 있음 → 무엇이 깨지는지 / 마이그레이션 / 롤아웃 전략:

---

## 🚀 배포/릴리즈 (해당 시 필수)
### Feature Flag
- [x] 사용 안함
- [ ] 사용함 → Flag/기본값/롤아웃:

### 모니터링/알림
- 확인할 대시보드/지표: QA deploy workflow 실행 결과, `wigul-backend` systemd active 상태
- 에러/로그 키워드: `No bootJar artifact found under build/libs`, `systemctl is-active`

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- QA deploy workflow의 remote jar 목적지는 기존 서비스 경로 호환을 위해 유지했습니다.
- 마이페이지 금액 필드 Java 타입이 long으로 확장되어 OpenAPI schema에는 int64로 보일 수 있습니다.

### 롤백
- [ ] 플래그/설정으로 우회 가능
- [x] 배포 롤백(이전 태그/이미지) 가능
- [ ] 데이터 롤백/역마이그레이션 필요 (절차: )

---

## 📸 증빙 (선택)
- 전체 테스트: `./gradlew test --no-daemon` PASS
- 이슈: #167

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직: `BrowserPageFetcher`, `ShoppingLinkImportService`, `MypageService`, `DeliberationService`, `deploy-qa.yml`
- 트레이드오프/대안: QA deploy remote jar 이름은 서비스 유닛 호환을 위해 유지하고 source jar 탐색만 동적화했습니다.
- 성능/보안/호환성 영향: 금액 합산 overflow 방지, 차단 페이지 오탐 감소, 배포 성공 판별 안정화