### PR TITLE
[fix] NF-84 Chromium 종료 후 서버 지표 수집 유지

### DIFF
--- a/load-tests/shopping-import/collect-server-metrics.sh
+++ b/load-tests/shopping-import/collect-server-metrics.sh
@@ -24,8 +24,12 @@ for ((sample = 0; sample < samples; sample++)); do
   timestamp="$(date --iso-8601=seconds)"
   java_cpu="$(ps -p "$PID" -o %cpu= | xargs)"
   java_rss="$(ps -p "$PID" -o rss= | xargs)"
-  chromium_cpu="$(ps -C chromium,chrome -o %cpu= 2>/dev/null | awk '{sum += $1} END {printf "%.2f", sum + 0}')"
-  chromium_rss="$(ps -C chromium,chrome -o rss= 2>/dev/null | awk '{sum += $1} END {printf "%d", sum + 0}')"
+  # Chromium is expected to disappear between crawl jobs. `ps` returns 1 when
+  # no matching process exists, which must not abort the collector under
+  # `set -euo pipefail`.
+  chromium_processes="$(ps -C chromium,chrome -o %cpu=,rss= 2>/dev/null || true)"
+  chromium_cpu="$(awk '{sum += $1} END {printf "%.2f", sum + 0}' <<< "$chromium_processes")"
+  chromium_rss="$(awk '{sum += $2} END {printf "%d", sum + 0}' <<< "$chromium_processes")"
   queue_pending=""
   queue_running=""
 


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크
- Tracking Key: `NF-84`
- GitHub: Related #190
- 발견 실행: [QA baseline run 29321278299](https://github.com/SaGongSa-404/404_BE/actions/runs/29321278299)

## 🐛 문제
비동기 baseline 부하는 정상 완료됐지만 크롤링 종료 후 Chromium 프로세스가 0개가 되면서 `ps`가 exit 1을 반환했습니다. 수집기가 `set -euo pipefail` 상태라 서버 지표 CSV 생성이 중단되고 workflow가 실패했습니다.

## 🔧 수정
- Chromium 프로세스 목록 조회에서 미실행 상태를 정상 상태로 처리
- 동일 시점 CPU/RSS를 한 번의 `ps` 출력에서 합산
- Chromium 미실행 시 CPU `0.00`, RSS `0` 기록

## ✅ 검증
- `bash -n collect-server-metrics.sh` 통과
- Chromium 미실행 환경에서 `EMPTY_SAFE cpu=0.00 rss=0` 확인
- `git diff --check` 통과

## 🌐 영향 범위
- 부하 테스트 지표 수집 스크립트만 변경
- Java 런타임·DB·QA 설정 변경 없음
