### PR TITLE
[test] NF-85 쇼핑 링크 비동기 워커 통합 테스트 격리

### DIFF
--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -43,6 +43,8 @@ app:
       enabled: true
   shopping:
     import:
+      job-worker:
+        enabled: false
       browser-fetch:
         enabled: false
   notification:


### PR DESCRIPTION
# 🧪 Test PR

## 🔗 작업 키 / 이슈 링크
- Tracking Key: `NF-85`
- GitHub: Closes #192
- 원인 PR: #191
- 실패 CI: https://github.com/SaGongSa-404/404_BE/actions/runs/29303834177

## 문제와 원인
- `develop` CI에서 `ShoppingImportJobApiIntegrationTest`가 재실행마다 서로 다른 지점에서 실패했습니다.
- 여러 Spring 테스트 컨텍스트가 같은 PostgreSQL Testcontainer를 공유하는 동안, 다른 캐시된 컨텍스트의 비동기 scheduler가 테스트 작업을 먼저 claim하는 경쟁 조건이 원인이었습니다.

## 변경사항
- 테스트 전역 설정에 `app.shopping.import.job-worker.enabled=false`를 추가했습니다.
- 워커 테스트는 기존처럼 `processNextJob()`을 직접 호출하므로 운영 코드 및 실제 worker 동작은 변경하지 않습니다.

## 테스트
- 문제 통합 테스트 단독 실행 통과
- 전체 554 tests, failures 0, errors 0
- `git diff --check` 통과

## 영향 범위
- 테스트 설정만 변경
- 운영 설정 및 런타임 동작 변경 없음