### PR TITLE
[chore] NF-74 QA VM 읽기 전용 점검 workflow 추가

### DIFF
--- a/.github/workflows/vm-readonly-audit.yml
+++ b/.github/workflows/vm-readonly-audit.yml
@@ -41,23 +41,15 @@ jobs:
 
           ssh-keyscan -H "${GCP_VM_HOST}" >> ~/.ssh/known_hosts
 
-          cat > ~/.ssh/config <<EOF
-          Host qa-vm
-            HostName ${GCP_VM_HOST}
-            User ${GCP_VM_USER}
-            IdentityFile ~/.ssh/deploy_key
-            IdentitiesOnly yes
-            StrictHostKeyChecking yes
-            ServerAliveInterval 15
-            ConnectTimeout 10
-          EOF
-
       - name: Run readonly audit
         shell: bash
         run: |
           set -Eeuo pipefail
 
-          ssh qa-vm 'bash -s' <<'REMOTE' | tee vm-readonly-audit.log
+          ssh -i ~/.ssh/deploy_key \
+            -o IdentitiesOnly=yes \
+            "${GCP_VM_USER}@${GCP_VM_HOST}" \
+            'bash -s' <<'REMOTE' | tee vm-readonly-audit.log
           set +e
 
           section() {

--- a/.github/workflows/vm-readonly-audit.yml
+++ b/.github/workflows/vm-readonly-audit.yml
@@ -1,0 +1,143 @@
+name: QA VM Readonly Audit
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Inspect QA VM without changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      GCP_VM_HOST: ${{ secrets.GCP_VM_HOST }}
+      GCP_VM_PORT: ${{ secrets.GCP_VM_PORT }}
+      GCP_VM_USER: ${{ secrets.GCP_VM_USER }}
+      GCP_VM_SSH_KEY: ${{ secrets.GCP_VM_SSH_KEY }}
+      GCP_VM_SSH_KEY_B64: ${{ secrets.GCP_VM_SSH_KEY_B64 }}
+
+    steps:
+      - name: Prepare SSH
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          : "${GCP_VM_HOST:?GCP_VM_HOST secret is required}"
+          : "${GCP_VM_USER:?GCP_VM_USER secret is required}"
+
+          vm_port="${GCP_VM_PORT:-22}"
+          echo "VM_PORT=${vm_port}" >> "${GITHUB_ENV}"
+
+          mkdir -p ~/.ssh
+          if [[ -n "${GCP_VM_SSH_KEY_B64:-}" ]]; then
+            printf '%s' "${GCP_VM_SSH_KEY_B64}" | base64 -d > ~/.ssh/deploy_key
+          elif [[ -n "${GCP_VM_SSH_KEY:-}" ]]; then
+            printf '%s\n' "${GCP_VM_SSH_KEY}" > ~/.ssh/deploy_key
+          else
+            echo "GCP_VM_SSH_KEY_B64 or GCP_VM_SSH_KEY secret is required" >&2
+            exit 1
+          fi
+          chmod 600 ~/.ssh/deploy_key
+
+          ssh-keyscan -p "${vm_port}" -H "${GCP_VM_HOST}" >> ~/.ssh/known_hosts
+
+          cat > ~/.ssh/config <<EOF
+          Host qa-vm
+            HostName ${GCP_VM_HOST}
+            User ${GCP_VM_USER}
+            Port ${vm_port}
+            IdentityFile ~/.ssh/deploy_key
+            IdentitiesOnly yes
+            StrictHostKeyChecking yes
+            ServerAliveInterval 15
+            ConnectTimeout 10
+          EOF
+
+      - name: Run readonly audit
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          ssh qa-vm 'bash -s' <<'REMOTE' | tee vm-readonly-audit.log
+          set +e
+
+          section() {
+            printf '\n===== %s =====\n' "$1"
+          }
+
+          redact() {
+            sed -E \
+              -e 's/([Pp]ass(word)?|[Ss]ecret|[Tt]oken|[Kk]ey|[Aa]uthorization)([^[:space:]]*)[[:space:]=:]+[^[:space:]]+/\1\3=<redacted>/g' \
+              -e 's/(Bearer )[A-Za-z0-9._~+\/-]+/\1<redacted>/g'
+          }
+
+          run() {
+            local title="$1"
+            local command="$2"
+            local status
+
+            section "$title"
+            bash -lc "$command" 2>&1 | redact
+            status=${PIPESTATUS[0]}
+            if [[ "$status" -ne 0 ]]; then
+              printf '[WARN] exit=%s command=%s\n' "$status" "$command"
+            fi
+          }
+
+          section "Audit scope"
+          printf 'readonly=true\n'
+          printf 'changes=none\n'
+          printf 'restarts=none\n'
+          printf 'timestamp=%s\n' "$(date -Is)"
+
+          run "Host identity" "hostname; hostnamectl 2>/dev/null || true; id"
+          run "Running service summary" "systemctl list-units --type=service --state=running --no-pager | grep -E 'caddy|nginx|wigul|backend|postgres|docker|containerd' || true"
+
+          run "Caddy service status" "systemctl status caddy --no-pager"
+          run "Caddy unit" "systemctl cat caddy"
+          run "Caddy validate" "if command -v caddy >/dev/null 2>&1; then sudo -n caddy validate --config /etc/caddy/Caddyfile || caddy validate --config /etc/caddy/Caddyfile; else echo 'caddy binary not found'; fi"
+          run "Caddyfile" "sudo -n sed -n '1,220p' /etc/caddy/Caddyfile || sed -n '1,220p' /etc/caddy/Caddyfile"
+
+          run "Backend service status" "systemctl status wigul-backend --no-pager"
+          run "Backend unit" "systemctl cat wigul-backend"
+          run "Backend unit properties" "systemctl show wigul-backend --property=Id,Names,LoadState,ActiveState,SubState,FragmentPath,DropInPaths,ExecStart,User,Group,EnvironmentFiles --no-pager"
+
+          run "Listening TCP ports" "sudo -n ss -ltnp || ss -ltn"
+          run "Top memory processes" "ps -eo pid,ppid,user,%mem,%cpu,etime,args --sort=-%mem | head -30"
+          run "Java, Caddy, Docker, PostgreSQL processes" "ps -ef | grep -E '[j]ava|[c]addy|[d]ocker|[p]ostgres|[c]ontainerd' || true"
+
+          run "Memory" "free -m"
+          run "Disk" "df -h; lsblk"
+          run "Docker containers" "if command -v docker >/dev/null 2>&1; then docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}'; else echo 'docker not installed'; fi"
+          run "Docker resource snapshot" "if command -v docker >/dev/null 2>&1; then docker stats --no-stream; else echo 'docker not installed'; fi"
+
+          run "Local health probes" "for port in 8080 8081 18080; do printf 'port=%s ' \"\$port\"; curl -fsS -m 3 \"http://127.0.0.1:\$port/health\" || true; printf '\n'; done"
+          run "Caddy journal tail" "sudo -n journalctl -u caddy -n 120 --no-pager -o short-iso || journalctl -u caddy -n 120 --no-pager -o short-iso"
+          run "Backend journal tail" "sudo -n journalctl -u wigul-backend -n 160 --no-pager -o short-iso || journalctl -u wigul-backend -n 160 --no-pager -o short-iso"
+
+          section "Audit finished"
+          printf 'timestamp=%s\n' "$(date -Is)"
+          exit 0
+          REMOTE
+
+      - name: Upload audit log
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: vm-readonly-audit-${{ github.run_id }}
+          path: vm-readonly-audit.log
+
+      - name: Write summary
+        shell: bash
+        if: always()
+        run: |
+          {
+            echo "### QA VM Readonly Audit"
+            echo "- Scope: read-only SSH inspection"
+            echo "- Changes: none"
+            echo "- Restarts: none"
+            echo "- Artifact: vm-readonly-audit-${GITHUB_RUN_ID}"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/vm-readonly-audit.yml
+++ b/.github/workflows/vm-readonly-audit.yml
@@ -14,7 +14,6 @@ jobs:
 
     env:
       GCP_VM_HOST: ${{ secrets.GCP_VM_HOST }}
-      GCP_VM_PORT: ${{ secrets.GCP_VM_PORT }}
       GCP_VM_USER: ${{ secrets.GCP_VM_USER }}
       GCP_VM_SSH_KEY: ${{ secrets.GCP_VM_SSH_KEY }}
       GCP_VM_SSH_KEY_B64: ${{ secrets.GCP_VM_SSH_KEY_B64 }}
@@ -28,9 +27,6 @@ jobs:
           : "${GCP_VM_HOST:?GCP_VM_HOST secret is required}"
           : "${GCP_VM_USER:?GCP_VM_USER secret is required}"
 
-          vm_port="${GCP_VM_PORT:-22}"
-          echo "VM_PORT=${vm_port}" >> "${GITHUB_ENV}"
-
           mkdir -p ~/.ssh
           if [[ -n "${GCP_VM_SSH_KEY_B64:-}" ]]; then
             echo "${GCP_VM_SSH_KEY_B64}" | base64 -d > ~/.ssh/deploy_key
@@ -43,13 +39,12 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh-keygen -y -f ~/.ssh/deploy_key > /dev/null
 
-          ssh-keyscan -p "${vm_port}" -H "${GCP_VM_HOST}" >> ~/.ssh/known_hosts
+          ssh-keyscan -H "${GCP_VM_HOST}" >> ~/.ssh/known_hosts
 
           cat > ~/.ssh/config <<EOF
           Host qa-vm
             HostName ${GCP_VM_HOST}
             User ${GCP_VM_USER}
-            Port ${vm_port}
             IdentityFile ~/.ssh/deploy_key
             IdentitiesOnly yes
             StrictHostKeyChecking yes

--- a/.github/workflows/vm-readonly-audit.yml
+++ b/.github/workflows/vm-readonly-audit.yml
@@ -33,7 +33,7 @@ jobs:
 
           mkdir -p ~/.ssh
           if [[ -n "${GCP_VM_SSH_KEY_B64:-}" ]]; then
-            printf '%s' "${GCP_VM_SSH_KEY_B64}" | base64 -d > ~/.ssh/deploy_key
+            echo "${GCP_VM_SSH_KEY_B64}" | base64 -d > ~/.ssh/deploy_key
           elif [[ -n "${GCP_VM_SSH_KEY:-}" ]]; then
             printf '%s\n' "${GCP_VM_SSH_KEY}" > ~/.ssh/deploy_key
           else
@@ -41,6 +41,7 @@ jobs:
             exit 1
           fi
           chmod 600 ~/.ssh/deploy_key
+          ssh-keygen -y -f ~/.ssh/deploy_key > /dev/null
 
           ssh-keyscan -p "${vm_port}" -H "${GCP_VM_HOST}" >> ~/.ssh/known_hosts
 


### PR DESCRIPTION
# 🧰 Chore PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-74**
- Jira: https://parkjaehong.atlassian.net/browse/NF-74 (있다면)

> PR 제목: `NF-74 Chore: QA VM 읽기 전용 점검 workflow 추가`  
> 브랜치: `chore/NF-74-vm-readonly-audit`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #171

---

## 🧩 한눈에 요약 (필수)
### 무엇을 변경했나? (인프라/빌드/CI/의존성 등)
- [ ] 인프라
- [ ] 설정파일
- [ ] 빌드 파일
- [x] CI
- [x] 런타임/비즈니스 로직 리팩터링 없음 (있으면 Refactor PR 템플릿 사용)

### 왜 필요한가? (안정성/속도/보안/개발경험)
- Caddy 포트 스위칭 기반 무중단 배포를 설계하기 전에 QA VM의 현재 Caddy, systemd, Java, 포트, 메모리, Docker/PostgreSQL, journal 상태를 확인해야 합니다.
- GitHub Secrets 값을 로컬로 꺼내지 않고 Actions 내부에서만 SSH 접속에 사용하기 위한 수동 점검 workflow가 필요합니다.

### 범위(스코프)
- Included:
  - 수동 실행 전용 `.github/workflows/vm-readonly-audit.yml` 추가
  - Caddy/systemd/포트/프로세스/메모리/디스크/Docker/health/journal 확인
  - 점검 로그 artifact 업로드
- Not included:
  - 배포 실행
  - 서비스 재시작
  - VM 파일 수정
  - Caddy 설정 변경

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command:
  - `python3` YAML 파싱
  - `git diff --cached --check`
  - 금지 명령 문자열 점검: `systemctl restart`, `scp`, `rm -rf`, `docker stop`, `docker rm`
- Result:
  - YAML 파싱 성공
  - diff check 통과
  - 금지 명령 미포함 확인

### CI
- 링크/결과: PR 생성 후 확인

### Smoke / 수동 검증 (해당 시)
- 시나리오: `workflow_dispatch`로 QA VM 읽기 전용 점검 실행
- 결과: PR 생성 후 실행 예정

### 테스트 공백(있다면 이유 필수)
- 애플리케이션 코드 변경이 없어 Gradle 테스트는 CI 결과로 확인합니다.

---

## 🧭 영향 범위 (필수)
- [ ] 설정/환경변수 변경 없음
- [x] 설정/환경변수 변경 있음 (항목: 기존 GitHub Secrets `GCP_VM_HOST`, `GCP_VM_PORT`, `GCP_VM_USER`, `GCP_VM_SSH_KEY`, `GCP_VM_SSH_KEY_B64` 참조)
- [ ] CI/빌드 파이프라인 영향 없음
- [x] CI/빌드 파이프라인 영향 있음 (요약: 수동 실행 전용 QA VM 점검 workflow 추가)
- [x] 의존성(dependency) 변경 없음
- [ ] 의존성(dependency) 변경 있음 (패키지/버전/주요 변경점: )

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- journal 로그에 민감한 값이 섞일 수 있어 token/key/password/authorization 패턴은 workflow에서 추가 마스킹합니다.
- SSH 또는 sudo 권한이 부족하면 일부 점검 항목은 WARN으로 남을 수 있습니다.

### 롤백
- [x] 단순 revert로 가능
- [ ] 버전 pin/되돌리기 필요 (대상: , 방법: )
- [ ] 배포 롤백(이전 태그/이미지) 가능

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/설정: `.github/workflows/vm-readonly-audit.yml`
- 트레이드오프/대안: 로컬 SSH 대신 GitHub Actions 내부에서 기존 Secrets를 사용합니다.
- 성능/보안/호환성 영향: 수동 실행 전용이며 서비스 재시작/파일 수정/배포 명령을 포함하지 않습니다.