### PR TITLE
[fix] NF-89 지그재그 현재 판매가·대표 이미지 추출 보완

### DIFF
--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
@@ -252,6 +252,7 @@ public class ShoppingLinkImportService {
 	private ExtractionResult extractFromPage(Document document, FetchedPage page) {
 		String html = page.body();
 		String sourceDomain = sourceDomain(page.finalUri());
+		ZigzagMetadata zigzagMetadata = zigzagMetadata(document, page.finalUri());
 		EmbeddedMetadata embeddedMetadata = embeddedMetadata(document);
 		String productJsonLdTitle = productJsonLdText(document, "name");
 		String productJsonLdDescription = productJsonLdText(document, "description");
@@ -275,6 +276,7 @@ public class ShoppingLinkImportService {
 		);
 		String title = firstProductTitle(
 			sourceDomain,
+			zigzagMetadata.title(),
 			productJsonLdTitle,
 			embeddedMetadata.title(),
 			metaContent(document, "meta[property=og:title]"),
@@ -293,6 +295,7 @@ public class ShoppingLinkImportService {
 		Integer price = firstNonNull(
 			parseListedPrice(siteSalePrice),
 			parseListedPrice(musinsaFinalPrice),
+			parseListedPrice(zigzagMetadata.priceText()),
 			parseListedPrice(productJsonLdPrice),
 			parseListedPrice(productMetaPrice),
 			parseListedPrice(embeddedMetadata.priceText()),
@@ -304,6 +307,7 @@ public class ShoppingLinkImportService {
 		String rawPriceText = firstValidPriceText(
 			siteSalePrice,
 			musinsaFinalPrice,
+			zigzagMetadata.priceText(),
 			productJsonLdPrice,
 			productMetaPrice,
 			embeddedMetadata.priceText(),
@@ -320,6 +324,7 @@ public class ShoppingLinkImportService {
 		);
 
 		String imageUrl = firstNonBlank(
+			normalizeImageUrl(zigzagMetadata.imageUrl()),
 			normalizeImageUrl(productJsonLdImage),
 			normalizeImageUrl(embeddedMetadata.imageUrl()),
 			normalizeImageUrl(metaContent(document, "meta[property=og:image]")),
@@ -328,7 +333,9 @@ public class ShoppingLinkImportService {
 		);
 
 		String method = "OPEN_GRAPH";
-		if (!isBlank(productJsonLdTitle) || !isBlank(productJsonLdPrice) || !isBlank(productJsonLdImage)) {
+		if (zigzagMetadata.hasAnyValue()) {
+			method = "ZIGZAG_PRODUCT_STATE";
+		} else if (!isBlank(productJsonLdTitle) || !isBlank(productJsonLdPrice) || !isBlank(productJsonLdImage)) {
 			method = "JSON_LD";
 		} else if (embeddedMetadata.hasAnyValue()) {
 			method = "EMBEDDED_JSON";
@@ -362,6 +369,96 @@ public class ShoppingLinkImportService {
 			method,
 			rawPayloadJson
 		);
+	}
+
+	private ZigzagMetadata zigzagMetadata(Document document, URI finalUri) {
+		String host = Optional.ofNullable(finalUri.getHost()).orElse("").toLowerCase(Locale.ROOT);
+		if (!host.equals("zigzag.kr") && !host.equals("www.zigzag.kr")) {
+			return ZigzagMetadata.empty();
+		}
+
+		Matcher productIdMatcher = Pattern.compile("/(?:app/)?catalog/products/([0-9]+)").matcher(
+			Optional.ofNullable(finalUri.getPath()).orElse("")
+		);
+		if (!productIdMatcher.find()) {
+			return ZigzagMetadata.empty();
+		}
+		String productId = productIdMatcher.group(1);
+
+		for (Element scriptElement : document.select("script")) {
+			String rawScript = firstNonBlank(scriptElement.data(), scriptElement.html());
+			String json = jsonCandidate(rawScript);
+			if (json == null) {
+				continue;
+			}
+			try {
+				JsonNode product = findZigzagProduct(objectMapper.readTree(json), productId);
+				if (product == null) {
+					continue;
+				}
+				String priceText = firstNonBlank(
+					textAt(product, "product_price", "display_final_price", "final_price", "price"),
+					textAt(product, "product_price", "store_discount_info", "discount_price"),
+					textAt(product, "product_price", "max_price_info", "price")
+				);
+				String imageUrl = firstZigzagProductImage(product.path("product_image_list"));
+				return new ZigzagMetadata(
+					normalizeWhitespace(product.path("name").asText(null)),
+					priceText,
+					imageUrl
+				);
+			} catch (JsonProcessingException ignored) {
+				// Continue until the target product state is found in another script.
+			}
+		}
+		return ZigzagMetadata.empty();
+	}
+
+	private JsonNode findZigzagProduct(JsonNode node, String productId) {
+		if (node == null || node.isNull()) {
+			return null;
+		}
+		if (node.isObject()
+			&& productId.equals(node.path("id").asText())
+			&& (node.has("product_price") || node.has("product_image_list"))) {
+			return node;
+		}
+		for (JsonNode child : node) {
+			JsonNode product = findZigzagProduct(child, productId);
+			if (product != null) {
+				return product;
+			}
+		}
+		return null;
+	}
+
+	private String textAt(JsonNode node, String... path) {
+		JsonNode current = node;
+		for (String segment : path) {
+			current = current.path(segment);
+			if (current.isMissingNode() || current.isNull()) {
+				return null;
+			}
+		}
+		return current.isValueNode() ? normalizeWhitespace(current.asText()) : null;
+	}
+
+	private String firstZigzagProductImage(JsonNode images) {
+		if (!images.isArray()) {
+			return null;
+		}
+		for (JsonNode image : images) {
+			String imageUrl = firstNonBlank(
+				textAt(image, "pdp_thumbnail_url"),
+				textAt(image, "pdp_static_image_url"),
+				textAt(image, "url"),
+				textAt(image, "origin_url")
+			);
+			if (!isBlank(imageUrl)) {
+				return imageUrl;
+			}
+		}
+		return null;
 	}
 
 	private URI rebuildUriWithHost(URI uri, String host) {
@@ -1192,6 +1289,17 @@ public class ShoppingLinkImportService {
 				return nextPriority;
 			}
 			return currentPriority;
+		}
+	}
+
+	private record ZigzagMetadata(String title, String priceText, String imageUrl) {
+
+		private static ZigzagMetadata empty() {
+			return new ZigzagMetadata(null, null, null);
+		}
+
+		private boolean hasAnyValue() {
+			return title != null || priceText != null || imageUrl != null;
 		}
 	}
 

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportLiveAccuracyTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportLiveAccuracyTest.java
@@ -435,11 +435,14 @@ class ShoppingLinkImportLiveAccuracyTest {
 			);
 		}
 		if (host.equals("zigzag.kr") || host.equals("www.zigzag.kr")) {
-			JsonNode product = productJsonLd(document);
+			JsonNode product = zigzagProductState(document, page.finalUri());
 			return new SourceProduct(
-				meta(document, "meta[property=og:title]"),
-				Integer.valueOf(meta(document, "meta[property=product:price:amount]").replace(",", "")),
-				Parser.unescapeEntities(firstTextValue(product.path("image")), false)
+				product.path("name").asText(),
+				product.path("product_price").path("display_final_price").path("final_price").path("price").intValue(),
+				Parser.unescapeEntities(
+					product.path("product_image_list").path(0).path("pdp_thumbnail_url").asText(),
+					false
+				)
 			);
 		}
 		if (host.endsWith("oliveyoung.co.kr")) {
@@ -524,6 +527,49 @@ class ShoppingLinkImportLiveAccuracyTest {
 			if (product != null) return product;
 		}
 		return null;
+	}
+
+	private JsonNode zigzagProductState(Document document, URI uri) throws IOException {
+		Matcher idMatcher = Pattern.compile("/(?:app/)?catalog/products/([0-9]+)").matcher(uri.getPath());
+		if (!idMatcher.find()) throw new IllegalArgumentException("Zigzag product id not found");
+		String productId = idMatcher.group(1);
+		for (Element script : document.select("script")) {
+			String raw = script.data().isBlank() ? script.html() : script.data();
+			String json = jsonCandidate(raw);
+			if (json == null) continue;
+			try {
+				JsonNode product = findZigzagProductNode(OBJECT_MAPPER.readTree(json), productId);
+				if (product != null) return product;
+			} catch (IOException ignored) {
+				// Ignore non-JSON application scripts and inspect the remaining state scripts.
+			}
+		}
+		throw new IllegalArgumentException("Zigzag product state not found: " + productId);
+	}
+
+	private JsonNode findZigzagProductNode(JsonNode node, String productId) {
+		if (node == null || node.isNull()) return null;
+		if (node.isObject()
+			&& productId.equals(node.path("id").asText())
+			&& node.has("product_price")
+			&& node.has("product_image_list")) {
+			return node;
+		}
+		Iterator<JsonNode> children = node.elements();
+		while (children.hasNext()) {
+			JsonNode product = findZigzagProductNode(children.next(), productId);
+			if (product != null) return product;
+		}
+		return null;
+	}
+
+	private String jsonCandidate(String raw) {
+		if (raw == null || raw.isBlank()) return null;
+		String trimmed = raw.trim();
+		if (trimmed.startsWith("{") || trimmed.startsWith("[")) return trimmed;
+		int start = trimmed.indexOf('{');
+		int end = trimmed.lastIndexOf('}');
+		return start >= 0 && end > start ? trimmed.substring(start, end + 1) : null;
 	}
 
 	private String firstTextValue(JsonNode node) {

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
@@ -303,6 +303,52 @@ class ShoppingLinkImportServiceTest {
 	}
 
 	@Test
+	void importsReportedZigzagProductUsingDisplayedPriceAndItsOwnProductImage() {
+		String requestedUrl = "https://store.zigzag.kr/catalog/products/136095576?catalog_product_id=136095576";
+		String canonicalUrl = "https://zigzag.kr/catalog/products/136095576?catalog_product_id=136095576";
+		pageFetcher.stub(
+			canonicalUrl,
+			"""
+				<html><head>
+				  <meta property="og:title" content="지그재그" />
+				  <meta property="product:price:amount" content="53,900" />
+				  <meta property="product:price:currency" content="KRW" />
+				  <meta property="og:image" content="https://cf.shop.s.zigzag.kr/common.jpg" />
+				  <script>
+				  window.__NEXT_DATA__ = {
+				    "queries": [{"data": {"product": {
+				      "id": "136095576",
+				      "name": "[🧊여름바지/3기장선택!] made. 모먼트 투커버 올데이슬랙스 (+숏/베이직/롱ver) - 4 size",
+				      "product_image_list": [{
+				        "url": "https://cf.product-image.s.zigzag.kr/original/product-136095576.jpeg",
+				        "pdp_thumbnail_url": "https://cf.product-image.s.zigzag.kr/original/product-136095576.jpeg?width=720&height=720"
+				      }],
+				      "product_price": {
+				        "max_price_info": {"price": 53900},
+				        "display_final_price": {
+				          "final_price": {"price": 29800},
+				          "final_price_additional": {"price": 26820}
+				        }
+				      }
+				    }}}]
+				  };
+				  </script>
+				</head><body></body></html>
+				"""
+		);
+
+		ShoppingLinkImportResponse response = service.importLink(new ShoppingLinkImportRequest(
+			ItemInputSource.SHARE, requestedUrl, null, null, null, null
+		));
+
+		assertThat(response.retrievalStatus()).isEqualTo("SUCCESS");
+		assertThat(response.item().title()).contains("여름바지/3기장선택");
+		assertThat(response.item().listedPrice()).isEqualTo(29800);
+		assertThat(response.item().imageUrl())
+			.isEqualTo("https://cf.product-image.s.zigzag.kr/original/product-136095576.jpeg?width=720&height=720");
+	}
+
+	@Test
 	void reportsPartialWhenPriceIsMissing() {
 		pageFetcher.stub(
 			"https://shopping.example.com/products/missing-price",


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-89**
- GitHub: Closes #203
- 선행 작업: #201, #202

### 🔒 Close Issue (필수)
- GitHub: Closes #203

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- 지그재그 상품이 화면의 현재 판매가 대신 할인 전 정가를 반환했습니다.
- 서로 다른 지그재그 상품에서 공통 또는 부정확한 이미지가 반환될 수 있었습니다.

### 왜 발생했나? (Root Cause)
- 임베디드 JSON 전체를 범용 탐색하면서 `display_final_price`보다 먼저 위치한 `max_price_info.price`를 선택했습니다.
- 상품 ID에 대응하는 상품 상태를 한정하지 않아 앞서 발견된 이미지 후보가 선택될 수 있었습니다.
- 기존 실사이트 테스트도 정가 메타값을 정답으로 사용해 오류를 놓쳤습니다.

### 어떻게 고쳤나?
- URL의 상품 ID와 일치하는 지그재그 상품 상태만 탐색합니다.
- `product_price.display_final_price.final_price.price`를 기본 현재 판매가로 우선합니다.
- 해당 상품의 `product_image_list`에서 PDP 대표 이미지를 선택합니다.
- 실사이트 정답값도 동일한 화면 표시 가격·상품 이미지 상태에서 독립적으로 읽도록 수정했습니다.

## 🧯 재현 & 검증 (권장)
### 재현 방법
- 제보된 지그재그 상품 3건의 반환 상품명, 기본 현재 판매가, 대표 이미지를 원본 상품 상태와 비교합니다.
- 상품 `136095576`은 정가 53,900원이 아닌 기본 현재 판매가 29,800원을 반환해야 합니다.

### 재발 방지
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [ ] 런북/문서 보강

## ✅ Acceptance Criteria (AC) (필수)
- [x] 지그재그 상품이 할인 전 정가 대신 기본 현재 판매가를 반환한다.
- [x] URL 상품 ID와 일치하는 상품의 PDP 이미지를 반환한다.
- [x] 제보된 지그재그 3개 URL의 실사이트 정확성 검증이 통과한다.

## 🧪 테스트 / 검증 (필수)
### 로컬
```text
./gradlew test --tests 'com.sagongsa.backend.itemimport.item.ShoppingLinkImportServiceTest' --no-daemon --console=plain
BUILD SUCCESSFUL in 20s

./gradlew test --tests 'com.sagongsa.backend.itemimport.item.*' --no-daemon --console=plain
BUILD SUCCESSFUL in 32s

SHOPPING_IMPORT_LIVE_TEST=true ./gradlew test \
  --tests 'com.sagongsa.backend.itemimport.item.ShoppingLinkImportLiveAccuracyTest.verifiesReportedShareLinkRegressionsAgainstSourceMetadata' \
  --no-daemon --console=plain
BUILD SUCCESSFUL in 42s
```

### CI
- 링크/결과: 자동 실행 예정

### Smoke / 수동 검증
- 지그재그 제보 URL 3건: 현재 판매가·상품별 대표 이미지 원본 상태 대조 통과

### 테스트 공백(있다면 이유 필수)
- 없음

## 🧭 영향 범위 (필수)
- [x] API 스펙 변경 없음
- [x] DB 스키마 변경 없음
- [x] 설정/환경변수 변경 없음
- [x] 외부 연동 영향 있음 (지그재그 상품 메타데이터 추출 경로)

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음

## 🚀 배포/릴리즈
### Feature Flag
- [x] 사용 안함

### 모니터링/알림
- 배포 후 제보된 지그재그 3개 URL을 앱에서 재확인합니다.

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 지그재그의 임베디드 상품 상태 필드가 변경되면 기존 범용 메타데이터로 폴백합니다.

### 롤백
- [x] PR revert 및 이전 배포 산출물로 롤백 가능

## 💬 리뷰 가이드 (필수)
- 집중 파일: `ShoppingLinkImportService`, `ShoppingLinkImportLiveAccuracyTest`
- 상품 ID 일치 조건과 현재 판매가·PDP 이미지 우선순위를 확인해 주세요.
- API/DB/환경변수 변경은 없습니다.
