### PR TITLE
NF-73 알림 전체 읽음 처리 API 추가

### DIFF
--- a/src/main/java/com/sagongsa/backend/notification/NotificationController.java
+++ b/src/main/java/com/sagongsa/backend/notification/NotificationController.java
@@ -58,4 +58,20 @@ public class NotificationController {
 	) {
 		return notificationService.markAsRead(userId, notificationId);
 	}
+
+	@PatchMapping("/read-all")
+	@Operation(
+		summary = "Mark all notifications as read",
+		description = "Marks all unread notifications for the authenticated user as read and returns the updated count.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "Notifications marked as read"),
+			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication"),
+			@ApiResponse(responseCode = "403", description = "Notifications can be used only after onboarding")
+		}
+	)
+	public NotificationReadAllResponse markAllAsRead(
+		@Parameter(hidden = true) @CurrentUserId UUID userId
+	) {
+		return notificationService.markAllAsRead(userId);
+	}
 }

--- a/src/main/java/com/sagongsa/backend/notification/NotificationReadAllResponse.java
+++ b/src/main/java/com/sagongsa/backend/notification/NotificationReadAllResponse.java
@@ -1,0 +1,4 @@
+package com.sagongsa.backend.notification;
+
+public record NotificationReadAllResponse(int updatedCount) {
+}

--- a/src/main/java/com/sagongsa/backend/notification/NotificationService.java
+++ b/src/main/java/com/sagongsa/backend/notification/NotificationService.java
@@ -74,6 +74,28 @@ public class NotificationService {
 		return findById(userId, notificationId);
 	}
 
+	@Transactional
+	public NotificationReadAllResponse markAllAsRead(UUID userId) {
+		requireUsableUser(userId);
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		int updated = jdbcTemplate.update(
+			"""
+			update notifications
+			set is_read = true,
+				read_at = ?,
+				updated_at = ?
+			where user_id = ?
+			  and is_read = false
+			  and created_at >= ?
+			""",
+			now,
+			now,
+			userId,
+			retentionCutoff()
+		);
+		return new NotificationReadAllResponse(updated);
+	}
+
 	private NotificationResponse findById(UUID userId, UUID notificationId) {
 		try {
 			return jdbcTemplate.queryForObject(

--- a/src/test/java/com/sagongsa/backend/notification/NotificationApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/notification/NotificationApiIntegrationTest.java
@@ -1,0 +1,96 @@
+package com.sagongsa.backend.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class NotificationApiIntegrationTest extends PostgreSqlContainerTest {
+
+	private static final String USER_ID_HEADER = "X-User-Id";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.execute("truncate table users cascade");
+	}
+
+	@Test
+	void markAllAsReadReturnsUpdatedCount() throws Exception {
+		UUID userId = createUser();
+		UUID otherUserId = createUser();
+		insertNotification(userId, "WISHLIST_REMINDER", false);
+		insertNotification(userId, "BUDGET_WARNING", false);
+		insertNotification(userId, "SOCIAL_VOTE", true);
+		insertNotification(otherUserId, "REGRET_CHECK_READY", false);
+
+		mockMvc.perform(patch("/api/v1/notifications/read-all")
+				.header(USER_ID_HEADER, userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.updatedCount").value(2));
+
+		assertThat(queryInteger("select count(*) from notifications where user_id = ? and is_read = false", userId))
+			.isZero();
+		assertThat(queryInteger("select count(*) from notifications where user_id = ? and is_read = false", otherUserId))
+			.isOne();
+	}
+
+	private UUID createUser() {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into users (id, status, onboarding_status, created_at, updated_at)
+			values (?, 'ACTIVE', 'COMPLETED', ?, ?)
+			""",
+			userId,
+			now,
+			now
+		);
+		return userId;
+	}
+
+	private void insertNotification(UUID userId, String type, boolean read) {
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		OffsetDateTime readAt = read ? now : null;
+		jdbcTemplate.update(
+			"""
+			insert into notifications (
+				id, user_id, notification_type, title, body, target_path,
+				is_read, read_at, created_at, updated_at
+			)
+			values (?, ?, ?, '알림', '내용', '/notifications', ?, ?, ?, ?)
+			""",
+			UUID.randomUUID(),
+			userId,
+			type,
+			read,
+			readAt,
+			now,
+			now
+		);
+	}
+
+	private Integer queryInteger(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(sql, Integer.class, args);
+	}
+}

--- a/src/test/java/com/sagongsa/backend/notification/NotificationServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/notification/NotificationServiceTest.java
@@ -71,10 +71,46 @@ class NotificationServiceTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void markAllAsReadUpdatesOnlyCurrentUsersRecentUnreadNotifications() {
+		UUID userId = createUser("ACTIVE", "COMPLETED");
+		UUID otherUserId = createUser("ACTIVE", "COMPLETED");
+		UUID firstUnreadId = insertNotification(userId, "WISHLIST_REMINDER", false, OffsetDateTime.now(ZoneOffset.UTC).minusHours(2));
+		UUID secondUnreadId = insertNotification(userId, "BUDGET_WARNING", false, OffsetDateTime.now(ZoneOffset.UTC).minusHours(1));
+		insertNotification(userId, "SOCIAL_VOTE", true, OffsetDateTime.now(ZoneOffset.UTC));
+		UUID expiredUnreadId = insertNotification(userId, "REGRET_CHECK_READY", false, OffsetDateTime.now(ZoneOffset.UTC).minusMonths(1).minusDays(1));
+		UUID otherUnreadId = insertNotification(otherUserId, "WISHLIST_REMINDER", false, OffsetDateTime.now(ZoneOffset.UTC));
+
+		NotificationReadAllResponse first = notificationService.markAllAsRead(userId);
+		NotificationReadAllResponse second = notificationService.markAllAsRead(userId);
+
+		assertThat(first.updatedCount()).isEqualTo(2);
+		assertThat(second.updatedCount()).isZero();
+		assertThat(queryBoolean("select is_read from notifications where id = ?", firstUnreadId)).isTrue();
+		assertThat(queryBoolean("select is_read from notifications where id = ?", secondUnreadId)).isTrue();
+		assertThat(queryInteger(
+			"select count(*) from notifications where id in (?, ?) and read_at is not null",
+			firstUnreadId,
+			secondUnreadId
+		)).isEqualTo(2);
+		assertThat(queryBoolean("select is_read from notifications where id = ?", expiredUnreadId)).isFalse();
+		assertThat(queryBoolean("select is_read from notifications where id = ?", otherUnreadId)).isFalse();
+	}
+
+	@Test
 	void rejectsNotificationsBeforeOnboardingCompletion() {
 		UUID userId = createUser("ACTIVE", "NOT_STARTED");
 
 		assertThatThrownBy(() -> notificationService.list(userId, false))
+			.isInstanceOf(ResponseStatusException.class)
+			.satisfies(exception -> assertThat(((ResponseStatusException) exception).getStatusCode())
+				.isEqualTo(HttpStatus.FORBIDDEN));
+	}
+
+	@Test
+	void rejectsMarkingAllNotificationsBeforeOnboardingCompletion() {
+		UUID userId = createUser("ACTIVE", "NOT_STARTED");
+
+		assertThatThrownBy(() -> notificationService.markAllAsRead(userId))
 			.isInstanceOf(ResponseStatusException.class)
 			.satisfies(exception -> assertThat(((ResponseStatusException) exception).getStatusCode())
 				.isEqualTo(HttpStatus.FORBIDDEN));
@@ -144,5 +180,9 @@ class NotificationServiceTest extends PostgreSqlContainerTest {
 
 	private Boolean queryBoolean(String sql, Object... args) {
 		return jdbcTemplate.queryForObject(sql, Boolean.class, args);
+	}
+
+	private Integer queryInteger(String sql, Object... args) {
+		return jdbcTemplate.queryForObject(sql, Integer.class, args);
 	}
 }


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-73`
- Jira: https://parkjaehong.atlassian.net/browse/NF-73 (있다면)
- GitHub: Related #169
- GitHub: Closes #169

> PR 제목: `NF-73 알림 전체 읽음 처리 API 추가`
> 브랜치: `feat/NF-73-notification-read-all`

---

## 🧩 이 PR의 변경사항 (필수)
### 전체 중 위치 (Stacked PR 시)
- 전체 이슈 #169의 1/1 단계
- 선행 PR: 없음
- 후속 PR: 없음

### 이 PR에서 변경한 것
- `PATCH /api/v1/notifications/read-all` endpoint를 추가했습니다.
- 현재 사용자에게 보존기간 내 표시되는 미읽음 알림만 전체 읽음 처리합니다.
- 응답으로 실제 갱신된 알림 수 `updatedCount`를 반환합니다.
- 서비스/MockMvc 테스트로 사용자 범위, 이미 읽은 알림, 만료 알림, endpoint 응답을 검증했습니다.

---

## ✅ 이 PR이 커버하는 AC (필수)
### Covers (이 PR에서 완료)
- AC1: `PATCH /api/v1/notifications/read-all` 요청 시 현재 사용자의 보존기간 내 미읽음 알림이 모두 읽음 처리된다.
- AC2: 응답에 실제 읽음 처리된 알림 수를 제공한다.
- AC3: 다른 사용자의 알림, 이미 읽은 알림, 보존기간 밖 알림은 갱신 대상에서 제외된다.
- AC4: 온보딩 미완료/비활성 사용자는 기존 알림 API와 동일하게 차단된다.

### Not covered (후속 작업)
- 없음

---

## 🧪 테스트 결과 (필수)
### 로컬
```
./gradlew test --tests 'com.sagongsa.backend.notification.NotificationServiceTest' --tests 'com.sagongsa.backend.notification.NotificationApiIntegrationTest'
./gradlew test
```
- ✅ 결과: 통과

### CI
- 자동 첨부

### Smoke 테스트
- 시나리오: 사용자 A 미읽음 2건/읽음 1건, 사용자 B 미읽음 1건 생성 후 사용자 A가 `PATCH /api/v1/notifications/read-all` 호출
- 결과: `updatedCount=2`, 사용자 A 미읽음 0건, 사용자 B 미읽음 1건 유지

---

## 🧭 영향 범위 체크 (필수)
- [x] API 변경 (요약: `PATCH /api/v1/notifications/read-all` 추가)
- [ ] DB 변경 (마이그레이션: 없음)
- [ ] 설정 변경 (항목: 없음)
- [ ] Breaking change (무엇: 없음)

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인: `NotificationService#markAllAsRead`, `NotificationController#markAllAsRead`
- 트레이드오프/대안: 단건 API처럼 갱신 후 목록을 반환하지 않고, FE 배지 갱신에 필요한 `updatedCount`만 반환하도록 범위를 좁혔습니다.
