### PR TITLE
[chore] NF-75 QA 배포 8081 스탠바이 절차 전환

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -6,6 +6,10 @@ on:
       - develop
   workflow_dispatch:
 
+concurrency:
+  group: qa-backend-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -41,16 +45,200 @@ jobs:
             ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }} \
             "whoami && hostname"
 
-      - name: Upload jar
-        run: |
-          scp -i ~/.ssh/deploy_key \
-            -o IdentitiesOnly=yes \
-            build/libs/wigul-backend-0.0.1-SNAPSHOT.jar \
-            ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }}:/home/${{ secrets.GCP_VM_USER }}/404_BE/build/libs/wigul-backend-0.0.1-SNAPSHOT.jar
-
-      - name: Restart service
+      - name: Upload candidate jar
         run: |
           ssh -i ~/.ssh/deploy_key \
             -o IdentitiesOnly=yes \
             ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }} \
-            "sudo -n systemctl restart wigul-backend && systemctl status wigul-backend --no-pager"
+            "mkdir -p /home/${{ secrets.GCP_VM_USER }}/404_BE/build/libs"
+
+          scp -i ~/.ssh/deploy_key \
+            -o IdentitiesOnly=yes \
+            build/libs/wigul-backend-0.0.1-SNAPSHOT.jar \
+            ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }}:/home/${{ secrets.GCP_VM_USER }}/404_BE/build/libs/wigul-backend-0.0.1-SNAPSHOT.jar.candidate-${{ github.sha }}
+
+      - name: Deploy through 8081 standby
+        run: |
+          ssh -i ~/.ssh/deploy_key \
+            -o IdentitiesOnly=yes \
+            ${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }} \
+            'bash -s' <<'REMOTE_DEPLOY'
+          set -Eeuo pipefail
+
+          APP_DIR="/home/${{ secrets.GCP_VM_USER }}/404_BE"
+          JAR_NAME="wigul-backend-0.0.1-SNAPSHOT.jar"
+          ACTIVE_JAR="$APP_DIR/build/libs/$JAR_NAME"
+          CANDIDATE_JAR="$ACTIVE_JAR.candidate-${{ github.sha }}"
+          ENV_FILE="$APP_DIR/.env.systemd"
+          CADDY_FILE="/etc/caddy/Caddyfile"
+          STANDBY_PID="/tmp/wigul-backend-standby.pid"
+          STANDBY_LOG="/tmp/wigul-backend-standby-${{ github.sha }}.log"
+          TS="$(date +%Y%m%d_%H%M%S)"
+          ACTIVE_BACKUP="$ACTIVE_JAR.bak.$TS"
+          CADDY_BACKUP="/etc/caddy/Caddyfile.bak.deploy.$TS"
+          CADDY_ON_8081=0
+
+          cleanup() {
+            code=$?
+            if [ "$code" -eq 0 ]; then
+              return
+            fi
+
+            echo "::error::8081 standby deploy failed. exit=$code"
+            if [ "${CADDY_ON_8081:-0}" = "1" ]; then
+              echo "::warning::Caddy remains on 8081 standby. Do not stop the standby process until 8080 is recovered."
+              sudo -n sed -n '1,120p' "$CADDY_FILE" || true
+              ss -ltnp 2>/dev/null | grep -E ':8080|:8081|:80|:443' || true
+              if [ -n "${CADDY_SITE:-}" ]; then
+                curl -skfsS "https://$CADDY_SITE/health" || true
+                echo
+              fi
+            else
+              if [ -f "$STANDBY_PID" ]; then
+                kill "$(cat "$STANDBY_PID")" 2>/dev/null || true
+                rm -f "$STANDBY_PID"
+              fi
+              if [ -f "$CADDY_BACKUP" ]; then
+                sudo -n cp "$CADDY_BACKUP" "$CADDY_FILE" || true
+                sudo -n systemctl reload caddy || true
+              fi
+            fi
+            exit "$code"
+          }
+          trap cleanup EXIT
+
+          wait_health() {
+            port="$1"
+            label="$2"
+            max_attempts="$3"
+
+            for i in $(seq 1 "$max_attempts"); do
+              if curl -fsS "http://127.0.0.1:$port/health"; then
+                echo
+                echo "$label health OK"
+                return 0
+              fi
+
+              echo "waiting $label health... $i/$max_attempts"
+              sleep 3
+            done
+
+            echo "::error::$label health failed"
+            return 1
+          }
+
+          switch_caddy() {
+            port="$1"
+            tmp_file="$(mktemp)"
+
+            cat > "$tmp_file" <<EOF
+          $CADDY_SITE {
+              reverse_proxy localhost:$port
+          }
+          EOF
+
+            sudo -n cp "$tmp_file" "$CADDY_FILE"
+            rm -f "$tmp_file"
+            sudo -n caddy fmt --overwrite "$CADDY_FILE"
+            sudo -n caddy validate --config "$CADDY_FILE"
+            sudo -n systemctl reload caddy
+          }
+
+          echo "===== deploy start ====="
+          echo "ts=$TS"
+          echo "candidate=$CANDIDATE_JAR"
+          echo "standby_log=$STANDBY_LOG"
+
+          test -f "$CANDIDATE_JAR"
+          test -f "$ACTIVE_JAR"
+          test -f "$ENV_FILE"
+          systemctl is-active --quiet caddy
+          systemctl is-active --quiet wigul-backend
+          systemctl is-active --quiet postgresql@15-main
+
+          CADDY_SITE="$(sudo -n awk 'NF && $1 !~ /^#/ && $NF == "{" { print $1; exit }' "$CADDY_FILE")"
+          if [ -z "$CADDY_SITE" ]; then
+            echo "::error::Could not detect Caddy site from $CADDY_FILE"
+            exit 1
+          fi
+          echo "caddy_site=$CADDY_SITE"
+
+          if ! grep -q 'reverse_proxy localhost:8080' "$CADDY_FILE"; then
+            echo "::error::Caddy must point to localhost:8080 before deploy"
+            sudo -n sed -n '1,120p' "$CADDY_FILE" || true
+            exit 1
+          fi
+
+          if ss -ltn | grep -q ':8081 '; then
+            echo "::error::Port 8081 is already listening"
+            ss -ltnp 2>/dev/null | grep ':8081' || true
+            exit 1
+          fi
+
+          wait_health 8080 "8080 main" 20
+          sudo -n cp "$CADDY_FILE" "$CADDY_BACKUP"
+          rm -f "$STANDBY_PID"
+
+          echo
+          echo "===== start 8081 standby ====="
+          (
+            cd "$APP_DIR"
+            set -a
+            . "$ENV_FILE"
+            set +a
+            export APP_PUSH_FCM_ENABLED=true
+            export APP_PUSH_FCM_CREDENTIALS_LOCATION="file:/opt/wigul/secrets/firebase-adminsdk.json"
+            exec /usr/bin/java \
+              -Xms128m \
+              -Xmx256m \
+              -XX:MaxMetaspaceSize=128m \
+              -jar "$CANDIDATE_JAR" \
+              --server.port=8081 \
+              --spring.datasource.hikari.maximum-pool-size=3
+          ) > "$STANDBY_LOG" 2>&1 &
+          echo "$!" > "$STANDBY_PID"
+          echo "8081 standby pid=$(cat "$STANDBY_PID")"
+
+          wait_health 8081 "8081 standby" 100
+
+          echo
+          echo "===== switch caddy to 8081 ====="
+          switch_caddy 8081
+          CADDY_ON_8081=1
+          curl -skfsS "https://$CADDY_SITE/health"
+          echo
+
+          echo
+          echo "===== replace active jar and restart 8080 ====="
+          cp "$ACTIVE_JAR" "$ACTIVE_BACKUP"
+          cp "$CANDIDATE_JAR" "$ACTIVE_JAR"
+          sudo -n systemctl restart wigul-backend
+          wait_health 8080 "8080 main" 120
+
+          echo
+          echo "===== switch caddy back to 8080 ====="
+          switch_caddy 8080
+          CADDY_ON_8081=0
+          curl -skfsS "https://$CADDY_SITE/health"
+          echo
+
+          echo
+          echo "===== stop 8081 standby ====="
+          kill "$(cat "$STANDBY_PID")" 2>/dev/null || true
+          rm -f "$STANDBY_PID"
+          rm -f "$CANDIDATE_JAR"
+
+          echo
+          echo "===== final check ====="
+          systemctl is-active caddy
+          systemctl is-active wigul-backend
+          systemctl is-active postgresql@15-main
+          sudo -n sed -n '1,80p' "$CADDY_FILE"
+          ss -ltnp 2>/dev/null | grep -E ':8080|:8081|:80|:443' || true
+          curl -fsS http://127.0.0.1:8080/health
+          echo
+          curl -skfsS "https://$CADDY_SITE/health"
+          echo
+          free -h
+          echo "deploy finished"
+          REMOTE_DEPLOY

--- a/docs/FCM_PUSH_OPERATIONS.md
+++ b/docs/FCM_PUSH_OPERATIONS.md
@@ -98,7 +98,9 @@ sudo journalctl -u wigul-backend --since "10 minutes ago" --no-pager
 
 ## 배포와의 관계
 
-QA 배포 workflow는 jar를 빌드해서 VM에 업로드하고 `wigul-backend`를 재시작한다.
+QA 배포 workflow는 jar를 후보 파일로 업로드한 뒤 8081 standby 프로세스를 먼저 띄운다. 8081 `/health`가 성공하면 Caddy를 8081로 전환하고, 기존 8080 `wigul-backend`의 jar를 교체한 뒤 서비스를 재시작한다. 8080 `/health`가 다시 성공하면 Caddy를 8080으로 되돌리고 8081 standby를 종료한다.
+
+8080 재시작이 실패하면 workflow는 실패 처리되지만, Caddy는 8081 standby를 바라보는 상태로 남겨 외부 요청을 계속 처리한다. 이 경우 8080 복구가 끝날 때까지 8081 standby 프로세스를 종료하면 안 된다.
 
 Firebase 서비스 계정 JSON을 업로드하지 않고, systemd drop-in도 만들지 않는다. VM-local secret 파일과 drop-in은 일반적인 jar 배포와 서비스 재시작 후에도 유지된다. 다만 새 VM을 만들거나 서비스 유닛을 다시 구성하면 FCM 설정을 다시 provision해야 한다.
 

--- a/docs/QA_DEPLOY_8081_STANDBY_COMPARISON_2026_06_27.html
+++ b/docs/QA_DEPLOY_8081_STANDBY_COMPARISON_2026_06_27.html
@@ -1,0 +1,442 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>QA 배포 방식 비교: 기존 재시작 vs 8081 스탠바이</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #172033;
+      --muted: #5c667a;
+      --line: #d8deea;
+      --panel: #f7f9fc;
+      --accent: #1267d8;
+      --good: #137a46;
+      --warn: #a15c00;
+      --bad: #b3261e;
+      --soft-blue: #eaf2ff;
+      --soft-green: #eaf7ef;
+      --soft-yellow: #fff5dc;
+      --soft-red: #fdeceb;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--ink);
+      background: #ffffff;
+      line-height: 1.6;
+    }
+
+    main {
+      width: min(1120px, calc(100% - 40px));
+      margin: 0 auto;
+      padding: 42px 0 64px;
+    }
+
+    header {
+      border-bottom: 2px solid var(--ink);
+      padding-bottom: 24px;
+      margin-bottom: 28px;
+    }
+
+    h1 {
+      margin: 0 0 10px;
+      font-size: clamp(28px, 4vw, 44px);
+      line-height: 1.16;
+      letter-spacing: 0;
+    }
+
+    h2 {
+      margin: 36px 0 14px;
+      font-size: 24px;
+      letter-spacing: 0;
+    }
+
+    h3 {
+      margin: 22px 0 8px;
+      font-size: 18px;
+      letter-spacing: 0;
+    }
+
+    p {
+      margin: 0 0 12px;
+    }
+
+    .meta {
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    .summary {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+      margin: 24px 0 8px;
+    }
+
+    .metric {
+      border: 1px solid var(--line);
+      background: var(--panel);
+      padding: 16px;
+      border-radius: 8px;
+      min-height: 132px;
+    }
+
+    .metric strong {
+      display: block;
+      font-size: 28px;
+      line-height: 1.2;
+      margin: 8px 0;
+    }
+
+    .label {
+      color: var(--muted);
+      font-size: 13px;
+      font-weight: 700;
+      text-transform: uppercase;
+    }
+
+    .callout {
+      border-left: 5px solid var(--accent);
+      background: var(--soft-blue);
+      padding: 16px 18px;
+      margin: 18px 0;
+      border-radius: 0 8px 8px 0;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+    }
+
+    .box {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 18px;
+      background: #ffffff;
+    }
+
+    .box.good {
+      border-color: #a8d8bc;
+      background: var(--soft-green);
+    }
+
+    .box.warn {
+      border-color: #eed08f;
+      background: var(--soft-yellow);
+    }
+
+    .box.bad {
+      border-color: #efb0ac;
+      background: var(--soft-red);
+    }
+
+    ul {
+      margin: 10px 0 0 20px;
+      padding: 0;
+    }
+
+    li {
+      margin: 6px 0;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 12px 0 22px;
+      font-size: 15px;
+    }
+
+    th,
+    td {
+      border: 1px solid var(--line);
+      padding: 12px 14px;
+      vertical-align: top;
+      text-align: left;
+    }
+
+    th {
+      background: #edf1f7;
+      font-weight: 700;
+    }
+
+    code {
+      font-family: "SFMono-Regular", Consolas, monospace;
+      background: #eef2f8;
+      padding: 2px 5px;
+      border-radius: 4px;
+      font-size: 0.92em;
+    }
+
+    .good-text {
+      color: var(--good);
+      font-weight: 700;
+    }
+
+    .warn-text {
+      color: var(--warn);
+      font-weight: 700;
+    }
+
+    .bad-text {
+      color: var(--bad);
+      font-weight: 700;
+    }
+
+    footer {
+      color: var(--muted);
+      border-top: 1px solid var(--line);
+      margin-top: 42px;
+      padding-top: 18px;
+      font-size: 13px;
+    }
+
+    @media (max-width: 820px) {
+      main {
+        width: min(100% - 24px, 1120px);
+        padding-top: 28px;
+      }
+
+      .summary,
+      .grid {
+        grid-template-columns: 1fr;
+      }
+
+      table {
+        display: block;
+        overflow-x: auto;
+        white-space: nowrap;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div class="meta">NF-75 · QA 배포 안정화 판단 자료 · 2026-06-27</div>
+      <h1>QA 배포 방식 비교: 기존 재시작 vs 8081 스탠바이</h1>
+      <p>
+        이 문서는 QA 서버 배포에서 8081 스탠바이 절차를 사용할 때와 사용하지 않을 때의
+        사용자 영향, 배포 소요 시간, 운영 장단점을 비교한다.
+      </p>
+    </header>
+
+    <section class="summary" aria-label="핵심 요약">
+      <div class="metric">
+        <div class="label">기존 방식</div>
+        <strong>짧은 배포, 노출되는 끊김</strong>
+        <p>8080 서비스를 바로 재시작하므로 배포 단계는 단순하지만, 기동 완료 전까지 외부 요청은 502 또는 연결 실패가 될 수 있다.</p>
+      </div>
+      <div class="metric">
+        <div class="label">8081 방식</div>
+        <strong>긴 배포, 끊김 최소화</strong>
+        <p>후보 jar를 8081에서 먼저 검증하고 Caddy를 전환하므로 작업 시간은 늘지만 사용자가 보는 다운타임을 줄인다.</p>
+      </div>
+      <div class="metric">
+        <div class="label">권장 판단</div>
+        <strong class="good-text">8081 스탠바이 유지</strong>
+        <p>비공개 테스트 기간에는 배포 속도보다 외부 사용자의 요청 성공률과 복구 여지가 더 중요하다.</p>
+      </div>
+    </section>
+
+    <section>
+      <h2>비교 기준</h2>
+      <div class="callout">
+        현재 QA VM은 2 vCPU, 약 4GB 메모리로 업그레이드되었고, Caddy가
+        <code>localhost:8080</code> 또는 <code>localhost:8081</code>로 reverse proxy를 전환하는 구조다.
+        8081 절차는 완전한 로드밸런서 blue/green은 아니지만, 단일 VM에서 가능한 경량 무중단 배포에 가깝다.
+      </div>
+
+      <table>
+        <thead>
+          <tr>
+            <th>항목</th>
+            <th>기존 8080 직접 재시작</th>
+            <th>8081 스탠바이 절차</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>배포 흐름</td>
+            <td>jar 업로드 후 <code>wigul-backend</code> 8080 서비스를 바로 재시작</td>
+            <td>candidate jar를 8081로 먼저 기동, health 성공 후 Caddy 전환, 8080 교체 후 복귀</td>
+          </tr>
+          <tr>
+            <td>사용자 체감 끊김</td>
+            <td><span class="bad-text">발생 가능</span>. 8080 재시작 동안 Caddy upstream이 비어 502가 날 수 있음</td>
+            <td><span class="good-text">최소화</span>. 8080 재시작 중 외부 요청은 8081이 받음</td>
+          </tr>
+          <tr>
+            <td>배포 작업 시간</td>
+            <td><span class="good-text">더 짧음</span>. standby 기동과 Caddy 왕복 전환이 없음</td>
+            <td><span class="warn-text">더 김</span>. 8081 기동 대기와 8080 재기동 대기를 모두 수행</td>
+          </tr>
+          <tr>
+            <td>실패 시 상태</td>
+            <td>8080이 실패하면 외부 요청도 실패할 가능성이 큼</td>
+            <td>8080 복구 실패 시 Caddy를 8081에 남겨 서비스 지속 가능</td>
+          </tr>
+          <tr>
+            <td>복잡도</td>
+            <td>낮음. systemd restart 중심</td>
+            <td>중간. standby pid, Caddyfile 전환, rollback guard가 필요</td>
+          </tr>
+          <tr>
+            <td>리소스 사용</td>
+            <td>Java 프로세스 1개</td>
+            <td>배포 중 잠시 Java 프로세스 2개. 4GB 업그레이드 이후 허용 가능한 수준</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>시간 차이</h2>
+      <p>
+        시간은 “전체 GitHub Actions 실행 시간”과 “사용자에게 노출되는 끊김 시간”을 나눠서 봐야 한다.
+        8081 방식은 전체 배포 시간은 늘지만, 사용자에게 노출되는 실패 시간을 줄이는 방식이다.
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>구분</th>
+            <th>기존 방식 예상</th>
+            <th>8081 방식 예상</th>
+            <th>판단</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>추가 준비 시간</td>
+            <td>거의 없음</td>
+            <td>8081 standby 기동 대기 약 20~40초 수준</td>
+            <td>8081 방식이 더 오래 걸림</td>
+          </tr>
+          <tr>
+            <td>8080 재시작 시간</td>
+            <td>현재 4GB 기준 약 20~40초 수준으로 예상</td>
+            <td>동일하게 발생하지만 외부 트래픽은 8081이 받음</td>
+            <td>작업 시간은 비슷하나 사용자 영향이 다름</td>
+          </tr>
+          <tr>
+            <td>Caddy 전환 시간</td>
+            <td>없음</td>
+            <td>8081 전환과 8080 복귀가 각각 짧게 발생</td>
+            <td>초 단위 추가 비용</td>
+          </tr>
+          <tr>
+            <td>사용자 체감 실패 시간</td>
+            <td>8080 기동 전까지 502 가능</td>
+            <td>정상 경로에서는 거의 없음. 실패 시에도 8081 유지 가능</td>
+            <td>8081 방식 우위</td>
+          </tr>
+          <tr>
+            <td>총 배포 시간</td>
+            <td>더 짧음</td>
+            <td>대략 8081 기동 대기만큼 더 길어짐</td>
+            <td>속도보다 안정성 우선이면 수용 가능</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="grid">
+      <div class="box warn">
+        <h2>8081 절차를 안 했을 때</h2>
+        <h3>장점</h3>
+        <ul>
+          <li>workflow가 짧고 단순하다.</li>
+          <li>배포 총 시간이 더 짧다.</li>
+          <li>추가 프로세스와 pid 관리가 없다.</li>
+        </ul>
+        <h3>단점</h3>
+        <ul>
+          <li>재시작 구간에 외부 사용자가 502를 볼 수 있다.</li>
+          <li>기동이 늦어지면 장애처럼 보이는 시간이 길어진다.</li>
+          <li>비공개 테스트 중 사용자 행동과 겹치면 신뢰도가 떨어질 수 있다.</li>
+        </ul>
+      </div>
+
+      <div class="box good">
+        <h2>8081 절차를 했을 때</h2>
+        <h3>장점</h3>
+        <ul>
+          <li>새 jar가 8081에서 뜨는지 먼저 확인하고 외부 전환한다.</li>
+          <li>8080 재시작 동안에도 외부 요청을 받을 수 있다.</li>
+          <li>8080 복구 실패 시 Caddy를 8081에 남겨 서비스 유지가 가능하다.</li>
+          <li>비공개 테스트 기간에 “배포 때문에 터졌다”는 리스크를 줄인다.</li>
+        </ul>
+        <h3>단점</h3>
+        <ul>
+          <li>전체 배포 시간은 더 길어진다.</li>
+          <li>Caddyfile 전환, standby 종료, 실패 시 복구 규칙이 추가된다.</li>
+          <li>배포 중 잠시 Java 프로세스 2개가 떠서 메모리를 더 쓴다.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section>
+      <h2>운영 판단</h2>
+      <div class="box">
+        <p>
+          QA 비공개 테스트 기준에서는 <span class="good-text">8081 스탠바이 절차를 사용하는 편이 더 낫다</span>.
+          이유는 배포 총 시간이 조금 늘어나는 비용보다, 실제 사용자 요청이 실패로 보이는 시간을 줄이는 이득이 더 크기 때문이다.
+        </p>
+        <p>
+          특히 테스트 인원이 동시에 앱을 쓰는 상황에서는 20~40초의 재시작 공백도 로그인, 알림, 위시리스트,
+          홈 요약 같은 API 실패로 체감될 수 있다. 8081 절차는 이 구간을 standby로 흡수하고,
+          실패 시에도 8081을 임시 운영 상태로 남겨 복구 시간을 벌 수 있다.
+        </p>
+      </div>
+    </section>
+
+    <section>
+      <h2>채택 조건</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>조건</th>
+            <th>필요 이유</th>
+            <th>현재 판단</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>QA VM 메모리 여유</td>
+            <td>배포 중 Java 프로세스 2개가 잠시 떠야 함</td>
+            <td><span class="good-text">충족</span>. 4GB 업그레이드 후 여유 확인</td>
+          </tr>
+          <tr>
+            <td>Caddy 전환 권한</td>
+            <td>workflow가 Caddyfile을 8081/8080으로 바꾸고 reload해야 함</td>
+            <td><span class="warn-text">PR 적용 후 첫 배포에서 확인 필요</span></td>
+          </tr>
+          <tr>
+            <td>8081 포트 비어 있음</td>
+            <td>standby 프로세스 기동 필요</td>
+            <td><span class="good-text">사전 검사 포함</span></td>
+          </tr>
+          <tr>
+            <td>DB migration 호환성</td>
+            <td>8080과 8081이 짧게 같은 DB를 바라볼 수 있음</td>
+            <td><span class="warn-text">파괴적 migration은 별도 배포 계획 필요</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <footer>
+      이 문서는 NF-75 QA CD 변경 PR의 보조 판단 자료다. 수치는 QA VM 4GB 업그레이드 이후의 관측 흐름을 기준으로 한 운영 추정이며,
+      실제 GitHub Actions 실행 시간은 네트워크, JVM 기동, DB migration, runner 상태에 따라 달라질 수 있다.
+    </footer>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
# 🧰 Chore PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-75**
- Jira: https://parkjaehong.atlassian.net/browse/NF-75 (있다면)

> PR 제목: `[chore] NF-75 QA 배포 8081 스탠바이 절차 전환`  
> 브랜치: `chore/NF-75-qa-deploy-8081-standby`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #173

---

## 🧩 한눈에 요약 (필수)
### 무엇을 변경했나? (인프라/빌드/CI/의존성 등)
- [x] 인프라
- [x] 설정파일
- [ ] 빌드 파일
- [x] CI
- [ ] 의존성
- [x] 런타임/비즈니스 로직 리팩터링 없음 (있으면 Refactor PR 템플릿 사용)

### 왜 필요한가? (안정성/속도/보안/개발경험)
- 기존 QA deploy는 jar 업로드 후 8080 `wigul-backend`를 바로 재시작해서 재시작 구간에 Caddy 502가 날 수 있었습니다.
- QA VM을 4GB급으로 올린 뒤 8081 standby를 잠시 함께 띄울 여유가 생겼으므로, 배포 중 외부 요청을 8081로 우회시키는 절차로 바꿉니다.

### 범위(스코프)
- Included:
  - deploy workflow candidate jar 업로드
  - 8081 standby 기동 및 `/health` 확인
  - Caddy 8081 전환 후 8080 서비스 재시작
  - 8080 복구 확인 후 Caddy 8080 복귀 및 8081 종료
  - 실패 시 Caddy를 8081에 남기는 guard
  - FCM 운영 문서의 배포 관계 설명 갱신
- Not included:
  - 애플리케이션 비즈니스 로직 변경
  - DB schema 변경
  - GitHub Secrets 변경
  - VM systemd unit 변경

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command:
  - `git diff --check HEAD~1..HEAD`
  - `python3` YAML 파싱
  - deploy workflow의 remote heredoc script 추출 후 `bash -n`
- Result:
  - diff check 통과
  - YAML 파싱 성공
  - remote bash 문법 확인 성공

### CI
- 링크/결과: PR 생성 후 확인

### Smoke / 수동 검증 (해당 시)
- 시나리오: QA VM에서 같은 8081 standby 절차를 수동 rehearsal로 검증
- 결과: 8081 standby health 성공, Caddy 8081 전환 성공, 8080 재시작 후 Caddy 8080 복귀 성공

### 테스트 공백(있다면 이유 필수)
- GitHub Actions deploy workflow 변경이라 실제 배포 smoke는 PR merge 후 `develop` 배포에서 최종 확인이 필요합니다.
- 애플리케이션 코드 변경이 없어 Gradle 테스트는 생략했습니다.

---

## 🧭 영향 범위 (필수)
- [ ] 설정/환경변수 변경 없음
- [x] 설정/환경변수 변경 있음 (항목: Caddyfile을 deploy 중 8080/8081 reverse_proxy로 재작성)
- [ ] CI/빌드 파이프라인 영향 없음
- [x] CI/빌드 파이프라인 영향 있음 (요약: QA deploy 절차를 8081 standby 기반으로 변경)
- [x] 의존성(dependency) 변경 없음
- [ ] 의존성(dependency) 변경 있음 (패키지/버전/주요 변경점: )

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- deploy user가 `sudo -n cp /etc/caddy/Caddyfile`, `sudo -n caddy validate`, `sudo -n systemctl reload caddy`, `sudo -n systemctl restart wigul-backend` 권한을 가져야 합니다.
- 새 jar의 DB migration이 기존 jar와 backward-compatible하지 않으면 8081 standby 기동 시점에 영향이 생길 수 있습니다.
- 8080 재시작 실패 시 서비스 보호를 위해 Caddy가 8081에 남으므로, 복구 전 8081 standby를 종료하면 안 됩니다.

### 롤백
- [x] 단순 revert로 가능
- [ ] 버전 pin/되돌리기 필요 (대상: , 방법: )
- [x] 배포 롤백(이전 jar 백업) 가능

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/설정: `.github/workflows/deploy-qa.yml`, `docs/FCM_PUSH_OPERATIONS.md`
- 트레이드오프/대안: 완전한 로드밸런서 blue/green은 아니고, 단일 VM에서 Caddy upstream을 8080/8081로 바꾸는 경량 절차입니다.
- 성능/보안/호환성 영향: 배포 중 짧게 Java 프로세스 2개가 떠서 메모리를 더 쓰지만, 4GB QA VM 기준 수동 검증에서 여유가 있었습니다.