### PR TITLE
[fix] NF-90 지그재그 단축 공유 링크 현재가·이미지 추출 보완

### DIFF
--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
@@ -50,11 +50,14 @@ public class ShoppingLinkImportService {
 		"deep_link_value", "tracking_content", "airbridge_referrer", "https_deeplink"
 	);
 	private static final Set<String> OLIVE_YOUNG_HOSTS = Set.of("oliveyoung.co.kr", "m.oliveyoung.co.kr");
+	private static final Set<String> ZIGZAG_PRODUCT_STATE_HOSTS = Set.of(
+		"zigzag.kr", "www.zigzag.kr", "store.zigzag.kr"
+	);
 	private static final Set<String> VERIFIED_PRODUCT_HOSTS = Set.of(
 		"musinsa.com", "www.musinsa.com",
 		"daangn.com", "www.daangn.com",
 		"bunjang.co.kr", "www.bunjang.co.kr", "m.bunjang.co.kr",
-		"zigzag.kr", "www.zigzag.kr",
+		"zigzag.kr", "www.zigzag.kr", "store.zigzag.kr", "s.zigzag.kr", "link.zigzag.kr",
 		"oliveyoung.co.kr", "www.oliveyoung.co.kr", "m.oliveyoung.co.kr",
 		"brand.naver.com", "m.brand.naver.com",
 		"smartstore.naver.com", "m.smartstore.naver.com",
@@ -373,7 +376,7 @@ public class ShoppingLinkImportService {
 
 	private ZigzagMetadata zigzagMetadata(Document document, URI finalUri) {
 		String host = Optional.ofNullable(finalUri.getHost()).orElse("").toLowerCase(Locale.ROOT);
-		if (!host.equals("zigzag.kr") && !host.equals("www.zigzag.kr")) {
+		if (!ZIGZAG_PRODUCT_STATE_HOSTS.contains(host)) {
 			return ZigzagMetadata.empty();
 		}
 
@@ -513,7 +516,7 @@ public class ShoppingLinkImportService {
 		if (host.endsWith("bunjang.co.kr")) {
 			return path.matches("/products/[0-9]+/?");
 		}
-		if (host.equals("zigzag.kr") || host.equals("www.zigzag.kr")) {
+		if (ZIGZAG_PRODUCT_STATE_HOSTS.contains(host)) {
 			return path.matches("/(?:app/)?catalog/products/[0-9]+/?");
 		}
 		if (host.equals("oliveyoung.co.kr") || host.equals("www.oliveyoung.co.kr") || host.equals("m.oliveyoung.co.kr")) {

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportLiveAccuracyTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportLiveAccuracyTest.java
@@ -143,6 +143,7 @@ class ShoppingLinkImportLiveAccuracyTest {
 		"https://m.a-bly.com/goods/12426697"
 	);
 	private static final List<String> REPORTED_ZIGZAG_STORE_URLS = List.of(
+		"https://s.zigzag.kr/hsiVNfPqd4",
 		"https://store.zigzag.kr/catalog/products/136095576?catalog_product_id=136095576",
 		"https://store.zigzag.kr/catalog/products/160269610?catalog_product_id=160269610",
 		"https://store.zigzag.kr/catalog/products/140798161?catalog_product_id=140798161"
@@ -279,7 +280,7 @@ class ShoppingLinkImportLiveAccuracyTest {
 		List<String> unavailable = new ArrayList<>();
 		ShoppingImportProperties properties = browserProperties();
 
-		int zigzag = verifyCandidates(REPORTED_ZIGZAG_STORE_URLS, 3, mismatches, unavailable);
+		int zigzag = verifyCandidates(REPORTED_ZIGZAG_STORE_URLS, 4, mismatches, unavailable);
 		int twentyNineCm = verifyCandidates(REPORTED_TWENTY_NINE_CM_URLS, 3, mismatches, unavailable);
 		int musinsa = verifyCandidates(List.of(REPORTED_MUSINSA_URL), 1, mismatches, unavailable);
 		int ably;
@@ -291,7 +292,7 @@ class ShoppingLinkImportLiveAccuracyTest {
 		ShoppingLinkImportService service = new ShoppingLinkImportService(new JsoupPageFetcher(10_000_000), OBJECT_MAPPER);
 
 		assertThat(mismatches).as("reported share-link title, KRW price, and product image must match").isEmpty();
-		assertThat(zigzag).as("reported Zigzag products; unavailable=%s", unavailable).isEqualTo(3);
+		assertThat(zigzag).as("reported Zigzag products; unavailable=%s", unavailable).isEqualTo(4);
 		assertThat(twentyNineCm).as("reported 29CM products; unavailable=%s", unavailable).isEqualTo(3);
 		assertThat(musinsa).as("reported Musinsa product; unavailable=%s", unavailable).isEqualTo(1);
 		assertThat(ably).as("reported Ably products; unavailable=%s", unavailable).isEqualTo(3);
@@ -434,7 +435,7 @@ class ShoppingLinkImportLiveAccuracyTest {
 				meta(document, "meta[property=og:image]")
 			);
 		}
-		if (host.equals("zigzag.kr") || host.equals("www.zigzag.kr")) {
+		if (host.equals("zigzag.kr") || host.equals("www.zigzag.kr") || host.equals("store.zigzag.kr")) {
 			JsonNode product = zigzagProductState(document, page.finalUri());
 			return new SourceProduct(
 				product.path("name").asText(),

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
@@ -349,6 +349,42 @@ class ShoppingLinkImportServiceTest {
 	}
 
 	@Test
+	void importsZigzagShortShareLinkAfterRedirectToStoreProduct() {
+		String shortUrl = "https://s.zigzag.kr/hsiVNfPqd4";
+		String finalUrl = "https://store.zigzag.kr/catalog/products/136095576?catalog_product_id=136095576";
+		pageFetcher.stubRedirect(
+			shortUrl,
+			finalUrl,
+			"""
+				<html><head><script>
+				window.__NEXT_DATA__ = {"product": {
+				  "id": "136095576",
+				  "name": "[🧊여름바지/3기장선택!] made. 모먼트 투커버 올데이슬랙스",
+				  "product_image_list": [{
+				    "pdp_thumbnail_url": "https://cf.product-image.s.zigzag.kr/product-136095576.jpeg?width=720&height=720"
+				  }],
+				  "product_price": {
+				    "max_price_info": {"price": 53900},
+				    "display_final_price": {"final_price": {"price": 29800}}
+				  }
+				}};
+				</script></head><body></body></html>
+				"""
+		);
+
+		ShoppingLinkImportResponse response = service.importLink(new ShoppingLinkImportRequest(
+			ItemInputSource.SHARE, shortUrl, null, null, null, null
+		));
+
+		assertThat(response.retrievalStatus()).isEqualTo("SUCCESS");
+		assertThat(response.item().listedPrice()).isEqualTo(29800);
+		assertThat(response.item().imageUrl())
+			.isEqualTo("https://cf.product-image.s.zigzag.kr/product-136095576.jpeg?width=720&height=720");
+		assertThat(response.sourceMetadata().sourceDomain()).isEqualTo("store.zigzag.kr");
+		assertThat(response.sourceMetadata().extractionMethod()).isEqualTo("ZIGZAG_PRODUCT_STATE");
+	}
+
+	@Test
 	void reportsPartialWhenPriceIsMissing() {
 		pageFetcher.stub(
 			"https://shopping.example.com/products/missing-price",
@@ -1298,19 +1334,30 @@ class ShoppingLinkImportServiceTest {
 
 	private static final class FakePageFetcher implements PageFetcher {
 
-		private final Map<String, String> pages = new java.util.HashMap<>();
+		private final Map<String, FetchedPage> pages = new java.util.HashMap<>();
 
 		private void stub(String url, String body) {
-			pages.put(url, body);
+			URI uri = URI.create(url);
+			pages.put(url, new FetchedPage(uri, uri, 200, "text/html", body));
+		}
+
+		private void stubRedirect(String requestedUrl, String finalUrl, String body) {
+			pages.put(requestedUrl, new FetchedPage(
+				URI.create(requestedUrl),
+				URI.create(finalUrl),
+				200,
+				"text/html",
+				body
+			));
 		}
 
 		@Override
 		public FetchedPage fetch(URI uri) {
-			String body = pages.get(uri.toString());
-			if (body == null) {
+			FetchedPage page = pages.get(uri.toString());
+			if (page == null) {
 				throw new AssertionError("No stubbed page for " + uri);
 			}
-			return new FetchedPage(uri, uri, 200, "text/html", body);
+			return page;
 		}
 	}
 }


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-90**
- GitHub: Closes #205
- 선행 작업: #203, #204

### 🔒 Close Issue (필수)
- GitHub: Closes #205

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- 지그재그 앱 단축 공유 링크가 정가 53,900원과 배너 이미지를 반환했습니다.

### 왜 발생했나? (Root Cause)
- `s.zigzag.kr` 단축 링크의 최종 URL이 `store.zigzag.kr`인데, 지그재그 전용 상품 상태 추출 대상에는 `zigzag.kr`만 포함돼 범용 추출기로 폴백했습니다.

### 어떻게 고쳤나?
- `store.zigzag.kr` 최종 상품 페이지도 상품 ID 기반 지그재그 상태 추출 대상으로 포함했습니다.
- `s.zigzag.kr`, `link.zigzag.kr`, `store.zigzag.kr` 리다이렉트 체인을 검증 대상 호스트로 포함했습니다.
- 실제 단축 링크 `https://s.zigzag.kr/hsiVNfPqd4`를 실사이트 회귀 표본에 추가했습니다.

## 🧯 재현 & 검증
- 단축 링크가 `store.zigzag.kr/catalog/products/136095576`으로 이동한 뒤 현재가 29,800원과 해당 상품 PDP 이미지를 반환하는지 검증합니다.
- [x] 회귀 테스트 추가

## ✅ Acceptance Criteria (AC)
- [x] 지그재그 단축 링크가 `ZIGZAG_PRODUCT_STATE` 경로를 사용한다.
- [x] 상품 136095576이 29,800원과 상품 PDP 이미지를 반환한다.
- [x] 제보 단축 링크를 포함한 지그재그 실사이트 검증이 통과한다.

## 🧪 테스트 / 검증
```text
./gradlew test --tests 'com.sagongsa.backend.itemimport.item.ShoppingLinkImportServiceTest' --no-daemon --console=plain
BUILD SUCCESSFUL in 25s

./gradlew test --tests 'com.sagongsa.backend.itemimport.item.*' --no-daemon --console=plain
BUILD SUCCESSFUL in 31s

SHOPPING_IMPORT_LIVE_TEST=true ./gradlew test \
  --tests 'com.sagongsa.backend.itemimport.item.ShoppingLinkImportLiveAccuracyTest.verifiesReportedShareLinkRegressionsAgainstSourceMetadata' \
  --no-daemon --console=plain
BUILD SUCCESSFUL in 46s
```

## 🧭 영향 범위
- [x] API 스펙 변경 없음
- [x] DB 스키마 변경 없음
- [x] 설정/환경변수 변경 없음
- [x] 지그재그 단축 링크 리다이렉트 추출 경로 영향 있음

## 💥 Breaking / Compatibility
- [x] Breaking change 없음

## ⚠️ 리스크 & 롤백
- 지그재그 호스트나 임베디드 상태 구조 변경 시 추출 실패 가능성이 있습니다.
- [x] PR revert 및 이전 배포 산출물로 롤백 가능

## 💬 리뷰 가이드
- `store.zigzag.kr`가 상품 ID 일치 상태만 선택하는지 확인해 주세요.
- 단축 호스트가 최종 검증 상품 호스트 밖으로 이동하면 거부되는지 확인해 주세요.
