### PR TITLE
[fix] NF-82 쇼핑 링크 필수 메타데이터 정확성 보완

### DIFF
--- a/docs/SHOPPING_BROWSER_FETCHER_OPERATIONS.md
+++ b/docs/SHOPPING_BROWSER_FETCHER_OPERATIONS.md
@@ -20,6 +20,14 @@
 - 이미지 빌드 단계에서 Playwright CLI로 Chromium을 미리 설치해 첫 요청 지연을 피한다.
 - 브라우저 수집은 정적 HTML 수집보다 비용이 크므로, 운영 활성화 전 응답 시간과 실패율을 별도 샘플로 확인한다.
 
+## KREAM 전용 프록시
+
+- KREAM이 배포 서버의 출구 IP에 빈 5xx를 반환하는 환경에서만 전용 프록시를 활성화한다.
+- `SHOPPING_IMPORT_KREAM_PROXY_ENABLED=true`, `SHOPPING_IMPORT_KREAM_PROXY_TYPE=SOCKS|HTTP`, `SHOPPING_IMPORT_KREAM_PROXY_HOST`, `SHOPPING_IMPORT_KREAM_PROXY_PORT`를 설정한다.
+- 프록시는 KREAM 및 KREAM API 호스트에만 적용되며 다른 쇼핑몰 요청은 기존 출구를 유지한다.
+- 인증 없는 내부 프록시를 전제로 하므로 방화벽에서 백엔드 서버 IP만 접근 가능하게 제한한다.
+- 활성화 전후로 동일 상품을 순차/동시 호출해 제목, 양수 가격, 유효 이미지와 5xx/429 여부를 확인한다.
+
 ## 검증 포인트
 
 - 플래그를 끄면 `JsoupPageFetcher`만 선택된다.

--- a/src/main/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcher.java
@@ -28,6 +28,7 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 			+ "(KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
 
 	private final ShoppingImportProperties.BrowserFetch properties;
+	private final ShoppingImportProperties.KreamProxy kreamProxy;
 	private final int maxResponseBytes;
 	private final Supplier<Playwright> playwrightFactory;
 	private final Object browserLock = new Object();
@@ -35,25 +36,35 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 	private Browser browser;
 
 	public BrowserPageFetcher(ShoppingImportProperties.BrowserFetch properties) {
-		this(properties, Playwright::create, 1_000_000);
+		this(properties, Playwright::create, 1_000_000, new ShoppingImportProperties.KreamProxy());
 	}
 
 	public BrowserPageFetcher(ShoppingImportProperties.BrowserFetch properties, int maxResponseBytes) {
-		this(properties, Playwright::create, maxResponseBytes);
+		this(properties, Playwright::create, maxResponseBytes, new ShoppingImportProperties.KreamProxy());
+	}
+
+	public BrowserPageFetcher(
+		ShoppingImportProperties.BrowserFetch properties,
+		int maxResponseBytes,
+		ShoppingImportProperties.KreamProxy kreamProxy
+	) {
+		this(properties, Playwright::create, maxResponseBytes, kreamProxy);
 	}
 
 	BrowserPageFetcher(ShoppingImportProperties.BrowserFetch properties, Supplier<Playwright> playwrightFactory) {
-		this(properties, playwrightFactory, 1_000_000);
+		this(properties, playwrightFactory, 1_000_000, new ShoppingImportProperties.KreamProxy());
 	}
 
 	BrowserPageFetcher(
 		ShoppingImportProperties.BrowserFetch properties,
 		Supplier<Playwright> playwrightFactory,
-		int maxResponseBytes
+		int maxResponseBytes,
+		ShoppingImportProperties.KreamProxy kreamProxy
 	) {
 		this.properties = properties;
 		this.playwrightFactory = playwrightFactory;
 		this.maxResponseBytes = maxResponseBytes <= 0 ? 1_000_000 : maxResponseBytes;
+		this.kreamProxy = kreamProxy == null ? new ShoppingImportProperties.KreamProxy() : kreamProxy;
 	}
 
 	@Override
@@ -148,25 +159,36 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 		}
 	}
 
-	private Browser.NewContextOptions contextOptions(URI uri) {
+	Browser.NewContextOptions contextOptions(URI uri) {
+		Browser.NewContextOptions options;
 		if (isAblyMobileUri(uri)) {
-			return new Browser.NewContextOptions()
+			options = new Browser.NewContextOptions()
 				.setUserAgent(IOS_MOBILE_USER_AGENT)
 				.setLocale(properties.getLocale())
 				.setViewportSize(390, 844)
 				.setDeviceScaleFactor(3)
 				.setIsMobile(true)
 				.setHasTouch(true);
+		} else {
+			options = new Browser.NewContextOptions()
+				.setUserAgent(properties.getUserAgent())
+				.setLocale(properties.getLocale())
+				.setViewportSize(properties.getViewportWidth(), properties.getViewportHeight());
 		}
-		return new Browser.NewContextOptions()
-			.setUserAgent(properties.getUserAgent())
-			.setLocale(properties.getLocale())
-			.setViewportSize(properties.getViewportWidth(), properties.getViewportHeight());
+		if (kreamProxy.isConfigured() && isKreamUri(uri)) {
+			options.setProxy(kreamProxy.browserServer());
+		}
+		return options;
 	}
 
 	private boolean isAblyMobileUri(URI uri) {
 		String host = Optional.ofNullable(uri.getHost()).orElse("").toLowerCase(Locale.ROOT);
 		return ABLY_MOBILE_HOST.equals(host);
+	}
+
+	private boolean isKreamUri(URI uri) {
+		String host = Optional.ofNullable(uri.getHost()).orElse("").toLowerCase(Locale.ROOT);
+		return host.equals("kream.co.kr") || host.endsWith(".kream.co.kr");
 	}
 
 	private void waitForNetworkIdle(Page page) {

--- a/src/main/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcher.java
@@ -8,8 +8,11 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jsoup.Connection;
@@ -28,8 +31,12 @@ public class JsoupPageFetcher implements PageFetcher {
 	private static final int DEFAULT_MAX_ATTEMPTS = 2;
 	private static final int DEFAULT_MAX_RESPONSE_BYTES = 1_000_000;
 	private static final int MAX_REDIRECTS = 5;
+	private static final int KREAM_API_TIMEOUT_MILLIS = 3_000;
 	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 	private static final Pattern BUNJANG_PRODUCT_PATH_PATTERN = Pattern.compile("^/products/(\\d+)(?:/.*)?$");
+	private static final Pattern KREAM_PRODUCT_PATH_PATTERN = Pattern.compile("^/products/(\\d+)(?:/.*)?$");
+	private static final DateTimeFormatter KREAM_CLIENT_DATETIME_FORMATTER =
+		DateTimeFormatter.ofPattern("yyyyMMddHHmmssXX");
 	private static final Pattern JS_HTTP_ASSIGNMENT_PATTERN = Pattern.compile(
 		"(?is)\\b(?:var|let|const)\\s+(store_link|fallback_url|fallbackUrl|target_url|targetUrl|web_url|webUrl|product_url|productUrl|landing_url|landingUrl|redirect_url|redirectUrl|af_android_url|af_ios_url|af_web_dp)\\s*=\\s*(['\"])(https?://.*?)\\2"
 	);
@@ -73,6 +80,15 @@ public class JsoupPageFetcher implements PageFetcher {
 
 	@Override
 	public FetchedPage fetch(URI uri) {
+		try {
+			Optional<FetchedPage> kreamProductPage = kreamProductApiPage(uri);
+			if (kreamProductPage.isPresent()) {
+				return kreamProductPage.get();
+			}
+		} catch (IOException ignored) {
+			// Continue with the regular HTML and browser fallback path.
+		}
+
 		ResponseStatusException lastStatusException = null;
 		IOException lastIoException = null;
 
@@ -363,6 +379,94 @@ public class JsoupPageFetcher implements PageFetcher {
 
 		return bunjangProductMetadataHtml(apiResponse.body())
 			.map(html -> new FetchedPage(requestedUri, finalUri, 200, "text/html; charset=UTF-8", html));
+	}
+
+	private Optional<FetchedPage> kreamProductApiPage(URI requestedUri) throws IOException {
+		Optional<String> productId = kreamProductId(requestedUri);
+		if (productId.isEmpty()) {
+			return Optional.empty();
+		}
+
+		URI apiUri = URI.create("https://api.kream.co.kr/api/p/products/" + productId.get());
+		ShoppingUrlSafety.validatePublicHost(apiUri);
+		String deviceId = "web;" + UUID.randomUUID();
+		Connection.Response apiResponse = Jsoup.connect(apiUri.toString())
+			.userAgent(ANDROID_USER_AGENT)
+			.header("Accept", "application/json, text/plain, */*")
+			.header("Accept-Language", "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7")
+			.header("Origin", "https://kream.co.kr")
+			.header("Referer", requestedUri.toString())
+			.header("X-KREAM-DEVICE-ID", deviceId)
+			.header("X-KREAM-CLIENT-DATETIME", OffsetDateTime.now().format(KREAM_CLIENT_DATETIME_FORMATTER))
+			.header("X-KREAM-API-VERSION", "61")
+			.header("X-KREAM-WEB-REQUEST-SECRET", "kream-djscjsghdkd")
+			.header("X-KREAM-WEB-BUILD-VERSION", "26.9.3")
+			.ignoreContentType(true)
+			.ignoreHttpErrors(true)
+			.timeout(Math.min(timeoutMillis, KREAM_API_TIMEOUT_MILLIS))
+			.maxBodySize(maxResponseBytes)
+			.execute();
+
+		if (apiResponse.statusCode() >= 400) {
+			return Optional.empty();
+		}
+		enforceBodySize(apiResponse.body());
+		return kreamProductMetadataHtml(apiResponse.body())
+			.map(html -> new FetchedPage(requestedUri, requestedUri, 200, "text/html; charset=UTF-8", html));
+	}
+
+	private static Optional<String> kreamProductId(URI uri) {
+		String host = Optional.ofNullable(uri.getHost()).orElse("").toLowerCase(Locale.ROOT);
+		if (!host.equals("kream.co.kr") && !host.equals("www.kream.co.kr")) {
+			return Optional.empty();
+		}
+		String path = Optional.ofNullable(uri.getPath()).orElse("");
+		Matcher matcher = KREAM_PRODUCT_PATH_PATTERN.matcher(path);
+		return matcher.matches() ? Optional.of(matcher.group(1)) : Optional.empty();
+	}
+
+	static Optional<String> kreamProductMetadataHtml(String apiBody) {
+		if (apiBody == null || apiBody.isBlank()) {
+			return Optional.empty();
+		}
+		try {
+			JsonNode root = OBJECT_MAPPER.readTree(apiBody);
+			JsonNode release = root.path("release");
+			String title = firstNonBlank(jsonText(release, "translated_name"), jsonText(release, "name"));
+			String price = jsonText(root, "market", "lowest_ask");
+			String imageUrl = firstJsonArrayText(release.path("image_urls"));
+			String brandName = firstNonBlank(
+				jsonText(release, "brand", "translated_name"),
+				jsonText(release, "brand", "name")
+			);
+			if (isBlank(title) && isBlank(price) && isBlank(imageUrl)) {
+				return Optional.empty();
+			}
+
+			StringBuilder html = new StringBuilder("<!doctype html><html><head>");
+			html.append("<title>").append(escapeHtml(firstNonBlank(title, "KREAM 상품"))).append("</title>");
+			appendPropertyMeta(html, "og:title", title);
+			appendPropertyMeta(html, "og:image", imageUrl);
+			appendPropertyMeta(html, "product:price:amount", price);
+			appendPropertyMeta(html, "kakao:commerce:brand_name", brandName);
+			html.append("</head><body></body></html>");
+			return Optional.of(html.toString());
+		} catch (JsonProcessingException exception) {
+			return Optional.empty();
+		}
+	}
+
+	private static String firstJsonArrayText(JsonNode node) {
+		if (!node.isArray()) {
+			return null;
+		}
+		for (JsonNode value : node) {
+			String text = value.asText();
+			if (!isBlank(text)) {
+				return text.trim();
+			}
+		}
+		return null;
 	}
 
 	private static boolean isBunjangProductShell(URI uri, String contentType, String body) {

--- a/src/main/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcher.java
@@ -59,23 +59,38 @@ public class JsoupPageFetcher implements PageFetcher {
 	private final int timeoutMillis;
 	private final int maxAttempts;
 	private final int maxResponseBytes;
+	private final ShoppingImportProperties.KreamProxy kreamProxy;
 
 	public JsoupPageFetcher() {
 		this(DEFAULT_MAX_RESPONSE_BYTES);
 	}
 
 	JsoupPageFetcher(int maxResponseBytes) {
-		this(DEFAULT_TIMEOUT_MILLIS, DEFAULT_MAX_ATTEMPTS, maxResponseBytes);
+		this(maxResponseBytes, new ShoppingImportProperties.KreamProxy());
+	}
+
+	JsoupPageFetcher(int maxResponseBytes, ShoppingImportProperties.KreamProxy kreamProxy) {
+		this(DEFAULT_TIMEOUT_MILLIS, DEFAULT_MAX_ATTEMPTS, maxResponseBytes, kreamProxy);
 	}
 
 	JsoupPageFetcher(int timeoutMillis, int maxAttempts) {
-		this(timeoutMillis, maxAttempts, DEFAULT_MAX_RESPONSE_BYTES);
+		this(timeoutMillis, maxAttempts, DEFAULT_MAX_RESPONSE_BYTES, new ShoppingImportProperties.KreamProxy());
 	}
 
 	JsoupPageFetcher(int timeoutMillis, int maxAttempts, int maxResponseBytes) {
+		this(timeoutMillis, maxAttempts, maxResponseBytes, new ShoppingImportProperties.KreamProxy());
+	}
+
+	JsoupPageFetcher(
+		int timeoutMillis,
+		int maxAttempts,
+		int maxResponseBytes,
+		ShoppingImportProperties.KreamProxy kreamProxy
+	) {
 		this.timeoutMillis = timeoutMillis <= 0 ? DEFAULT_TIMEOUT_MILLIS : timeoutMillis;
 		this.maxAttempts = maxAttempts <= 0 ? DEFAULT_MAX_ATTEMPTS : maxAttempts;
 		this.maxResponseBytes = maxResponseBytes <= 0 ? DEFAULT_MAX_RESPONSE_BYTES : maxResponseBytes;
+		this.kreamProxy = kreamProxy == null ? new ShoppingImportProperties.KreamProxy() : kreamProxy;
 	}
 
 	@Override
@@ -123,7 +138,7 @@ public class JsoupPageFetcher implements PageFetcher {
 				currentUri = queryRedirect.get();
 				continue;
 			}
-			Connection.Response response = Jsoup.connect(currentUri.toString())
+			Connection connection = Jsoup.connect(currentUri.toString())
 				.userAgent(ANDROID_USER_AGENT)
 				.header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
 				.header("Accept-Language", "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7")
@@ -132,8 +147,9 @@ public class JsoupPageFetcher implements PageFetcher {
 				.ignoreContentType(true)
 				.ignoreHttpErrors(true)
 				.timeout(timeoutMillis)
-				.maxBodySize(maxResponseBytes)
-				.execute();
+				.maxBodySize(maxResponseBytes);
+			applyKreamProxy(connection, currentUri);
+			Connection.Response response = connection.execute();
 
 			if (isRedirect(response.statusCode())) {
 				String location = response.header("Location");
@@ -390,7 +406,7 @@ public class JsoupPageFetcher implements PageFetcher {
 		URI apiUri = URI.create("https://api.kream.co.kr/api/p/products/" + productId.get());
 		ShoppingUrlSafety.validatePublicHost(apiUri);
 		String deviceId = "web;" + UUID.randomUUID();
-		Connection.Response apiResponse = Jsoup.connect(apiUri.toString())
+		Connection connection = Jsoup.connect(apiUri.toString())
 			.userAgent(ANDROID_USER_AGENT)
 			.header("Accept", "application/json, text/plain, */*")
 			.header("Accept-Language", "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7")
@@ -404,8 +420,9 @@ public class JsoupPageFetcher implements PageFetcher {
 			.ignoreContentType(true)
 			.ignoreHttpErrors(true)
 			.timeout(Math.min(timeoutMillis, KREAM_API_TIMEOUT_MILLIS))
-			.maxBodySize(maxResponseBytes)
-			.execute();
+			.maxBodySize(maxResponseBytes);
+		applyKreamProxy(connection, apiUri);
+		Connection.Response apiResponse = connection.execute();
 
 		if (apiResponse.statusCode() >= 400) {
 			return Optional.empty();
@@ -423,6 +440,17 @@ public class JsoupPageFetcher implements PageFetcher {
 		String path = Optional.ofNullable(uri.getPath()).orElse("");
 		Matcher matcher = KREAM_PRODUCT_PATH_PATTERN.matcher(path);
 		return matcher.matches() ? Optional.of(matcher.group(1)) : Optional.empty();
+	}
+
+	private void applyKreamProxy(Connection connection, URI uri) {
+		if (kreamProxy.isConfigured() && isKreamHost(uri)) {
+			connection.proxy(kreamProxy.javaProxy());
+		}
+	}
+
+	private static boolean isKreamHost(URI uri) {
+		String host = Optional.ofNullable(uri.getHost()).orElse("").toLowerCase(Locale.ROOT);
+		return host.equals("kream.co.kr") || host.endsWith(".kream.co.kr");
 	}
 
 	static Optional<String> kreamProductMetadataHtml(String apiBody) {

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportConfig.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportConfig.java
@@ -11,9 +11,14 @@ public class ShoppingImportConfig {
 	@Bean
 	public PageFetcher pageFetcher(ShoppingImportProperties properties) {
 		ShoppingImportProperties.BrowserFetch browserFetch = properties.getBrowserFetch();
-		JsoupPageFetcher jsoupPageFetcher = new JsoupPageFetcher(properties.getMaxResponseBytes());
+		ShoppingImportProperties.KreamProxy kreamProxy = properties.getKreamProxy();
+		kreamProxy.validate();
+		JsoupPageFetcher jsoupPageFetcher = new JsoupPageFetcher(properties.getMaxResponseBytes(), kreamProxy);
 		if (browserFetch.isEnabled()) {
-			return new FallbackPageFetcher(jsoupPageFetcher, new BrowserPageFetcher(browserFetch, properties.getMaxResponseBytes()));
+			return new FallbackPageFetcher(
+				jsoupPageFetcher,
+				new BrowserPageFetcher(browserFetch, properties.getMaxResponseBytes(), kreamProxy)
+			);
 		}
 		return jsoupPageFetcher;
 	}

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportProperties.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportProperties.java
@@ -1,5 +1,7 @@
 package com.sagongsa.backend.itemimport.item;
 
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -8,6 +10,7 @@ public class ShoppingImportProperties {
 
 	private int maxResponseBytes = 1_000_000;
 	private final BrowserFetch browserFetch = new BrowserFetch();
+	private final KreamProxy kreamProxy = new KreamProxy();
 
 	public int getMaxResponseBytes() {
 		return maxResponseBytes;
@@ -19,6 +22,75 @@ public class ShoppingImportProperties {
 
 	public BrowserFetch getBrowserFetch() {
 		return browserFetch;
+	}
+
+	public KreamProxy getKreamProxy() {
+		return kreamProxy;
+	}
+
+	public static class KreamProxy {
+
+		private boolean enabled;
+		private Type type = Type.SOCKS;
+		private String host;
+		private int port = 1080;
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public Type getType() {
+			return type;
+		}
+
+		public void setType(Type type) {
+			this.type = type == null ? Type.SOCKS : type;
+		}
+
+		public String getHost() {
+			return host;
+		}
+
+		public void setHost(String host) {
+			this.host = host == null ? null : host.trim();
+		}
+
+		public int getPort() {
+			return port;
+		}
+
+		public void setPort(int port) {
+			this.port = port;
+		}
+
+		boolean isConfigured() {
+			return enabled && host != null && !host.isBlank() && port > 0 && port <= 65_535;
+		}
+
+		void validate() {
+			if (enabled && !isConfigured()) {
+				throw new IllegalStateException("KREAM proxy requires a host and a valid port");
+			}
+		}
+
+		Proxy javaProxy() {
+			Proxy.Type proxyType = type == Type.HTTP ? Proxy.Type.HTTP : Proxy.Type.SOCKS;
+			return new Proxy(proxyType, InetSocketAddress.createUnresolved(host, port));
+		}
+
+		String browserServer() {
+			String scheme = type == Type.HTTP ? "http" : "socks5";
+			return scheme + "://" + host + ":" + port;
+		}
+
+		public enum Type {
+			HTTP,
+			SOCKS
+		}
 	}
 
 	public static class BrowserFetch {

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sagongsa.backend.domain.enums.ItemCategory;
 import com.sagongsa.backend.domain.enums.ItemInputSource;
 import com.sagongsa.backend.domain.enums.ItemStatus;
+import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
@@ -33,6 +34,8 @@ import org.springframework.web.server.ResponseStatusException;
 public class ShoppingLinkImportService {
 
 	private static final Pattern PRICE_WITH_CURRENCY_PATTERN = Pattern.compile("\\b([0-9]{1,3}(?:,[0-9]{3})+)\\s*원");
+	private static final Pattern WON_PRICE_AMOUNT_PATTERN = Pattern.compile("([0-9]+(?:,[0-9]{3})*(?:\\.[0-9]+)?)\\s*원");
+	private static final Pattern PRICE_AMOUNT_PATTERN = Pattern.compile("([0-9]+(?:,[0-9]{3})*(?:\\.[0-9]+)?)");
 	private static final Set<String> NOISE_IMAGE_KEYWORDS = Set.of("logo", "icon", "sprite", "badge", "banner");
 	private static final Set<String> TRACKING_QUERY_KEYS = Set.of(
 		"fbclid", "gclid", "igshid", "mc_cid", "mc_eid", "n_media", "n_query", "n_rank", "n_ad_group"
@@ -614,13 +617,21 @@ public class ShoppingLinkImportService {
 		if (isBlank(rawPrice)) {
 			return null;
 		}
-		String digitsOnly = rawPrice.replaceAll("[^0-9]", "");
-		if (digitsOnly.isBlank()) {
+		Matcher wonPriceMatcher = WON_PRICE_AMOUNT_PATTERN.matcher(rawPrice);
+		Matcher priceMatcher = PRICE_AMOUNT_PATTERN.matcher(rawPrice);
+		String amount = wonPriceMatcher.find()
+			? wonPriceMatcher.group(1)
+			: priceMatcher.find() ? priceMatcher.group(1) : null;
+		if (amount == null) {
 			return null;
 		}
 		try {
-			return Integer.parseInt(digitsOnly);
-		} catch (NumberFormatException exception) {
+			BigDecimal price = new BigDecimal(amount.replace(",", "")).stripTrailingZeros();
+			if (price.scale() > 0) {
+				return null;
+			}
+			return price.intValueExact();
+		} catch (ArithmeticException | NumberFormatException exception) {
 			return null;
 		}
 	}
@@ -742,7 +753,7 @@ public class ShoppingLinkImportService {
 		try {
 			URI uri = URI.create(imageUrl.trim());
 			String scheme = Optional.ofNullable(uri.getScheme()).orElse("").toLowerCase(Locale.ROOT);
-			if (!scheme.equals("http") && !scheme.equals("https")) {
+			if ((!scheme.equals("http") && !scheme.equals("https")) || isBlank(uri.getHost())) {
 				return null;
 			}
 			return uri.toString();
@@ -981,17 +992,7 @@ public class ShoppingLinkImportService {
 		}
 
 		private boolean isPartial() {
-			int count = 0;
-			if (!isBlank(title)) {
-				count++;
-			}
-			if (price != null) {
-				count++;
-			}
-			if (!isBlank(imageUrl)) {
-				count++;
-			}
-			return count < 3;
+			return isBlank(title) || price == null || price <= 0 || isBlank(imageUrl);
 		}
 
 		private boolean isBlank(String value) {

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
@@ -220,6 +220,9 @@ public class ShoppingLinkImportService {
 		String html = page.body();
 		String sourceDomain = sourceDomain(page.finalUri());
 		EmbeddedMetadata embeddedMetadata = embeddedMetadata(document);
+		String siteSalePrice = isOliveYoungDomain(sourceDomain)
+			? metaContent(document, "meta[property=eg:salePrice]")
+			: null;
 		String summary = firstNonBlank(
 			metaContent(document, "meta[property=og:description]"),
 			metaContent(document, "meta[name=description]"),
@@ -245,6 +248,7 @@ public class ShoppingLinkImportService {
 		);
 
 		Integer price = firstNonNull(
+			parseListedPrice(siteSalePrice),
 			parseListedPrice(metaContent(document, "meta[property=product:price:amount]")),
 			parseListedPrice(metaContent(document, "meta[property=og:price:amount]")),
 			parseListedPrice(metaContent(document, "meta[property=kakao:commerce:price]")),
@@ -254,6 +258,7 @@ public class ShoppingLinkImportService {
 			parseListedPrice(findByRegex(html, PRICE_WITH_CURRENCY_PATTERN))
 		);
 		String rawPriceText = firstValidPriceText(
+			siteSalePrice,
 			metaContent(document, "meta[property=product:price:amount]"),
 			metaContent(document, "meta[property=og:price:amount]"),
 			metaContent(document, "meta[property=kakao:commerce:price]"),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,6 +75,11 @@ app:
   shopping:
     import:
       max-response-bytes: ${SHOPPING_IMPORT_MAX_RESPONSE_BYTES:1000000}
+      kream-proxy:
+        enabled: ${SHOPPING_IMPORT_KREAM_PROXY_ENABLED:false}
+        type: ${SHOPPING_IMPORT_KREAM_PROXY_TYPE:SOCKS}
+        host: ${SHOPPING_IMPORT_KREAM_PROXY_HOST:}
+        port: ${SHOPPING_IMPORT_KREAM_PROXY_PORT:1080}
       browser-fetch:
         enabled: ${SHOPPING_IMPORT_BROWSER_FETCH_ENABLED:true}
         timeout: ${SHOPPING_IMPORT_BROWSER_FETCH_TIMEOUT:PT30S}

--- a/src/test/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcherTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcherTest.java
@@ -1,5 +1,6 @@
 package com.sagongsa.backend.itemimport.item;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -15,6 +16,22 @@ import java.net.URI;
 import org.junit.jupiter.api.Test;
 
 class BrowserPageFetcherTest {
+
+	@Test
+	void appliesConfiguredProxyOnlyToKreamContext() {
+		ShoppingImportProperties.BrowserFetch browserFetch = new ShoppingImportProperties.BrowserFetch();
+		ShoppingImportProperties.KreamProxy kreamProxy = new ShoppingImportProperties.KreamProxy();
+		kreamProxy.setEnabled(true);
+		kreamProxy.setType(ShoppingImportProperties.KreamProxy.Type.SOCKS);
+		kreamProxy.setHost("127.0.0.1");
+		kreamProxy.setPort(18080);
+		BrowserPageFetcher fetcher = new BrowserPageFetcher(browserFetch, 1_000_000, kreamProxy);
+
+		assertThat(fetcher.contextOptions(URI.create("https://kream.co.kr/products/444045")).proxy.server)
+			.isEqualTo("socks5://127.0.0.1:18080");
+		assertThat(fetcher.contextOptions(URI.create("https://zigzag.kr/catalog/products/1")).proxy)
+			.isNull();
+	}
 
 	@Test
 	void closesPlaywrightWhenBrowserLaunchFailsWithThrowable() {

--- a/src/test/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcherTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcherTest.java
@@ -245,4 +245,37 @@ class JsoupPageFetcherTest {
 		assertThat(document.selectFirst("meta[property=kakao:commerce:brand_name]").attr("content"))
 			.isEqualTo("아디다스");
 	}
+
+	@Test
+	void buildsKreamProductMetadataHtmlFromWebApiResponse() {
+		String apiBody = """
+			{
+			  "release": {
+			    "id": 444045,
+			    "name": "(W) Nike LD-1000 Summit White Sail",
+			    "translated_name": "(W) 나이키 LD-1000 서밋 화이트 세일",
+			    "image_urls": ["https://kream-phinf.pstatic.net/product.png"],
+			    "brand": {
+			      "name": "Nike",
+			      "translated_name": "나이키"
+			    }
+			  },
+			  "market": {
+			    "lowest_ask": 33000.0
+			  }
+			}
+			""";
+
+		String html = JsoupPageFetcher.kreamProductMetadataHtml(apiBody).orElseThrow();
+		Document document = Jsoup.parse(html);
+
+		assertThat(document.selectFirst("meta[property=og:title]").attr("content"))
+			.isEqualTo("(W) 나이키 LD-1000 서밋 화이트 세일");
+		assertThat(document.selectFirst("meta[property=product:price:amount]").attr("content"))
+			.isEqualTo("33000.0");
+		assertThat(document.selectFirst("meta[property=og:image]").attr("content"))
+			.isEqualTo("https://kream-phinf.pstatic.net/product.png");
+		assertThat(document.selectFirst("meta[property=kakao:commerce:brand_name]").attr("content"))
+			.isEqualTo("나이키");
+	}
 }

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportConfigTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportConfigTest.java
@@ -47,4 +47,31 @@ class ShoppingImportConfigTest {
 					.getRenderWait()).isEqualTo(Duration.ofSeconds(5));
 			});
 	}
+
+	@Test
+	void bindsKreamProxySettings() {
+		contextRunner
+			.withPropertyValues(
+				"app.shopping.import.kream-proxy.enabled=true",
+				"app.shopping.import.kream-proxy.type=http",
+				"app.shopping.import.kream-proxy.host=proxy.internal",
+				"app.shopping.import.kream-proxy.port=3128"
+			)
+			.run(context -> {
+				assertThat(context).hasNotFailed();
+				ShoppingImportProperties.KreamProxy proxy = context.getBean(ShoppingImportProperties.class)
+					.getKreamProxy();
+				assertThat(proxy.isEnabled()).isTrue();
+				assertThat(proxy.getType()).isEqualTo(ShoppingImportProperties.KreamProxy.Type.HTTP);
+				assertThat(proxy.getHost()).isEqualTo("proxy.internal");
+				assertThat(proxy.getPort()).isEqualTo(3128);
+			});
+	}
+
+	@Test
+	void rejectsEnabledKreamProxyWithoutHost() {
+		contextRunner
+			.withPropertyValues("app.shopping.import.kream-proxy.enabled=true")
+			.run(context -> assertThat(context).hasFailed());
+	}
 }

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
@@ -302,6 +302,39 @@ class ShoppingLinkImportServiceTest {
 	}
 
 	@Test
+	void prefersOliveYoungSalePriceOverOriginalPrice() {
+		pageFetcher.stub(
+			"https://www.oliveyoung.co.kr/store/goods/getGoodsDetail.do?goodsNo=A000000137482",
+			"""
+				<html>
+				<head>
+				  <meta property="og:title" content="로벡틴 카밍 연꽃수 크림 60ml | 올리브영" />
+				  <meta property="og:image" content="https://image.oliveyoung.co.kr/item.png" />
+				  <meta property="product:price:amount" content="24000" />
+				  <meta property="eg:originalPrice" content="24000" />
+				  <meta property="eg:salePrice" content="18000" />
+				</head>
+				<body></body>
+				</html>
+				"""
+		);
+
+		ShoppingLinkImportResponse response = service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.SHARE,
+				"https://www.oliveyoung.co.kr/store/goods/getGoodsDetail.do?goodsNo=A000000137482",
+				null,
+				null,
+				null,
+				null
+			)
+		);
+
+		assertThat(response.item().listedPrice()).isEqualTo(18000);
+		assertThat(response.saveRequest().listedPrice()).isEqualTo(18000);
+	}
+
+	@Test
 	void rejectsOliveYoungChallengePageInsteadOfUsingChallengeTitle() {
 		pageFetcher.stub(
 			"https://www.oliveyoung.co.kr/store/goods/getGoodsDetail.do?goodsNo=A000000230109",

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
@@ -115,6 +115,158 @@ class ShoppingLinkImportServiceTest {
 	}
 
 	@Test
+	void parsesDecimalJsonLdPriceWithoutAppendingFractionDigits() {
+		pageFetcher.stub(
+			"https://www.daangn.com/articles/1200892330",
+			"""
+				<html>
+				<head>
+				  <script type="application/ld+json">
+				  {
+				    "@context": "https://schema.org",
+				    "@type": "Product",
+				    "name": "나이키 운동화",
+				    "image": "https://dnvefa72aowie.cloudfront.net/product.jpg",
+				    "offers": {
+				      "@type": "Offer",
+				      "price": "18000.0"
+				    }
+				  }
+				  </script>
+				</head>
+				<body></body>
+				</html>
+				"""
+		);
+
+		ShoppingLinkImportResponse response = service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.SHARE,
+				"https://www.daangn.com/articles/1200892330",
+				null,
+				null,
+				null,
+				null
+			)
+		);
+
+		assertThat(response.retrievalStatus()).isEqualTo("SUCCESS");
+		assertThat(response.item().title()).isEqualTo("나이키 운동화");
+		assertThat(response.item().listedPrice()).isEqualTo(18000);
+		assertThat(response.item().imageUrl()).isEqualTo("https://dnvefa72aowie.cloudfront.net/product.jpg");
+	}
+
+	@Test
+	void reportsPartialWhenPriceIsMissing() {
+		pageFetcher.stub(
+			"https://shopping.example.com/products/missing-price",
+			"""
+				<html><head>
+				  <meta property="og:title" content="가격 누락 상품" />
+				  <meta property="og:image" content="https://cdn.example.com/item.jpg" />
+				</head><body></body></html>
+				"""
+		);
+
+		ShoppingLinkImportResponse response = service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.SHARE,
+				"https://shopping.example.com/products/missing-price",
+				null,
+				null,
+				null,
+				null
+			)
+		);
+
+		assertThat(response.retrievalStatus()).isEqualTo("PARTIAL");
+		assertThat(response.item().listedPrice()).isNull();
+	}
+
+	@Test
+	void reportsPartialWhenImageIsMissing() {
+		pageFetcher.stub(
+			"https://shopping.example.com/products/missing-image",
+			"""
+				<html><head>
+				  <meta property="og:title" content="이미지 누락 상품" />
+				  <meta property="product:price:amount" content="18,000원" />
+				</head><body></body></html>
+				"""
+		);
+
+		ShoppingLinkImportResponse response = service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.SHARE,
+				"https://shopping.example.com/products/missing-image",
+				null,
+				null,
+				null,
+				null
+			)
+		);
+
+		assertThat(response.retrievalStatus()).isEqualTo("PARTIAL");
+		assertThat(response.item().listedPrice()).isEqualTo(18000);
+		assertThat(response.item().imageUrl()).isNull();
+	}
+
+	@Test
+	void reportsPartialWhenImageUrlHasNoHost() {
+		pageFetcher.stub(
+			"https://shopping.example.com/products/invalid-image",
+			"""
+				<html><head>
+				  <meta property="og:title" content="잘못된 이미지 상품" />
+				  <meta property="og:image" content="https:missing-host.jpg" />
+				  <meta property="product:price:amount" content="18000" />
+				</head><body></body></html>
+				"""
+		);
+
+		ShoppingLinkImportResponse response = service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.SHARE,
+				"https://shopping.example.com/products/invalid-image",
+				null,
+				null,
+				null,
+				null
+			)
+		);
+
+		assertThat(response.retrievalStatus()).isEqualTo("PARTIAL");
+		assertThat(response.item().imageUrl()).isNull();
+	}
+
+	@Test
+	void neverReportsSuccessWhenTitleIsMissing() {
+		pageFetcher.stub(
+			"https://shopping.example.com/products/missing-title",
+			"""
+				<html><head>
+				  <meta property="og:image" content="https://cdn.example.com/item.jpg" />
+				  <meta property="product:price:amount" content="18000" />
+				</head><body></body></html>
+				"""
+		);
+
+		assertThatThrownBy(() -> service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.SHARE,
+				"https://shopping.example.com/products/missing-title",
+				null,
+				null,
+				null,
+				null
+			)
+		))
+			.isInstanceOf(ResponseStatusException.class)
+			.satisfies(exception -> assertThat(((ResponseStatusException) exception).getStatusCode())
+				.isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY));
+	}
+
+	@Test
 	void skipsOliveYoungSiteTitleAndUsesProductTitleFallback() {
 		pageFetcher.stub(
 			"https://www.oliveyoung.co.kr/store/goods/getGoodsDetail.do?goodsNo=A000000230109",


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-82**
- Jira: https://parkjaehong.atlassian.net/browse/NF-82

> PR 제목: `NF-82 쇼핑 링크 필수 메타데이터 정확성 보완`
> 브랜치: `fix/NF-82-shopping-import-metadata`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #187

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- 당근 JSON-LD 가격 `18000.0`이 기존 숫자 필터에서 `180000`으로 변환됐습니다.
- KREAM은 QA GCP 출구 IP에서 일반 상품 HTML/API 모두 빈 500을 반환해 제목, 가격, 이미지를 가져오지 못했습니다.
- 이미지 URL은 `http/https` 문자열이기만 하면 host가 없어도 유효값처럼 남을 수 있었습니다.

### 왜 발생했나? (Root Cause)
- 가격에서 숫자가 아닌 문자를 모두 제거해 소수점 뒤의 `0`까지 원 단위 숫자에 붙였습니다.
- KREAM 연동이 배포 서버의 네트워크 출구에 의존했고, 사이트별 egress 우회 수단이 없었습니다.
- 성공 판정이 필수 3필드 개수 중심이었고 이미지 URI host까지 검증하지 않았습니다.

### 어떻게 고쳤나?
- 쉼표와 `.0`을 구분해 정수 원화로 변환하는 가격 파서를 적용했습니다.
- KREAM 웹 클라이언트 API에서 번역 상품명, `market.lowest_ask`, 대표 이미지를 읽습니다.
- KREAM에만 적용되는 선택적 HTTP/SOCKS 프록시를 Jsoup과 Playwright 경로에 추가했습니다.
- 제목, 양수 가격, host가 있는 HTTP(S) 이미지가 모두 있어야 `SUCCESS`로 판정합니다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법
- `POST /api/v1/items/import-link`에 실제 쇼핑몰 상품 URL을 전달합니다.
- `retrievalStatus`, `item.title`, `item.listedPrice`, `item.imageUrl`을 확인합니다.

### 재발 방지
- [x] 회귀 테스트 추가
- [x] 프록시 설정 검증 테스트 추가
- [x] 운영 문서 보강
- [ ] 모니터링/알람 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] AC1: 당근 JSON-LD `18000.0`이 `listedPrice=18000`으로 변환된다.
- [x] AC2: KREAM API 응답에서 제목, 현재 최저 판매가, 대표 이미지를 추출한다.
- [x] AC3: 제목, 양수 가격, 유효 이미지가 모두 있을 때만 `SUCCESS`다.
- [x] AC4: 가격/이미지 누락은 `PARTIAL`, 제목 누락은 기존 계약대로 422다.
- [x] AC5: KREAM 전용 프록시를 기본 OFF로 제공하고 다른 쇼핑몰에는 적용하지 않는다.
- [ ] AC6: 영구 프록시 엔드포인트를 QA에 설정하고 KREAM import-link 200을 확인한다.

---

## 🧪 테스트 / 검증 (필수)
### 자동 테스트
- `./gradlew test`: 546 tests, failures 0
- `git diff --check`: 통과

### QA팀 현재 확인 결과 (수정본 미배포)
| 쇼핑몰 | QA 결과 | 판정 |
| --- | --- | --- |
| KREAM | 수집 실패 | 미해결, 프록시 설정 후 재검증 필요 |
| 올리브영 | 수집 실패 | 미해결, 판매가 우선 코드는 PR에 추가 |
| 당근 | 가격 10배 | 미해결, 소수 가격 수정본 미배포 |
| 네이버쇼핑 | 링크만 확인 | 미해결, 수정본 배포 후 동일 링크 재검증 필요 |
| 지그재그 | 사진 누락 | 미해결, 수정본 배포 후 동일 링크 재검증 필요 |
| 무신사 | 정상 | QA 확인 완료 |
| 번개장터 | 정상 | QA 확인 완료 |

### PR 브랜치 로컬 URL smoke (QA 정상 판정 아님, 2026-07-14)
| 쇼핑몰 | 결과 | 가격 | 이미지 |
| --- | --- | ---: | --- |
| KREAM `444045` | `SUCCESS`, `(W) 나이키 LD-1000 서밋 화이트 세일` | 32,000 | HTTP 200 `image/png` |
| 무신사 `478021` | `SUCCESS`, 키르시 코치 자켓 | 125,000 | HTTP 200 `image/jpeg` |
| 네이버쇼핑 `13194003181` | `SUCCESS`, 쿠키런 굿나잇 보조배터리 | 19,900 | HTTP 200 `image/jpeg` |
| 지그재그 `141911042` | `SUCCESS`, 모티브 핀턱 슬랙스 | 27,450 | HTTP 200 `image/jpeg` |
| 당근 `1200892330` | `SUCCESS`, 판도라 하트 반지 12호 | 18,000 | HTTP 200 `image/webp` |
| 번개장터 `398473587` | `SUCCESS`, 용인대 아디다스 유도복 165 | 100,000 | HTTP 200 `image/webp` |
| 에이블리 `6070447` | `SUCCESS`, 우유 시스루 슬림핏 가디건 | 27,900 | HTTP 200 `image/webp` |
| 올리브영 `A000000137482` | `SUCCESS`, 로벡틴 카밍 연꽃수 크림 | 18,000 | 상품 이미지 URL 확인 |

### 프록시 근거와 남은 검증
- QA 직접 egress: KREAM HTML/API 빈 HTTP 500 재현.
- QA에서 개발 머신 SSH SOCKS egress 사용: KREAM HTML HTTP 200, 134,279 bytes, 제목/가격/이미지 확인.
- 2026-07-14 최종 QA 재접속은 SSH 공개키 거절로 실패해, 영구 프록시 설정 후 실 API smoke는 남아 있습니다.

---

## 🧭 영향 범위 (필수)
- [x] API 스펙 변경 없음
- [x] DB 스키마 변경 없음
- [x] 설정/환경변수 변경 있음
- [x] 외부 연동 영향 있음

추가 환경변수:
- `SHOPPING_IMPORT_KREAM_PROXY_ENABLED` (기본 `false`)
- `SHOPPING_IMPORT_KREAM_PROXY_TYPE` (`SOCKS` 또는 `HTTP`)
- `SHOPPING_IMPORT_KREAM_PROXY_HOST`
- `SHOPPING_IMPORT_KREAM_PROXY_PORT` (기본 `1080`)

---

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음

---

## 🚀 배포/릴리스
- 프록시 기본값은 OFF입니다.
- 프록시를 켜면 host/port 누락 시 기동 단계에서 실패합니다.
- 인증 없는 내부 프록시를 전제로 하며, 방화벽에서 백엔드 IP만 허용해야 합니다.

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- KREAM API 헤더/응답 구조가 변경되면 HTML/Playwright fallback으로 돌아갑니다.
- 영구 프록시의 가용성과 출구 IP 품질은 인프라 운영 대상입니다.

### 롤백
- 환경변수 `SHOPPING_IMPORT_KREAM_PROXY_ENABLED=false`로 프록시만 즉시 비활성화할 수 있습니다.
- 기존 배포 태그/이미지로 롤백 가능합니다.

---

## 💬 리뷰 가이드 (필수)
- 주요 로직: `JsoupPageFetcher.kreamProductApiPage`, `applyKreamProxy`, `BrowserPageFetcher.contextOptions`, `ShoppingLinkImportService.parsePrice`
- 보안 경계: 프록시는 KREAM 호스트에만 적용되고 요청 URI는 기존 public-host 검증을 유지합니다.
