### PR TITLE
[fix] NF-77 지그재그/번개장터 브릿지 쇼핑 링크 가져오기 보완

### DIFF
--- a/src/main/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcher.java
@@ -1,5 +1,8 @@
 package com.sagongsa.backend.itemimport.item;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -24,6 +27,8 @@ public class JsoupPageFetcher implements PageFetcher {
 	private static final int DEFAULT_TIMEOUT_MILLIS = 30_000;
 	private static final int DEFAULT_MAX_ATTEMPTS = 2;
 	private static final int MAX_REDIRECTS = 5;
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+	private static final Pattern BUNJANG_PRODUCT_PATH_PATTERN = Pattern.compile("^/products/(\\d+)(?:/.*)?$");
 	private static final Pattern JS_HTTP_ASSIGNMENT_PATTERN = Pattern.compile(
 		"(?is)\\b(?:var|let|const)\\s+(store_link|fallback_url|fallbackUrl|target_url|targetUrl|web_url|webUrl|product_url|productUrl|landing_url|landingUrl|redirect_url|redirectUrl|af_android_url|af_ios_url|af_web_dp)\\s*=\\s*(['\"])(https?://.*?)\\2"
 	);
@@ -120,9 +125,21 @@ public class JsoupPageFetcher implements PageFetcher {
 				continue;
 			}
 
+			URI finalUri = URI.create(response.url().toString());
+			Optional<FetchedPage> bunjangProductPage = bunjangProductApiPage(
+				uri,
+				finalUri,
+				response.statusCode(),
+				response.contentType(),
+				response.body()
+			);
+			if (bunjangProductPage.isPresent()) {
+				return bunjangProductPage.get();
+			}
+
 			return new FetchedPage(
 				uri,
-				URI.create(response.url().toString()),
+				finalUri,
 				response.statusCode(),
 				response.contentType(),
 				response.body()
@@ -244,20 +261,27 @@ public class JsoupPageFetcher implements PageFetcher {
 	private static boolean isKnownBridgeHost(String host) {
 		return host.equals("app.shopping.naver.com")
 			|| host.equals("naver.me")
+			|| host.equals("abr.ge")
+			|| host.endsWith(".airbridge.io")
 			|| host.endsWith(".onelink.me")
 			|| host.endsWith(".app.link")
 			|| host.equals("oy.run")
 			|| host.equals("s.zigzag.kr")
 			|| host.equals("link.zigzag.kr")
+			|| host.equals("go.bgzt.link")
 			|| host.equals("link.bunjang.co.kr")
 			|| host.equals("share.bunjang.co.kr");
 	}
 
-	private static Optional<URI> queryRedirectTarget(URI uri) {
+	static Optional<URI> queryRedirectTarget(URI uri) {
 		String host = Optional.ofNullable(uri.getHost()).orElse("").toLowerCase(Locale.ROOT);
 		String rawQuery = uri.getRawQuery();
 		if (!isKnownBridgeHost(host) || rawQuery == null || rawQuery.isBlank()) {
 			return Optional.empty();
+		}
+		Optional<URI> bunjangProductTarget = bunjangAirbridgeProductTarget(uri, rawQuery);
+		if (bunjangProductTarget.isPresent()) {
+			return bunjangProductTarget;
 		}
 		for (String key : redirectQueryKeys()) {
 			Optional<URI> target = queryParameter(rawQuery, key)
@@ -268,6 +292,189 @@ public class JsoupPageFetcher implements PageFetcher {
 			}
 		}
 		return Optional.empty();
+	}
+
+	private static Optional<URI> bunjangAirbridgeProductTarget(URI uri, String rawQuery) {
+		String host = Optional.ofNullable(uri.getHost()).orElse("").toLowerCase(Locale.ROOT);
+		if (!host.equals("bunjang.airbridge.io")) {
+			return Optional.empty();
+		}
+		boolean isProduct = queryParameter(rawQuery, "type")
+			.map(type -> type.equalsIgnoreCase("product"))
+			.orElse(false);
+		return queryParameter(rawQuery, "val")
+			.filter(productId -> isProduct)
+			.filter(productId -> productId.matches("\\d+"))
+			.map(productId -> URI.create("https://m.bunjang.co.kr/products/" + productId));
+	}
+
+	private Optional<FetchedPage> bunjangProductApiPage(
+		URI requestedUri,
+		URI finalUri,
+		int statusCode,
+		String contentType,
+		String body
+	) throws IOException {
+		if (statusCode != 200 || !isBunjangProductShell(finalUri, contentType, body)) {
+			return Optional.empty();
+		}
+		Optional<String> productId = bunjangProductId(finalUri);
+		if (productId.isEmpty()) {
+			return Optional.empty();
+		}
+
+		URI apiUri = URI.create("https://api.bunjang.co.kr/api/pms/v1/products/" + productId.get() + "/detail/web");
+		ShoppingUrlSafety.validatePublicHost(apiUri);
+		Connection.Response apiResponse = Jsoup.connect(apiUri.toString())
+			.userAgent(ANDROID_USER_AGENT)
+			.header("Accept", "application/json, text/plain, */*")
+			.header("Accept-Language", "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7")
+			.header("Origin", "https://m.bunjang.co.kr")
+			.header("Referer", finalUri.toString())
+			.ignoreContentType(true)
+			.ignoreHttpErrors(true)
+			.timeout(timeoutMillis)
+			.execute();
+
+		if (apiResponse.statusCode() >= 400) {
+			return Optional.empty();
+		}
+
+		return bunjangProductMetadataHtml(apiResponse.body())
+			.map(html -> new FetchedPage(requestedUri, finalUri, 200, "text/html; charset=UTF-8", html));
+	}
+
+	private static boolean isBunjangProductShell(URI uri, String contentType, String body) {
+		if (bunjangProductId(uri).isEmpty() || body == null || body.isBlank() || !mayContainClientSideRedirect(contentType)) {
+			return false;
+		}
+		Document document = Jsoup.parse(body, uri.toString());
+		return isBunjangSiteTitle(document.title())
+			&& isBunjangSiteTitle(document.selectFirst("meta[property=og:title]") == null
+				? null
+				: document.selectFirst("meta[property=og:title]").attr("content"));
+	}
+
+	private static Optional<String> bunjangProductId(URI uri) {
+		String host = Optional.ofNullable(uri.getHost()).orElse("").toLowerCase(Locale.ROOT);
+		if (!host.equals("m.bunjang.co.kr") && !host.equals("bunjang.co.kr")) {
+			return Optional.empty();
+		}
+		String path = Optional.ofNullable(uri.getPath()).orElse("");
+		Matcher matcher = BUNJANG_PRODUCT_PATH_PATTERN.matcher(path);
+		return matcher.matches() ? Optional.of(matcher.group(1)) : Optional.empty();
+	}
+
+	static Optional<String> bunjangProductMetadataHtml(String apiBody) {
+		if (apiBody == null || apiBody.isBlank()) {
+			return Optional.empty();
+		}
+		try {
+			JsonNode product = OBJECT_MAPPER.readTree(apiBody).path("data").path("product");
+			if (product.isMissingNode() || product.isNull()) {
+				return Optional.empty();
+			}
+
+			String title = jsonText(product, "name");
+			String description = jsonText(product, "description");
+			String price = jsonText(product, "price");
+			String brandName = jsonText(product, "brand", "name");
+			String imageUrl = normalizeBunjangImageUrl(jsonText(product, "imageUrl"));
+			if (isBlank(title) && isBlank(price) && isBlank(imageUrl)) {
+				return Optional.empty();
+			}
+
+			StringBuilder html = new StringBuilder("<!doctype html><html><head>");
+			html.append("<title>").append(escapeHtml(firstNonBlank(title, "번개장터 상품"))).append("</title>");
+			appendPropertyMeta(html, "og:title", title);
+			appendNameMeta(html, "twitter:title", title);
+			appendPropertyMeta(html, "og:description", description);
+			appendNameMeta(html, "description", description);
+			appendPropertyMeta(html, "og:image", imageUrl);
+			appendNameMeta(html, "twitter:image", imageUrl);
+			appendPropertyMeta(html, "product:price:amount", price);
+			appendPropertyMeta(html, "kakao:commerce:price", price);
+			appendPropertyMeta(html, "kakao:commerce:brand_name", brandName);
+			html.append("</head><body></body></html>");
+			return Optional.of(html.toString());
+		} catch (JsonProcessingException exception) {
+			return Optional.empty();
+		}
+	}
+
+	private static String jsonText(JsonNode node, String... path) {
+		JsonNode current = node;
+		for (String key : path) {
+			current = current.path(key);
+			if (current.isMissingNode() || current.isNull()) {
+				return null;
+			}
+		}
+		String value = current.asText();
+		return isBlank(value) ? null : value.trim();
+	}
+
+	private static String normalizeBunjangImageUrl(String imageUrl) {
+		if (isBlank(imageUrl)) {
+			return null;
+		}
+		String normalized = imageUrl.replace("{cnt}", "1").replace("{res}", "900");
+		try {
+			URI uri = URI.create(normalized);
+			String scheme = Optional.ofNullable(uri.getScheme()).orElse("").toLowerCase(Locale.ROOT);
+			return scheme.equals("http") || scheme.equals("https") ? uri.toString() : null;
+		} catch (IllegalArgumentException exception) {
+			return null;
+		}
+	}
+
+	private static void appendPropertyMeta(StringBuilder html, String property, String content) {
+		appendMeta(html, "property", property, content);
+	}
+
+	private static void appendNameMeta(StringBuilder html, String name, String content) {
+		appendMeta(html, "name", name, content);
+	}
+
+	private static void appendMeta(StringBuilder html, String attributeName, String key, String content) {
+		if (isBlank(content)) {
+			return;
+		}
+		html.append("<meta ")
+			.append(attributeName)
+			.append("=\"")
+			.append(escapeHtml(key))
+			.append("\" content=\"")
+			.append(escapeHtml(content))
+			.append("\" />");
+	}
+
+	private static boolean isBunjangSiteTitle(String value) {
+		if (isBlank(value)) {
+			return false;
+		}
+		String normalized = value.replace(" ", "").trim().toLowerCase(Locale.ROOT);
+		return normalized.equals("번개장터") || normalized.equals("bunjang");
+	}
+
+	private static String firstNonBlank(String... values) {
+		for (String value : values) {
+			if (!isBlank(value)) {
+				return value.trim();
+			}
+		}
+		return null;
+	}
+
+	private static boolean isBlank(String value) {
+		return value == null || value.isBlank();
+	}
+
+	private static String escapeHtml(String value) {
+		return value.replace("&", "&amp;")
+			.replace("\"", "&quot;")
+			.replace("<", "&lt;")
+			.replace(">", "&gt;");
 	}
 
 	private static Optional<URI> assignedHttpUrlTarget(URI baseUri, String body) {
@@ -314,9 +521,11 @@ public class JsoupPageFetcher implements PageFetcher {
 
 	private static String[] redirectQueryKeys() {
 		return new String[] {
-			"url", "link", "dst", "deepLink", "deep_link", "deeplink", "appLink", "app_link", "af_dp",
+			"url", "link", "dst", "deepLink", "deep_link", "deeplink", "deeplinkUrl", "deeplink_url",
+			"deepLinkUrl", "deep_link_url", "appLink", "app_link", "af_dp",
 			"targetUrl", "target_url", "webUrl", "web_url", "productUrl", "product_url",
 			"landingUrl", "landing_url", "fallbackUrl", "fallback_url", "redirectUrl", "redirect_url",
+			"fallbackDesktop", "fallback_desktop", "fallbackWeb", "fallback_web",
 			"af_web_dp", "af_android_url", "af_ios_url"
 		};
 	}

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
@@ -308,7 +308,7 @@ public class ShoppingLinkImportService {
 		if (containsAny(haystack, "셔츠", "니트", "가디건", "팬츠", "아우터", "원피스", "스니커즈", "신발", "가방", "musinsa", "zigzag", "ably", "29cm")) {
 			return ItemCategory.FASHION;
 		}
-		if (containsAny(haystack, "립", "쿠션", "에센스", "크림", "마스크팩", "oliveyoung", "향수", "샴푸")) {
+		if (containsAny(haystack, "립스틱", "립밤", "립틴트", "립글로스", "립라이너", "쿠션", "에센스", "크림", "마스크팩", "oliveyoung", "향수", "샴푸")) {
 			return ItemCategory.BEAUTY;
 		}
 		if (containsAny(haystack, "이어폰", "헤드폰", "키보드", "마우스", "노트북", "갤럭시", "아이폰", "ipad", "monitor", "ssd", "보조배터리", "충전기")) {
@@ -320,7 +320,7 @@ public class ShoppingLinkImportService {
 		if (containsAny(haystack, "간식", "음료", "커피", "프로틴", "식품", "라면", "과자")) {
 			return ItemCategory.FOOD;
 		}
-		if (containsAny(haystack, "레고", "피규어", "게임", "취미", "캠핑", "자전거")) {
+		if (containsAny(haystack, "레고", "피규어", "게임", "취미", "캠핑", "자전거", "스포츠", "레저", "유도", "도복", "운동")) {
 			return ItemCategory.HOBBY;
 		}
 		if (containsAny(haystack, "subscription", "멤버십", "정기구독", "월간", "연간 구독")) {
@@ -704,9 +704,10 @@ public class ShoppingLinkImportService {
 			.trim()
 			.toLowerCase(Locale.ROOT);
 		return switch (sourceDomain) {
-			case "zigzag.kr", "s.zigzag.kr", "link.zigzag.kr" ->
+			case "zigzag.kr", "s.zigzag.kr", "link.zigzag.kr", "zigzag.airbridge.io" ->
 				normalizedTitle.equals("지그재그") || normalizedTitle.equals("zigzag") || normalizedTitle.equals("지그재그스토어");
-			case "bunjang.co.kr", "m.bunjang.co.kr", "link.bunjang.co.kr", "share.bunjang.co.kr" ->
+			case "bunjang.co.kr", "m.bunjang.co.kr", "bunjang.airbridge.io", "go.bgzt.link",
+				"link.bunjang.co.kr", "share.bunjang.co.kr" ->
 				normalizedTitle.equals("번개장터") || normalizedTitle.equals("bunjang");
 			case "app.shopping.naver.com", "naver.me" ->
 				normalizedTitle.equals("네이버스토어") || normalizedTitle.equals("네이버플러스스토어");

--- a/src/test/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcherTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcherTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
 import org.junit.jupiter.api.Test;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
 
 class JsoupPageFetcherTest {
 
@@ -181,5 +183,66 @@ class JsoupPageFetcherTest {
 			"text/html",
 			body
 		)).contains(URI.create("https://m.oliveyoung.co.kr/m/goods/getGoodsDetail.do?goodsNo=A000000186792"));
+	}
+
+	@Test
+	void resolvesAirbridgeShareLinkQueryToZigzagProductPage() {
+		assertThat(JsoupPageFetcher.queryRedirectTarget(
+			URI.create("https://abr.ge/@zigzag/sharelink"
+				+ "?deeplink_url=zigzag%3A%2F%2Fopen%2Fproduct_detail%3Furl%3Dhttps%253A%252F%252Fstore.zigzag.kr%252Fcatalog%252Fproducts%252F170411267%253Fcatalog_product_id%253D170411267%26catalog_product_id%3D170411267"
+				+ "&fallback_desktop=https%3A%2F%2Fzigzag.kr%2Fp%2F170411267")
+		)).contains(URI.create("https://store.zigzag.kr/catalog/products/170411267?catalog_product_id=170411267"));
+	}
+
+	@Test
+	void resolvesAirbridgeProductDetailQueryToZigzagProductPage() {
+		assertThat(JsoupPageFetcher.queryRedirectTarget(
+			URI.create("https://zigzag.airbridge.io/open/product_detail"
+				+ "?url=https%3A%2F%2Fstore.zigzag.kr%2Fcatalog%2Fproducts%2F170411267%3Fcatalog_product_id%3D170411267"
+				+ "&catalog_product_id=170411267"
+				+ "&fallback_desktop=https%3A%2F%2Fzigzag.kr%2Fp%2F170411267")
+		)).contains(URI.create("https://store.zigzag.kr/catalog/products/170411267?catalog_product_id=170411267"));
+	}
+
+	@Test
+	void resolvesBunjangAirbridgeProductQueryToMobileProductPage() {
+		assertThat(JsoupPageFetcher.queryRedirectTarget(
+			URI.create("https://bunjang.airbridge.io/goto"
+				+ "?type=product"
+				+ "&val=398473587"
+				+ "&airbridge_referrer=airbridge%3Dtrue")
+		)).contains(URI.create("https://m.bunjang.co.kr/products/398473587"));
+	}
+
+	@Test
+	void buildsBunjangProductMetadataHtmlFromDetailApiResponse() {
+		String apiBody = """
+			{
+			  "data": {
+			    "product": {
+			      "pid": 398473587,
+			      "name": "용인대 아디다스 유도복 165",
+			      "description": "용인대 마크가 새겨진 아디다스 유도복",
+			      "price": 100000,
+			      "imageUrl": "https://media.bunjang.co.kr/product/398473587_{cnt}_1781014735_w{res}.jpg",
+			      "brand": {
+			        "name": "아디다스"
+			      }
+			    }
+			  }
+			}
+			""";
+
+		String html = JsoupPageFetcher.bunjangProductMetadataHtml(apiBody).orElseThrow();
+		Document document = Jsoup.parse(html);
+
+		assertThat(document.selectFirst("meta[property=og:title]").attr("content"))
+			.isEqualTo("용인대 아디다스 유도복 165");
+		assertThat(document.selectFirst("meta[property=product:price:amount]").attr("content"))
+			.isEqualTo("100000");
+		assertThat(document.selectFirst("meta[property=og:image]").attr("content"))
+			.isEqualTo("https://media.bunjang.co.kr/product/398473587_1_1781014735_w900.jpg");
+		assertThat(document.selectFirst("meta[property=kakao:commerce:brand_name]").attr("content"))
+			.isEqualTo("아디다스");
 	}
 }

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
@@ -434,6 +434,39 @@ class ShoppingLinkImportServiceTest {
 	}
 
 	@Test
+	void classifiesBunjangSportsProductWithoutLipFalsePositive() {
+		pageFetcher.stub(
+			"https://m.bunjang.co.kr/products/398473587",
+			"""
+				<html>
+				<head>
+				  <meta property="og:title" content="용인대 아디다스 유도복 165" />
+				  <meta property="og:description" content="수선하시면 될것같고 그거 감안해서 싸게 올립니다" />
+				  <meta property="og:image" content="https://media.bunjang.co.kr/product/398473587_1_1781014735_w900.jpg" />
+				  <meta property="product:price:amount" content="100000" />
+				</head>
+				<body></body>
+				</html>
+				"""
+		);
+
+		ShoppingLinkImportResponse response = service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.SHARE,
+				"https://m.bunjang.co.kr/products/398473587",
+				null,
+				null,
+				null,
+				null
+			)
+		);
+
+		assertThat(response.item().title()).isEqualTo("용인대 아디다스 유도복 165");
+		assertThat(response.item().listedPrice()).isEqualTo(100000);
+		assertThat(response.item().category()).isEqualTo(ItemCategory.HOBBY);
+	}
+
+	@Test
 	void rejectsCommerceBridgeShellInsteadOfImportingSiteNameWithZeroPrice() {
 		pageFetcher.stub(
 			"https://zigzag.kr/share/products/110621280",
@@ -461,6 +494,74 @@ class ShoppingLinkImportServiceTest {
 			new ShoppingLinkImportRequest(
 				ItemInputSource.SHARE,
 				"https://zigzag.kr/share/products/110621280",
+				null,
+				null,
+				null,
+				null
+			)
+		))
+			.isInstanceOf(ResponseStatusException.class)
+			.satisfies(exception -> {
+				ResponseStatusException responseStatusException = (ResponseStatusException) exception;
+				assertThat(responseStatusException.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+			});
+	}
+
+	@Test
+	void rejectsZigzagAirbridgeShellInsteadOfImportingSiteName() {
+		pageFetcher.stub(
+			"https://zigzag.airbridge.io/open/product_detail?fallback_desktop=https%3A%2F%2Fzigzag.kr%2Fp%2F170411267",
+			"""
+				<html>
+				<head>
+				  <title>지그재그</title>
+				  <meta property="og:title" content="지그재그" />
+				  <meta property="og:description" content="4,000만 여성이 선택한 쇼핑앱, 지그재그" />
+				  <meta property="og:image" content="http://static.airbridge.io/images/og_tags/zigzag.png" />
+				</head>
+				<body></body>
+				</html>
+				"""
+		);
+
+		assertThatThrownBy(() -> service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.SHARE,
+				"https://zigzag.airbridge.io/open/product_detail?fallback_desktop=https%3A%2F%2Fzigzag.kr%2Fp%2F170411267",
+				null,
+				null,
+				null,
+				null
+			)
+		))
+			.isInstanceOf(ResponseStatusException.class)
+			.satisfies(exception -> {
+				ResponseStatusException responseStatusException = (ResponseStatusException) exception;
+				assertThat(responseStatusException.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+			});
+	}
+
+	@Test
+	void rejectsBunjangAirbridgeShellInsteadOfImportingSiteName() {
+		pageFetcher.stub(
+			"https://bunjang.airbridge.io/goto?type=product&val=398473587",
+			"""
+				<html>
+				<head>
+				  <title>번개장터</title>
+				  <meta property="og:title" content="번개장터" />
+				  <meta property="og:description" content="취향을 잇는 거래, 번개장터" />
+				  <meta property="og:image" content="https://static.bunjang.co.kr/images/logo.png" />
+				</head>
+				<body></body>
+				</html>
+				"""
+		);
+
+		assertThatThrownBy(() -> service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.SHARE,
+				"https://bunjang.airbridge.io/goto?type=product&val=398473587",
 				null,
 				null,
 				null,


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-77**
- Jira: https://parkjaehong.atlassian.net/browse/NF-77 (있다면)

> PR 제목: `NF-77 지그재그/번개장터 브릿지 쇼핑 링크 가져오기 보완`
> 브랜치: `fix/NF-77-zigzag-airbridge-import`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #177

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- 지그재그 Airbridge 공유 링크가 실제 상품 URL까지 안정적으로 풀리지 않는 케이스가 있었습니다.
- 번개장터 공유/브릿지 링크는 실제 상품명이 아니라 사이트명 `번개장터`만 추출되거나 가격/이미지가 비는 문제가 있었습니다.
- 네이버는 이번 커밋의 신규 수정 대상이 아니라 기존 처리 로직이 깨지지 않았는지 회귀 검증했습니다.

### 왜 발생했나? (Root Cause)
- 지그재그 Airbridge 링크는 `deeplink_url`, `fallback_desktop` 등 브릿지 쿼리 키를 해석해야 실제 상품 URL로 이동할 수 있는데, 해당 키들이 기존 redirect 후보에 부족했습니다.
- 번개장터 `go.bgzt.link` / `bunjang.airbridge.io` 링크가 최종적으로 도달하는 번개장터 모바일 상품 페이지는 SPA shell HTML을 반환합니다.
- 번개장터 shell에는 상품 메타데이터가 없고 `<title>번개장터</title>` / 사이트 OG 태그만 있어 기존 HTML 메타 파서가 사이트명을 상품명처럼 읽었습니다.

### 어떻게 고쳤나?
- Airbridge 계열 호스트와 redirect query key를 보강해 지그재그 브릿지 링크가 `store.zigzag.kr` 상품 URL로 풀리도록 했습니다.
- 지그재그 Airbridge 사이트명 shell은 성공으로 취급하지 않도록 필터를 보강했습니다.
- 번개장터 Airbridge `type=product&val={id}` 쿼리를 모바일 상품 URL로 정규화했습니다.
- 번개장터 상품 shell을 감지하면 공개 웹 detail API(`/api/pms/v1/products/{id}/detail/web`)에서 상품명/가격/이미지/브랜드를 보강해 기존 메타 파서가 읽도록 했습니다.
- `bunjang.airbridge.io`, `go.bgzt.link` 사이트명 shell은 성공으로 취급하지 않도록 필터를 보강했습니다.
- `올립니다` 안의 `립`이 뷰티 키워드로 오인되는 부수 분류 문제도 좁게 보정했습니다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법(가능하면)
- Steps: `POST /api/v1/items/import-link`에 지그재그/번개장터 공유 링크 전달
- 기대 결과: 실제 상품 URL로 정규화되고 상품명/가격/이미지 등 메타데이터가 추출됨
- 실제 결과: 수정 전에는 브릿지/사이트 shell 메타가 읽히거나 부분 성공 처리될 수 있음

### 재발 방지(있다면)
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [ ] 런북/문서 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] AC1: 지그재그 Airbridge/단축 링크가 실제 지그재그 상품 URL로 정규화된다.
- [x] AC2: 번개장터 단축/브릿지 링크가 실제 모바일 상품 URL로 정규화된다.
- [x] AC3: 번개장터 상품명, 가격, 이미지, 브랜드가 추출된다.
- [x] AC4: 네이버/KREAM 기존 성공 케이스가 깨지지 않는다.

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `git diff --check`
- Result: 통과
- Command: `./gradlew test`
- Result: `BUILD SUCCESSFUL`
- Command: `./gradlew test --tests com.sagongsa.backend.itemimport.item.JsoupPageFetcherTest --tests com.sagongsa.backend.itemimport.item.ShoppingLinkImportServiceTest --tests com.sagongsa.backend.itemimport.item.FallbackPageFetcherTest`
- Result: `BUILD SUCCESSFUL`

### CI
- GitHub Actions `Gradle Test`: `SUCCESS`

### Smoke / 수동 검증
- 시나리오: 로컬 BE에서 `POST /api/v1/items/import-link` 실제 링크 호출
- 결과:
  - 지그재그 `https://s.zigzag.kr/V4z7MYxFDN`: `SUCCESS`, `74000`
  - 지그재그 `https://s.zigzag.kr/d98UNotp2M`: `SUCCESS`, `29900`
  - 지그재그 `https://s.zigzag.kr/sHxVvyecoJ`: `SUCCESS`, `45000`
  - 번개장터 `https://go.bgzt.link/amxvhhf`: `SUCCESS`, `100000`
  - 번개장터 `https://go.bgzt.link/c8z6zn`: `SUCCESS`, `190000`
  - 네이버 `https://naver.me/FriqITBp`: `SUCCESS`, `59900`
  - 네이버 `https://naver.me/5Ol9TotE`: `SUCCESS`, `169000`
  - KREAM `https://kream.co.kr/products/941062`: `SUCCESS`, `275000`

### 테스트 공백(있다면 이유 필수)
- 없음

---

## 🧭 영향 범위 (필수)
- [x] API 스펙 변경 없음
- [ ] API 스펙 변경 있음 (요약: )
- [x] DB 스키마 변경 없음
- [ ] DB 스키마 변경 있음 (마이그레이션/락/시간: )
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음 (항목: )
- [ ] 캐시/큐/외부 연동 영향 없음
- [x] 캐시/큐/외부 연동 영향 있음 (요약: 지그재그/번개장터 브릿지 링크 해석 보강, 번개장터 공개 웹 detail API를 상품 shell 보강 경로로 사용)

---

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음
- [ ] Breaking change 있음 → 무엇이 깨지는지 / 마이그레이션 / 롤아웃 전략:

---

## 🚀 배포/릴리즈 (해당 시 필수)
### Feature Flag
- [x] 사용 안함
- [ ] 사용함 → Flag/기본값/롤아웃:

### 모니터링/알림
- 확인할 대시보드/지표: import-link 4xx/5xx 응답 비율
- 에러/로그 키워드: `Unable to extract shopping item title`, `Unable to extract shopping metadata`, `Shopping page returned`

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 번개장터 공개 웹 detail API 응답 구조가 바뀌면 보강 추출이 실패할 수 있습니다. 이 경우 기존처럼 extraction failure로 떨어지도록 했습니다.
- 지그재그/번개장터 브릿지 링크의 쿼리 구조가 바뀌면 추가 보강이 필요할 수 있습니다.

### 롤백
- [ ] 플래그/설정으로 우회 가능
- [x] 배포 롤백(이전 태그/이미지) 가능
- [ ] 데이터 롤백/역마이그레이션 필요 (절차: )

---

## 📸 증빙 (선택)
- 실제 smoke 결과는 위 테스트 섹션에 기재했습니다.

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직: `JsoupPageFetcher`, `ShoppingLinkImportService`
- 트레이드오프/대안: 브라우저 렌더링으로 모든 SPA를 처리하기보다 브릿지 해석과 번개장터 detail API 보강을 좁게 적용해 속도와 안정성을 우선했습니다.
- 성능/보안/호환성 영향: 번개장터 상품 shell로 판단된 경우에만 추가 API 요청이 1회 발생하며, 요청 URL은 기존 public host 검증을 거칩니다.