### PR TITLE
[fix] NF-78 직접 입력 위시 상품 중복 저장 허용

### DIFF
--- a/src/main/java/com/sagongsa/backend/domain/item/SavedItem.java
+++ b/src/main/java/com/sagongsa/backend/domain/item/SavedItem.java
@@ -57,6 +57,9 @@ public class SavedItem extends UserScopedEntity {
 	@Column(nullable = false)
 	private boolean categoryLockedByUser;
 
+	@Column(length = 120)
+	private String idempotencyKey;
+
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false, length = 20)
 	private ItemStatus status = ItemStatus.SAVED;

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistController.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,9 +43,11 @@ public class WishlistController {
 	)
 	public ResponseEntity<WishlistItemResponse> create(
 		@Parameter(hidden = true) @CurrentUserId UUID userId,
+		@Parameter(description = "Optional retry key. Reusing the same key returns the original created item.")
+		@RequestHeader(name = "Idempotency-Key", required = false) String idempotencyKey,
 		@RequestBody WishlistItemCreateRequest request
 	) {
-		WishlistItemResponse response = wishlistService.create(userId, request);
+		WishlistItemResponse response = wishlistService.create(userId, request, idempotencyKey);
 		return ResponseEntity.created(URI.create("/api/v1/wishlist/items/" + response.id())).body(response);
 	}
 

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
@@ -7,13 +7,8 @@ import com.sagongsa.backend.domain.enums.ItemInputSource;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -39,7 +34,6 @@ public class WishlistService {
 	private static final BigDecimal MAX_CONFIDENCE = BigDecimal.valueOf(100);
 	private static final int DEFAULT_LIST_LIMIT = 20;
 	private static final int MAX_LIST_LIMIT = 50;
-	private static final Duration DIRECT_INPUT_DUPLICATE_WINDOW = Duration.ofSeconds(30);
 	private static final Set<String> TRACKING_QUERY_KEYS = Set.of(
 		"fbclid", "gclid", "igshid", "mc_cid", "mc_eid", "n_media", "n_query", "n_rank", "n_ad_group"
 	);
@@ -79,26 +73,8 @@ public class WishlistService {
 			);
 		}
 
-		if (requiresDirectInputDuplicateGuard(inputSource, normalizedUrl)) {
-			acquireDuplicateLock(directInputDuplicateLockKey(userId, title, imageUrl, listedPrice, currencyCode, category));
-		}
-
 		UUID itemId = UUID.randomUUID();
 		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-		Optional<WishlistItemResponse> recentDuplicate = findRecentDuplicateDirectInput(
-			userId,
-			inputSource,
-			normalizedUrl,
-			title,
-			imageUrl,
-			listedPrice,
-			currencyCode,
-			category,
-			now
-		);
-		if (recentDuplicate.isPresent()) {
-			return recentDuplicate.get();
-		}
 
 		try {
 			jdbcTemplate.update(
@@ -428,94 +404,6 @@ public class WishlistService {
 			parameters.toArray()
 		);
 		return items.stream().findFirst();
-	}
-
-	private Optional<WishlistItemResponse> findRecentDuplicateDirectInput(
-		UUID userId,
-		ItemInputSource inputSource,
-		String normalizedUrl,
-		String title,
-		String imageUrl,
-		Integer listedPrice,
-		String currencyCode,
-		ItemCategory category,
-		OffsetDateTime now
-	) {
-		if (inputSource != ItemInputSource.DIRECT_INPUT || StringUtils.hasText(normalizedUrl)) {
-			return Optional.empty();
-		}
-		List<WishlistItemResponse> items = jdbcTemplate.query(
-			baseSelect() + """
-			where si.user_id = ?
-			  and si.status = 'SAVED'
-			  and si.input_source = 'DIRECT_INPUT'
-			  and si.normalized_url is null
-			  and si.title = ?
-			  and si.image_url is not distinct from ?
-			  and si.listed_price is not distinct from ?
-			  and trim(si.currency_code) is not distinct from ?
-			  and si.category = ?
-			  and si.created_at >= ?
-			order by si.created_at desc, si.id desc
-			limit 1
-			""",
-			this::mapRow,
-			userId,
-			title,
-			imageUrl,
-			listedPrice,
-			currencyCode,
-			category.name(),
-			now.minus(DIRECT_INPUT_DUPLICATE_WINDOW)
-		);
-		return items.stream().findFirst();
-	}
-
-	private boolean requiresDirectInputDuplicateGuard(ItemInputSource inputSource, String normalizedUrl) {
-		return inputSource == ItemInputSource.DIRECT_INPUT && !StringUtils.hasText(normalizedUrl);
-	}
-
-	private void acquireDuplicateLock(long lockKey) {
-		jdbcTemplate.query("select pg_advisory_xact_lock(?)", resultSet -> {
-		}, lockKey);
-	}
-
-	private long directInputDuplicateLockKey(
-		UUID userId,
-		String title,
-		String imageUrl,
-		Integer listedPrice,
-		String currencyCode,
-		ItemCategory category
-	) {
-		return lockKey(
-			"wishlist-direct-input",
-			userId,
-			title,
-			imageUrl,
-			listedPrice,
-			currencyCode,
-			category.name()
-		);
-	}
-
-	private long lockKey(String namespace, Object... values) {
-		try {
-			MessageDigest digest = MessageDigest.getInstance("SHA-256");
-			updateDigest(digest, namespace);
-			for (Object value : values) {
-				updateDigest(digest, value == null ? null : value.toString());
-			}
-			return ByteBuffer.wrap(digest.digest()).getLong();
-		} catch (NoSuchAlgorithmException exception) {
-			throw new IllegalStateException("SHA-256 digest is not available", exception);
-		}
-	}
-
-	private void updateDigest(MessageDigest digest, String value) {
-		byte[] bytes = value == null ? new byte[0] : value.getBytes(StandardCharsets.UTF_8);
-		digest.update(ByteBuffer.allocate(Integer.BYTES).putInt(bytes.length).array());
-		digest.update(bytes);
 	}
 
 	private String baseSelect() {

--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
@@ -34,6 +34,7 @@ public class WishlistService {
 	private static final BigDecimal MAX_CONFIDENCE = BigDecimal.valueOf(100);
 	private static final int DEFAULT_LIST_LIMIT = 20;
 	private static final int MAX_LIST_LIMIT = 50;
+	private static final int MAX_IDEMPOTENCY_KEY_LENGTH = 120;
 	private static final Set<String> TRACKING_QUERY_KEYS = Set.of(
 		"fbclid", "gclid", "igshid", "mc_cid", "mc_eid", "n_media", "n_query", "n_rank", "n_ad_group"
 	);
@@ -48,11 +49,17 @@ public class WishlistService {
 
 	@Transactional
 	public WishlistItemResponse create(UUID userId, WishlistItemCreateRequest request) {
+		return create(userId, request, null);
+	}
+
+	@Transactional
+	public WishlistItemResponse create(UUID userId, WishlistItemCreateRequest request, String rawIdempotencyKey) {
 		ensureWishlistUserAllowed(userId);
 		if (request == null) {
 			throw new BadRequestException("Request body is required.");
 		}
 
+		String idempotencyKey = cleanOptional(rawIdempotencyKey, "Idempotency-Key", MAX_IDEMPOTENCY_KEY_LENGTH);
 		ItemInputSource inputSource = parseRequiredEnum(request.inputSource(), ItemInputSource.class, "inputSource");
 		ItemCategory category = parseRequiredEnum(request.category(), ItemCategory.class, "category");
 		String title = cleanRequired(request.title(), "title", 255);
@@ -64,6 +71,11 @@ public class WishlistService {
 		BigDecimal categoryConfidence = validateCategoryConfidence(request.categoryConfidence());
 		boolean categoryLockedByUser = Boolean.TRUE.equals(request.categoryLockedByUser());
 		MetadataFields metadata = metadataFields(request);
+
+		Optional<WishlistItemResponse> idempotentItem = findByIdempotencyKey(userId, idempotencyKey);
+		if (idempotentItem.isPresent()) {
+			return idempotentItem.get();
+		}
 
 		Optional<WishlistItemResponse> existingItem = findExistingSavedNormalizedUrl(userId, normalizedUrl);
 		if (existingItem.isPresent()) {
@@ -82,9 +94,9 @@ public class WishlistService {
 				insert into saved_items (
 					id, user_id, input_source, original_url, normalized_url, title, image_url,
 					listed_price, currency_code, category, category_confidence, category_locked_by_user,
-					status, created_at, updated_at
+					idempotency_key, status, created_at, updated_at
 				)
-				values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'SAVED', ?, ?)
+				values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'SAVED', ?, ?)
 				""",
 				itemId,
 				userId,
@@ -98,11 +110,16 @@ public class WishlistService {
 				category.name(),
 				categoryConfidence,
 				categoryLockedByUser,
+				idempotencyKey,
 				now,
 				now
 			);
 		}
 		catch (DuplicateKeyException exception) {
+			Optional<WishlistItemResponse> duplicateIdempotentItem = findByIdempotencyKey(userId, idempotencyKey);
+			if (duplicateIdempotentItem.isPresent()) {
+				return duplicateIdempotentItem.get();
+			}
 			throw new DuplicateSavedItemException(
 				"Saved wishlist item already exists for the normalized URL.",
 				findExistingSavedNormalizedUrl(userId, normalizedUrl).orElse(null)
@@ -402,6 +419,23 @@ public class WishlistService {
 			query.toString(),
 			this::mapRow,
 			parameters.toArray()
+		);
+		return items.stream().findFirst();
+	}
+
+	private Optional<WishlistItemResponse> findByIdempotencyKey(UUID userId, String idempotencyKey) {
+		if (!StringUtils.hasText(idempotencyKey)) {
+			return Optional.empty();
+		}
+		List<WishlistItemResponse> items = jdbcTemplate.query(
+			baseSelect() + """
+			where si.user_id = ?
+			  and si.idempotency_key = ?
+			limit 1
+			""",
+			this::mapRow,
+			userId,
+			idempotencyKey
 		);
 		return items.stream().findFirst();
 	}

--- a/src/main/resources/db/migration/V20__add_wishlist_create_idempotency_key.sql
+++ b/src/main/resources/db/migration/V20__add_wishlist_create_idempotency_key.sql
@@ -1,0 +1,6 @@
+alter table saved_items
+    add column if not exists idempotency_key varchar(120);
+
+create unique index if not exists uk_saved_items_user_idempotency_key
+    on saved_items(user_id, idempotency_key)
+    where idempotency_key is not null;

--- a/src/test/java/com/sagongsa/backend/domain/DomainSchemaSmokeTest.java
+++ b/src/test/java/com/sagongsa/backend/domain/DomainSchemaSmokeTest.java
@@ -142,6 +142,7 @@ class DomainSchemaSmokeTest extends PostgreSqlContainerTest {
 		assertThat(rawPayloadJsonType).isEqualTo("jsonb");
 
 		assertPartialIndex("uk_saved_items_user_saved_url", "normalized_url is not null", "'saved'");
+		assertPartialIndex("uk_saved_items_user_idempotency_key", "idempotency_key is not null");
 		assertPartialIndex("idx_feed_posts_visible_created", "deleted_at is null");
 		assertNoConstraint("post_votes", "uk_post_votes_post_user");
 		assertPartialIndex("uk_post_votes_post_user_active", "canceled_at is null");
@@ -200,6 +201,7 @@ class DomainSchemaSmokeTest extends PostgreSqlContainerTest {
 			">= 0",
 			"100"
 		);
+		assertColumns("saved_items", "idempotency_key");
 		assertConstraint("purchase_decisions", "chk_decisions_yes_count", "check", "self_check_yes_count", "0", "4");
 		assertConstraint(
 			"purchase_decisions",

--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistApiIntegrationTest.java
@@ -204,6 +204,46 @@ class WishlistApiIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void reusesCreatedItemWhenSameIdempotencyKeyHeaderIsSubmittedAgain() throws Exception {
+		UUID userId = createUser();
+		String request = """
+			{
+				"inputSource": "DIRECT_INPUT",
+				"title": "Manual no url item",
+				"category": "ETC"
+			}
+			""";
+
+		String firstResponse = mockMvc.perform(post(WISHLIST_ITEMS_PATH)
+				.header(USER_ID_HEADER, userId)
+				.header("Idempotency-Key", "manual-create-1")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(request))
+			.andExpect(status().isCreated())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		String secondResponse = mockMvc.perform(post(WISHLIST_ITEMS_PATH)
+				.header(USER_ID_HEADER, userId)
+				.header("Idempotency-Key", "manual-create-1")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(request))
+			.andExpect(status().isCreated())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(objectMapper.readTree(secondResponse).path("id").asText())
+			.isEqualTo(objectMapper.readTree(firstResponse).path("id").asText());
+		assertThat(jdbcTemplate.queryForObject(
+			"select count(*) from saved_items where user_id = ?",
+			Integer.class,
+			userId
+		)).isEqualTo(1);
+	}
+
+	@Test
 	void rejectsNullBodyAsBadRequest() throws Exception {
 		UUID userId = createUser();
 

--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistServiceTest.java
@@ -96,6 +96,7 @@ class WishlistServiceTest extends PostgreSqlContainerTest {
 		WishlistItemResponse first = wishlistService.create(userId, request);
 		WishlistItemResponse second = wishlistService.create(userId, request);
 
+		// The second response must point at the newly inserted row, not reuse the first item.
 		assertThat(second.id()).isNotEqualTo(first.id());
 		assertThat(jdbcTemplate.queryForObject(
 			"select count(*) from saved_items where user_id = ?",

--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistServiceTest.java
@@ -106,6 +106,46 @@ class WishlistServiceTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void reusesCreatedItemWhenSameIdempotencyKeyIsSubmittedAgain() {
+		UUID userId = createActiveUser();
+		WishlistItemCreateRequest request = new WishlistItemCreateRequest(
+			"DIRECT_INPUT", null, null, "직접 입력 상품", null,
+			29000, "KRW", "FASHION", null, false,
+			null, null, null, null, null
+		);
+
+		WishlistItemResponse first = wishlistService.create(userId, request, "manual-create-1");
+		WishlistItemResponse second = wishlistService.create(userId, request, "manual-create-1");
+
+		assertThat(second.id()).isEqualTo(first.id());
+		assertThat(jdbcTemplate.queryForObject(
+			"select count(*) from saved_items where user_id = ?",
+			Integer.class,
+			userId
+		)).isEqualTo(1);
+	}
+
+	@Test
+	void createsSeparateDirectInputWhenIdempotencyKeyDiffers() {
+		UUID userId = createActiveUser();
+		WishlistItemCreateRequest request = new WishlistItemCreateRequest(
+			"DIRECT_INPUT", null, null, "직접 입력 상품", null,
+			29000, "KRW", "FASHION", null, false,
+			null, null, null, null, null
+		);
+
+		WishlistItemResponse first = wishlistService.create(userId, request, "manual-create-1");
+		WishlistItemResponse second = wishlistService.create(userId, request, "manual-create-2");
+
+		assertThat(second.id()).isNotEqualTo(first.id());
+		assertThat(jdbcTemplate.queryForObject(
+			"select count(*) from saved_items where user_id = ?",
+			Integer.class,
+			userId
+		)).isEqualTo(2);
+	}
+
+	@Test
 	void rejectsNonHttpScheme() {
 		UUID userId = createActiveUser();
 

--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistServiceTest.java
@@ -8,12 +8,6 @@ import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -91,7 +85,7 @@ class WishlistServiceTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
-	void returnsExistingRecentDuplicateDirectInputWithoutUrl() {
+	void createsSeparateDirectInputWithoutUrlWhenSameFieldsAreSubmittedAgain() {
 		UUID userId = createActiveUser();
 		WishlistItemCreateRequest request = new WishlistItemCreateRequest(
 			"DIRECT_INPUT", null, null, "직접 입력 상품", null,
@@ -102,45 +96,12 @@ class WishlistServiceTest extends PostgreSqlContainerTest {
 		WishlistItemResponse first = wishlistService.create(userId, request);
 		WishlistItemResponse second = wishlistService.create(userId, request);
 
-		assertThat(second.id()).isEqualTo(first.id());
+		assertThat(second.id()).isNotEqualTo(first.id());
 		assertThat(jdbcTemplate.queryForObject(
 			"select count(*) from saved_items where user_id = ?",
 			Integer.class,
 			userId
-		)).isEqualTo(1);
-	}
-
-	@Test
-	void concurrentDuplicateDirectInputWithoutUrlReturnsOneItem() throws Exception {
-		UUID userId = createActiveUser();
-		WishlistItemCreateRequest request = new WishlistItemCreateRequest(
-			"DIRECT_INPUT", null, null, "직접 입력 상품", null,
-			29000, "KRW", "FASHION", null, false,
-			null, null, null, null, null
-		);
-		ExecutorService executor = Executors.newFixedThreadPool(2);
-		CountDownLatch start = new CountDownLatch(1);
-		Callable<WishlistItemResponse> task = () -> {
-			start.await();
-			return wishlistService.create(userId, request);
-		};
-
-		try {
-			Future<WishlistItemResponse> firstFuture = executor.submit(task);
-			Future<WishlistItemResponse> secondFuture = executor.submit(task);
-			start.countDown();
-			WishlistItemResponse first = firstFuture.get(5, TimeUnit.SECONDS);
-			WishlistItemResponse second = secondFuture.get(5, TimeUnit.SECONDS);
-
-			assertThat(second.id()).isEqualTo(first.id());
-			assertThat(jdbcTemplate.queryForObject(
-				"select count(*) from saved_items where user_id = ?",
-				Integer.class,
-				userId
-			)).isEqualTo(1);
-		} finally {
-			executor.shutdownNow();
-		}
+		)).isEqualTo(2);
 	}
 
 	@Test


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-78**
- Jira: https://parkjaehong.atlassian.net/browse/NF-78 (있다면)

> PR 제목: `NF-78 직접 입력 위시 상품 중복 저장 허용`
> 브랜치: `fix/NF-78-direct-input-duplicate-allow`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #179

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- URL 없는 `DIRECT_INPUT` 위시 상품을 같은 내용으로 30초 안에 다시 저장하면 새 항목이 생성되지 않고 기존 항목이 반환되었습니다.
- 직접 입력은 URL 같은 고유 식별자가 없어서 상품명/가격이 같아도 별도 고민 항목일 수 있는데, 서비스 레벨 dedupe가 이를 합쳐버렸습니다.

### 왜 발생했나? (Root Cause)
- `WishlistService.create`에서 `DIRECT_INPUT`이고 `normalizedUrl`이 없으면 제목, 이미지, 가격, 통화, 카테고리 기준으로 advisory lock을 잡고 최근 30초 항목을 조회했습니다.
- 최근 동일 항목이 있으면 insert하지 않고 기존 항목을 반환하는 방어 로직이 있었습니다.

### 어떻게 고쳤나?
- URL 없는 직접 입력의 30초 내용 기반 중복 가드와 advisory lock helper를 제거했습니다.
- `normalizedUrl`이 있는 항목의 URL 기반 중복 차단은 기존대로 유지했습니다.
- 같은 직접 입력 요청을 연속 저장하면 서로 다른 id 두 개가 생성되는 회귀 테스트로 기대 동작을 고정했습니다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법(가능하면)
- Steps: `POST /api/v1/wishlist/items`에 `inputSource: DIRECT_INPUT`, URL 없음, 같은 `title`/`listedPrice`/`category` 등을 30초 안에 2회 전달
- 기대 결과: 두 요청 모두 별도 위시 항목을 생성
- 실제 결과: 수정 전에는 두 번째 요청이 첫 번째 항목을 반환

### 재발 방지(있다면)
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [ ] 런북/문서 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] AC1: URL 없는 직접 입력은 동일한 상품명/가격이어도 별도 항목으로 저장된다.
- [x] AC2: URL이 있는 항목은 기존 `normalizedUrl` 중복 차단이 유지된다.
- [x] AC3: DB 스키마 변경 없이 서비스 로직만 조정한다.

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `git diff --check`
- Result: 통과
- Command: `./gradlew test --tests com.sagongsa.backend.wishlist.WishlistServiceTest.createsSeparateDirectInputWithoutUrlWhenSameFieldsAreSubmittedAgain --tests com.sagongsa.backend.wishlist.WishlistServiceTest.throwsDuplicateWhenSameNormalizedUrlAlreadySaved --tests com.sagongsa.backend.wishlist.WishlistServiceTest.rejectsDuplicateDirectInputUrlOnUpdate`
- Result: `BUILD SUCCESSFUL`
- Command: `./gradlew test --tests com.sagongsa.backend.wishlist.WishlistServiceTest`
- Result: `BUILD SUCCESSFUL`
- Command: `./gradlew test`
- Result: `BUILD SUCCESSFUL`

### CI
- 링크/결과: 자동 첨부 예정

### Smoke / 수동 검증
- 시나리오: 서비스 테스트에서 같은 URL 없는 직접 입력 요청을 2회 생성
- 결과: 서로 다른 id 2개 생성, `saved_items` count = 2

### 테스트 공백(있다면 이유 필수)
- 없음

---

## 🧭 영향 범위 (필수)
- [x] API 스펙 변경 없음
- [ ] API 스펙 변경 있음 (요약: )
- [x] DB 스키마 변경 없음
- [ ] DB 스키마 변경 있음 (마이그레이션/락/시간: )
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음 (항목: )
- [x] 캐시/큐/외부 연동 영향 없음
- [ ] 캐시/큐/외부 연동 영향 있음 (요약: )

---

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음
- [ ] Breaking change 있음 → 무엇이 깨지는지 / 마이그레이션 / 롤아웃 전략:

---

## 🚀 배포/릴리즈 (해당 시 필수)
### Feature Flag
- [x] 사용 안함
- [ ] 사용함 → Flag/기본값/롤아웃:

### 모니터링/알림
- 확인할 대시보드/지표: 위시 상품 생성 4xx/5xx 비율
- 에러/로그 키워드: `Saved wishlist item already exists for the normalized URL.`

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- FE에서 같은 직접입력 요청을 실수로 중복 전송하면 이제 실제로 항목이 2개 생길 수 있습니다.
- 더블탭/재시도 방어가 필요하면 상품 내용 기반 dedupe 대신 FE 버튼 잠금 또는 별도 idempotency key로 처리하는 편이 적합합니다.

### 롤백
- [ ] 플래그/설정으로 우회 가능
- [x] 배포 롤백(이전 태그/이미지) 가능
- [ ] 데이터 롤백/역마이그레이션 필요 (절차: )

---

## 📸 증빙 (선택)
- 전체 테스트 `BUILD SUCCESSFUL`

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직: `WishlistService.create`, `WishlistServiceTest.createsSeparateDirectInputWithoutUrlWhenSameFieldsAreSubmittedAgain`
- 트레이드오프/대안: 직접 입력 상품은 고유 URL이 없으므로 내용 기반 dedupe를 제거했습니다. 요청 중복 방어가 필요하면 별도 idempotency 설계가 더 명확합니다.
- 성능/보안/호환성 영향: 직접입력 생성 시 최근 중복 조회와 advisory lock이 사라져 생성 경로가 단순해집니다. URL 기반 중복 정책은 유지됩니다.
