### PR TITLE
[fix] NF-86 reviewer-token CORS 허용 헤더 보완

### DIFF
--- a/src/main/resources/config/cors.yml
+++ b/src/main/resources/config/cors.yml
@@ -3,7 +3,7 @@ app:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:}
     allowed-origin-patterns: ${APP_CORS_ALLOWED_ORIGIN_PATTERNS:http://localhost:*,http://127.0.0.1:*}
     allowed-methods: ${APP_CORS_ALLOWED_METHODS:GET,POST,PATCH,PUT,DELETE,OPTIONS}
-    allowed-headers: ${APP_CORS_ALLOWED_HEADERS:Authorization,Content-Type,X-User-Id,X-Admin-Token,X-Request-Id}
+    allowed-headers: ${APP_CORS_ALLOWED_HEADERS:Authorization,Content-Type,X-User-Id,X-Admin-Token,X-Request-Id,X-Reviewer-Token}
     exposed-headers: ${APP_CORS_EXPOSED_HEADERS:Location,X-Request-Id}
     allow-credentials: ${APP_CORS_ALLOW_CREDENTIALS:false}
     max-age: ${APP_CORS_MAX_AGE:PT1H}

--- a/src/test/java/com/sagongsa/backend/auth/AuthApiControllerTest.java
+++ b/src/test/java/com/sagongsa/backend/auth/AuthApiControllerTest.java
@@ -96,6 +96,21 @@ class AuthApiControllerTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void acceptsReviewerTokenHeaderInCorsPreflight() throws Exception {
+		mockMvc.perform(options("/api/auth/reviewer-token")
+			.header(HttpHeaders.ORIGIN, "http://localhost:5173")
+			.header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "POST")
+			.header(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, "Content-Type,X-Reviewer-Token"))
+			.andExpect(status().isOk())
+			.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://localhost:5173"))
+			.andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, org.hamcrest.Matchers.containsString("POST")))
+			.andExpect(header().string(
+				HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
+				org.hamcrest.Matchers.containsString("X-Reviewer-Token")
+			));
+	}
+
+	@Test
 	void rejectsCorsPreflightFromUnconfiguredOrigin() throws Exception {
 		mockMvc.perform(options("/api/auth/token/refresh")
 			.header(HttpHeaders.ORIGIN, "https://evil.example")


### PR DESCRIPTION
# Bugfix PR

## 작업 키 / 이슈 링크
- Tracking Key: **NF-86**
- GitHub: Closes #196

## 한눈에 요약
### 어떤 버그였나?
- 허용된 웹 오리진에서 `X-Reviewer-Token` 헤더를 포함해 관리자 로그인 API를 호출하면 브라우저 CORS preflight가 실패했습니다.

### 왜 발생했나? (Root Cause)
- QA 서버는 `APP_CORS_ALLOWED_HEADERS`를 별도로 설정하지 않아 저장소 기본값을 사용하고 있었고, 기본 허용 헤더 목록에 `X-Reviewer-Token`이 없었습니다.

### 어떻게 고쳤나?
- CORS 기본 허용 헤더에 `X-Reviewer-Token`을 추가했습니다.
- reviewer-token preflight 응답에 해당 헤더가 포함되는 통합 테스트를 추가했습니다.

## 재현 & 검증
### 재현 방법
- Steps: 허용된 오리진에서 `Access-Control-Request-Headers: Content-Type,X-Reviewer-Token`으로 `OPTIONS /api/auth/reviewer-token` 요청
- 기대 결과: `Access-Control-Allow-Headers`에 `X-Reviewer-Token` 포함
- 기존 실제 결과: `content-type`만 반환되어 브라우저가 본 요청을 차단

### 재발 방지
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [ ] 런북/문서 보강

## Acceptance Criteria (AC)
- [x] 허용된 웹 오리진의 reviewer-token preflight가 `X-Reviewer-Token`을 허용한다.
- [x] 설정되지 않은 오리진은 기존처럼 차단된다.
- [x] reviewer-token 인증 및 rate limit 동작은 변경하지 않는다.

## 테스트 / 검증
### 로컬
- Command: `./gradlew test --no-daemon --console=plain --tests com.sagongsa.backend.auth.AuthApiControllerTest`
- Result: 성공
- Command: `./gradlew test --no-daemon --console=plain && git diff --check`
- Result: 555 tests, failures 0, errors 0 / diff check 성공

### CI
- 링크/결과: PR 생성 후 자동 실행

### Smoke / 수동 검증
- 시나리오: 로컬 허용 오리진에서 reviewer-token CORS preflight 수행
- 결과: 통합 테스트로 응답 헤더 포함 확인

### 테스트 공백
- QA 실서버 검증은 머지 및 배포 후 동일 preflight 요청으로 재확인해야 합니다.

## 영향 범위
- [x] API 엔드포인트 스펙 변경 없음
- [x] CORS 응답 계약 확장 (`X-Reviewer-Token` 허용)
- [x] DB 스키마 변경 없음
- [x] 설정 기본값 변경 있음 (`app.cors.allowed-headers`)
- [x] 캐시/큐/외부 연동 영향 없음

## Breaking / Compatibility
- [x] Breaking change 없음

## 배포/릴리즈
### Feature Flag
- [x] 사용 안함

### 모니터링/알림
- 확인: 배포 후 QA 웹 오리진의 reviewer-token preflight 응답 헤더
- 에러/로그 키워드: CORS, reviewer-token

## 리스크 & 롤백
### 리스크
- 신뢰할 수 없는 오리진은 기존 origin 검증에서 차단되므로 헤더 추가만으로 접근 권한이 확장되지 않습니다.

### 롤백
- [x] `APP_CORS_ALLOWED_HEADERS` 환경변수로 즉시 우회 가능
- [x] 배포 롤백 가능
- [x] 데이터 롤백 불필요

## 리뷰 가이드
- 꼭 봐야 하는 파일/로직: `config/cors.yml`, `AuthApiControllerTest`
- 트레이드오프/대안: 서버 환경변수만 수정할 수 있으나 환경별 누락 재발을 막기 위해 저장소 기본값을 보완했습니다.
- 성능/보안/호환성 영향: 성능 영향 없음. origin 검증과 reviewer-token 검증은 그대로 유지됩니다.
