### PR TITLE
[fix] NF-91 29CM·에이블리 현재가 추출 보완

### DIFF
--- a/src/main/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcher.java
@@ -17,12 +17,16 @@ import java.time.Duration;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
 public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 
 	private static final String ABLY_MOBILE_HOST = "m.a-bly.com";
+	private static final Pattern ABLY_PRODUCT_PRICE_META = Pattern.compile(
+		"(?is)<meta[^>]*property\\s*=\\s*[\\\"']product:price:amount[\\\"'][^>]*content\\s*=\\s*[\\\"']\\s*[1-9][0-9,]*"
+	);
 	private static final String IOS_MOBILE_USER_AGENT =
 		"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 "
 			+ "(KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
@@ -84,6 +88,7 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 					);
 					waitForNetworkIdle(page);
 					waitForRenderDelay(page);
+					waitForAblyProductMetadata(page, uri);
 
 					URI finalUri = URI.create(page.url());
 					ShoppingUrlSafety.validatePublicHost(finalUri);
@@ -92,10 +97,15 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 						throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Rendered shopping page response is too large");
 					}
 
+					int statusCode = response == null ? 200 : response.status();
+					if (isAblyMobileUri(finalUri) && hasAblyProductMetadata(body)) {
+						statusCode = 200;
+					}
+
 					return new FetchedPage(
 						uri,
 						finalUri,
-						response == null ? 200 : response.status(),
+						statusCode,
 						response == null ? "text/html" : response.headerValue("content-type"),
 						body
 					);
@@ -214,6 +224,24 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 		if (!isZeroOrNegative(renderWait)) {
 			page.waitForTimeout(toMillis(renderWait));
 		}
+	}
+
+	private void waitForAblyProductMetadata(Page page, URI uri) {
+		if (!isAblyMobileUri(uri)) {
+			return;
+		}
+		try {
+			page.waitForSelector(
+				"meta[property='product:price:amount']",
+				new Page.WaitForSelectorOptions().setTimeout(Math.min(toMillis(properties.getTimeout()), 10_000))
+			);
+		} catch (PlaywrightException ignored) {
+			// Keep the challenge page so the caller can report a normal import failure.
+		}
+	}
+
+	static boolean hasAblyProductMetadata(String body) {
+		return body != null && ABLY_PRODUCT_PRICE_META.matcher(body).find();
 	}
 
 	private boolean isZeroOrNegative(Duration duration) {

--- a/src/main/java/com/sagongsa/backend/itemimport/item/FallbackPageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/FallbackPageFetcher.java
@@ -73,8 +73,15 @@ public class FallbackPageFetcher implements PageFetcher, AutoCloseable {
 	private boolean isKnownErrorShell(FetchedPage page) {
 		String host = Optional.ofNullable(page.finalUri().getHost()).orElse("").toLowerCase(Locale.ROOT);
 		String body = Optional.ofNullable(page.body()).orElse("");
-		return (host.equals("brand.naver.com") || host.equals("smartstore.naver.com"))
+		boolean naverErrorShell = (host.equals("brand.naver.com") || host.equals("smartstore.naver.com"))
 			&& (body.contains("시스템오류") || body.contains("에러페이지"));
+		boolean ablyChallengeShell = host.equals("m.a-bly.com")
+			&& (body.contains("보안 확인 중")
+				|| body.contains("에이블리에 연결하고 있습니다")
+				|| body.contains("challenge-error-text")
+				|| body.contains("/cdn-cgi/challenge-platform/")
+				|| body.contains("Enable JavaScript and cookies to continue"));
+		return naverErrorShell || ablyChallengeShell;
 	}
 
 	private boolean shouldFallback(HttpStatusCode statusCode) {

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
@@ -40,6 +40,9 @@ public class ShoppingLinkImportService {
 	private static final Pattern MUSINSA_FINAL_PRICE_PATTERN = Pattern.compile(
 		"(?s)\\\"goodsPrice\\\"\\s*:\\s*\\{.{0,2000}?\\\"finalPrice\\\"\\s*:\\s*([0-9]+)"
 	);
+	private static final Pattern TWENTY_NINE_CM_DISPLAYED_PRICE_PATTERN = Pattern.compile(
+		"(?s)\"id\"\\s*:\\s*\"pdp_product_price\".{0,500}?\"children\"\\s*:\\s*\\[\"([0-9][0-9,]*)\""
+	);
 	private static final Set<String> NOISE_IMAGE_KEYWORDS = Set.of("logo", "icon", "sprite", "badge", "banner");
 	private static final Set<String> TRACKING_QUERY_KEYS = Set.of(
 		"fbclid", "gclid", "igshid", "mc_cid", "mc_eid", "n_media", "n_query", "n_rank", "n_ad_group"
@@ -263,12 +266,16 @@ public class ShoppingLinkImportService {
 		String productJsonLdCurrency = productJsonLdText(document, "offers.priceCurrency");
 		String productJsonLdImage = productJsonLdText(document, "image");
 		String productMetaPrice = metaContent(document, "meta[property=product:price:amount]");
+		String ablyDisplayedPrice = isAblyDomain(sourceDomain) && isPositivePrice(productMetaPrice)
+			? productMetaPrice
+			: null;
 		String siteSalePrice = isOliveYoungDomain(sourceDomain)
 			? metaContent(document, "meta[property=eg:salePrice]")
 			: null;
 		String musinsaFinalPrice = isMusinsaDomain(sourceDomain)
 			? findByRegex(html, MUSINSA_FINAL_PRICE_PATTERN)
 			: null;
+		String twentyNineCmDisplayedPrice = twentyNineCmDisplayedPrice(document, html, sourceDomain);
 		String summary = firstNonBlank(
 			productJsonLdDescription,
 			embeddedMetadata.description(),
@@ -299,6 +306,8 @@ public class ShoppingLinkImportService {
 			parseListedPrice(siteSalePrice),
 			parseListedPrice(musinsaFinalPrice),
 			parseListedPrice(zigzagMetadata.priceText()),
+			parseListedPrice(twentyNineCmDisplayedPrice),
+			parseListedPrice(ablyDisplayedPrice),
 			parseListedPrice(productJsonLdPrice),
 			parseListedPrice(productMetaPrice),
 			parseListedPrice(embeddedMetadata.priceText()),
@@ -311,6 +320,8 @@ public class ShoppingLinkImportService {
 			siteSalePrice,
 			musinsaFinalPrice,
 			zigzagMetadata.priceText(),
+			twentyNineCmDisplayedPrice,
+			ablyDisplayedPrice,
 			productJsonLdPrice,
 			productMetaPrice,
 			embeddedMetadata.priceText(),
@@ -338,6 +349,10 @@ public class ShoppingLinkImportService {
 		String method = "OPEN_GRAPH";
 		if (zigzagMetadata.hasAnyValue()) {
 			method = "ZIGZAG_PRODUCT_STATE";
+		} else if (!isBlank(twentyNineCmDisplayedPrice)) {
+			method = "TWENTY_NINE_CM_PAGE_STATE";
+		} else if (!isBlank(ablyDisplayedPrice)) {
+			method = "ABLY_PRODUCT_META";
 		} else if (!isBlank(productJsonLdTitle) || !isBlank(productJsonLdPrice) || !isBlank(productJsonLdImage)) {
 			method = "JSON_LD";
 		} else if (embeddedMetadata.hasAnyValue()) {
@@ -372,6 +387,26 @@ public class ShoppingLinkImportService {
 			method,
 			rawPayloadJson
 		);
+	}
+
+	private String twentyNineCmDisplayedPrice(Document document, String html, String sourceDomain) {
+		if (!"29cm.co.kr".equals(sourceDomain) && !"product.29cm.co.kr".equals(sourceDomain)) {
+			return null;
+		}
+		String renderedPrice = firstText(document, "#pdp_product_price");
+		if (!isBlank(renderedPrice)) {
+			return renderedPrice;
+		}
+		return findByRegex(html.replace("\\\"", "\""), TWENTY_NINE_CM_DISPLAYED_PRICE_PATTERN);
+	}
+
+	private boolean isPositivePrice(String value) {
+		Integer parsed = parseListedPrice(value);
+		return parsed != null && parsed > 0;
+	}
+
+	private boolean isAblyDomain(String sourceDomain) {
+		return "m.a-bly.com".equals(sourceDomain);
 	}
 
 	private ZigzagMetadata zigzagMetadata(Document document, URI finalUri) {

--- a/src/test/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcherTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcherTest.java
@@ -75,4 +75,15 @@ class BrowserPageFetcherTest {
 
 		verify(route).abort();
 	}
+
+	@Test
+	void recognizesRenderedAblyProductMetadataOnlyForPositivePrice() {
+		assertThat(BrowserPageFetcher.hasAblyProductMetadata(
+			"<meta property=\"product:price:amount\" content=\"52,110\">"
+		)).isTrue();
+		assertThat(BrowserPageFetcher.hasAblyProductMetadata(
+			"<meta property=\"product:price:amount\" content=\"0\">"
+		)).isFalse();
+		assertThat(BrowserPageFetcher.hasAblyProductMetadata("<title>보안 확인 중..</title>")).isFalse();
+	}
 }

--- a/src/test/java/com/sagongsa/backend/itemimport/item/FallbackPageFetcherTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/FallbackPageFetcherTest.java
@@ -72,4 +72,28 @@ class FallbackPageFetcherTest {
 			URI.create("https://m.smartstore.naver.com/sample/products/11933395125")
 		);
 	}
+
+	@Test
+	void usesBrowserFallbackForAblyCloudflareChallengeShell() {
+		URI uri = URI.create("https://m.a-bly.com/goods/70247267");
+		AtomicReference<URI> fallbackRequest = new AtomicReference<>();
+		FallbackPageFetcher fetcher = new FallbackPageFetcher(
+			requestedUri -> new FetchedPage(
+				requestedUri,
+				requestedUri,
+				200,
+				"text/html",
+				"<html><title>보안 확인 중..</title><body>에이블리에 연결하고 있습니다</body></html>"
+			),
+			requestedUri -> {
+				fallbackRequest.set(requestedUri);
+				return new FetchedPage(requestedUri, requestedUri, 200, "text/html", "<html>rendered product</html>");
+			}
+		);
+
+		FetchedPage page = fetcher.fetch(uri);
+
+		assertThat(fallbackRequest.get()).isEqualTo(uri);
+		assertThat(page.body()).contains("rendered product");
+	}
 }

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportLiveAccuracyTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportLiveAccuracyTest.java
@@ -37,6 +37,9 @@ class ShoppingLinkImportLiveAccuracyTest {
 	private static final Pattern MUSINSA_FINAL_PRICE = Pattern.compile(
 		"(?s)\\\"goodsPrice\\\"\\s*:\\s*\\{.{0,2000}?\\\"finalPrice\\\"\\s*:\\s*([0-9]+)"
 	);
+	private static final Pattern TWENTY_NINE_CM_DISPLAYED_PRICE = Pattern.compile(
+		"(?s)\"id\"\\s*:\\s*\"pdp_product_price\".{0,500}?\"children\"\\s*:\\s*\\[\"([0-9][0-9,]*)\""
+	);
 	private static final Pattern WON_PRICE = Pattern.compile("([0-9][0-9,]*)\\s*원");
 	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 	private static final String VERIFIED_ZIGZAG_URL =
@@ -267,7 +270,8 @@ class ShoppingLinkImportLiveAccuracyTest {
 
 		int verified;
 		try (BrowserPageFetcher browser = new BrowserPageFetcher(properties.getBrowserFetch(), 20_000_000)) {
-			verified = verifyCandidates(ABLY_PRODUCT_URLS, 10, mismatches, unavailable, browser);
+			PageFetcher fetcher = new FallbackPageFetcher(new JsoupPageFetcher(20_000_000), browser);
+			verified = verifyCandidates(ABLY_PRODUCT_URLS, 10, mismatches, unavailable, fetcher);
 		}
 
 		assertThat(mismatches).as("Ably title, KRW price, and product image must match").isEmpty();
@@ -286,7 +290,8 @@ class ShoppingLinkImportLiveAccuracyTest {
 		int ably;
 		int oliveYoung;
 		try (BrowserPageFetcher browser = new BrowserPageFetcher(properties.getBrowserFetch(), 20_000_000)) {
-			ably = verifyCandidates(REPORTED_ABLY_SHARE_URLS, 3, mismatches, unavailable, browser);
+			PageFetcher ablyFetcher = new FallbackPageFetcher(new JsoupPageFetcher(20_000_000), browser);
+			ably = verifyCandidates(REPORTED_ABLY_SHARE_URLS, 3, mismatches, unavailable, ablyFetcher);
 			oliveYoung = verifyCandidates(List.of(REPORTED_OLIVE_YOUNG_URL), 1, mismatches, unavailable, browser);
 		}
 		ShoppingLinkImportService service = new ShoppingLinkImportService(new JsoupPageFetcher(10_000_000), OBJECT_MAPPER);
@@ -479,9 +484,12 @@ class ShoppingLinkImportLiveAccuracyTest {
 		}
 		if (host.equals("www.29cm.co.kr") || host.equals("product.29cm.co.kr")) {
 			JsonNode product = productJsonLd(document);
+			String displayedPrice = regexGroup(
+				TWENTY_NINE_CM_DISPLAYED_PRICE.matcher(page.body().replace("\\\"", "\""))
+			);
 			return new SourceProduct(
 				product.path("name").asText(),
-				product.path("offers").path("price").decimalValue().intValueExact(),
+				Integer.valueOf(displayedPrice.replace(",", "")),
 				meta(document, "meta[property=og:image]")
 			);
 		}
@@ -489,7 +497,7 @@ class ShoppingLinkImportLiveAccuracyTest {
 			JsonNode product = productJsonLd(document);
 			return new SourceProduct(
 				product.path("name").asText(),
-				product.path("offers").path("price").decimalValue().intValueExact(),
+				Integer.valueOf(meta(document, "meta[property=product:price:amount]").replace(",", "")),
 				firstTextValue(product.path("image"))
 			);
 		}

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
@@ -748,6 +748,41 @@ class ShoppingLinkImportServiceTest {
 	}
 
 	@Test
+	void prefersTwentyNineCmDisplayedPriceOverJsonLdPrice() {
+		String url = "https://www.29cm.co.kr/products/3853210";
+		pageFetcher.stub(
+			url,
+			"""
+				<html>
+				<head>
+				  <meta property="og:image" content="https://img.29cm.co.kr/product.jpg" />
+				  <script type="application/ld+json">
+				  {
+				    "@type": "Product",
+				    "name": "Ruby Berry Tee-Lavender",
+				    "image": "https://img.29cm.co.kr/product.jpg",
+				    "offers": {"price": 41800, "priceCurrency": "KRW"}
+				  }
+				  </script>
+				</head>
+				<body>
+				  <strong id="pdp_product_price">31,980<span>원</span></strong>
+				</body>
+				</html>
+				"""
+		);
+
+		ShoppingLinkImportResponse response = service.importLink(
+			new ShoppingLinkImportRequest(ItemInputSource.SHARE, url, null, null, null, null)
+		);
+
+		assertThat(response.item().listedPrice()).isEqualTo(31980);
+		assertThat(response.item().title()).isEqualTo("Ruby Berry Tee-Lavender");
+		assertThat(response.item().imageUrl()).isEqualTo("https://img.29cm.co.kr/product.jpg");
+		assertThat(response.sourceMetadata().extractionMethod()).isEqualTo("TWENTY_NINE_CM_PAGE_STATE");
+	}
+
+	@Test
 	void normalizesZigzagStoreShareLinkToPublicProductDetail() {
 		String canonicalUrl = "https://zigzag.kr/catalog/products/136095576?catalog_product_id=136095576";
 		pageFetcher.stub(canonicalUrl, completeProductMetadata("모먼트 투커버 올데이슬랙스"));
@@ -785,6 +820,40 @@ class ShoppingLinkImportServiceTest {
 
 		assertThat(response.item().normalizedUrl()).isEqualTo(canonicalUrl);
 		assertThat(response.warnings()).contains("에이블리 공유 링크를 모바일 상품 경로로 정규화했습니다.");
+	}
+
+	@Test
+	void prefersPositiveAblyProductMetaPriceOverZeroJsonLdPrice() {
+		String url = "https://m.a-bly.com/goods/70247267";
+		pageFetcher.stub(
+			url,
+			"""
+				<html>
+				<head>
+				  <meta property="product:price:amount" content="52,110" />
+				  <meta property="og:image" content="https://d3ha2047wt6x28.cloudfront.net/product.jpg" />
+				  <script type="application/ld+json">
+				  {
+				    "@type": "Product",
+				    "name": "made 엣지 여름 슬랙스",
+				    "image": "https://d3ha2047wt6x28.cloudfront.net/product.jpg",
+				    "offers": {"price": 0, "priceCurrency": "KRW"}
+				  }
+				  </script>
+				</head>
+				<body></body>
+				</html>
+				"""
+		);
+
+		ShoppingLinkImportResponse response = service.importLink(
+			new ShoppingLinkImportRequest(ItemInputSource.SHARE, url, null, null, null, null)
+		);
+
+		assertThat(response.item().listedPrice()).isEqualTo(52110);
+		assertThat(response.item().title()).isEqualTo("made 엣지 여름 슬랙스");
+		assertThat(response.item().imageUrl()).isEqualTo("https://d3ha2047wt6x28.cloudfront.net/product.jpg");
+		assertThat(response.sourceMetadata().extractionMethod()).isEqualTo("ABLY_PRODUCT_META");
 	}
 
 	@Test


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-91**
- GitHub: Closes #207
- 선행 작업: #205, #206

### 🔒 Close Issue (필수)
- GitHub: Closes #207

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- 29CM 제보 상품 3건이 화면 현재가보다 높은 JSON-LD 가격을 반환했습니다.
- 에이블리 제보 상품 3건은 가격이 `0원`으로 저장되거나 가져오기에 실패했습니다.

### 왜 발생했나? (Root Cause)
- 29CM은 화면의 `pdp_product_price`보다 범용 JSON-LD `offers.price`를 먼저 선택했습니다.
- 에이블리의 HTTP 200 보안 확인 셸을 정상 상품 HTML로 오인해 브라우저 폴백이 실행되지 않았습니다.
- 브라우저가 보안 확인 뒤 상품 페이지로 이동해도 최초 응답 상태가 남을 수 있었고, JSON-LD의 `0` 가격도 유효 후보로 채택될 수 있었습니다.

### 어떻게 고쳤나?
- 29CM 화면 렌더링 상태의 `pdp_product_price`를 우선 추출합니다.
- 에이블리 보안 확인 셸을 감지해 브라우저 폴백으로 전환합니다.
- 브라우저에서 양수 상품 가격 메타가 렌더링될 때까지 기다리고, 해당 상품 문서만 정상 응답으로 인정합니다.
- 에이블리는 양수인 `product:price:amount`를 JSON-LD 가격보다 우선합니다.
- 라이브 정확성 테스트가 구현과 독립적인 화면/상품 메타 가격을 기대값으로 사용하도록 보완했습니다.

## 🧯 재현 & 검증
- 29CM `3853210 / 3307910 / 3053978`: `31,980 / 24,420 / 25,200원`
- 에이블리 `70247267 / 62561082 / 70219189`: `52,110 / 28,310 / 17,700원`
- 각 상품의 상품명·원화 가격·상품 이미지를 원본 상품 페이지와 대조합니다.
- [x] 회귀 테스트 추가

## ✅ Acceptance Criteria (AC)
- [x] 29CM 제보 3건이 화면 현재가를 반환한다.
- [x] 에이블리 보안 확인 셸이 브라우저 폴백을 실행한다.
- [x] 에이블리 제보 3건이 `0`이 아닌 현재가를 반환한다.
- [x] 제보 상품의 상품명·원화 가격·상품 이미지가 원본과 일치한다.

## 🧪 테스트 / 검증
```text
./gradlew test --tests 'com.sagongsa.backend.itemimport.item.ShoppingLinkImportServiceTest' \
  --tests 'com.sagongsa.backend.itemimport.item.FallbackPageFetcherTest' \
  --tests 'com.sagongsa.backend.itemimport.item.BrowserPageFetcherTest'
BUILD SUCCESSFUL in 26s

./gradlew test --tests 'com.sagongsa.backend.itemimport.item.*' --no-daemon --console=plain
BUILD SUCCESSFUL in 32s

SHOPPING_IMPORT_LIVE_TEST=true ./gradlew test \
  --tests 'com.sagongsa.backend.itemimport.item.ShoppingLinkImportLiveAccuracyTest.verifiesReportedShareLinkRegressionsAgainstSourceMetadata'
BUILD SUCCESSFUL in 1m 10s
```

## 🧭 영향 범위
- [x] API 스펙 변경 없음
- [x] DB 스키마 변경 없음
- [x] 설정/환경변수 변경 없음
- [x] 29CM·에이블리 상품 링크 추출 경로 영향 있음

## 💥 Breaking / Compatibility
- [x] Breaking change 없음

## ⚠️ 리스크 & 롤백
- 외부 상품 페이지의 렌더링 구조나 보안 확인 방식이 변경되면 다시 추출에 실패할 수 있습니다.
- 에이블리 브라우저 폴백은 일반 HTTP 수집보다 처리 시간이 깁니다.
- [x] PR revert 및 이전 배포 산출물로 롤백 가능

## 💬 리뷰 가이드
- 보안 확인 HTML 자체를 상품 성공으로 인정하지 않는지 확인해 주세요.
- 에이블리 가격 `0`이 양수 상품 메타보다 우선되지 않는지 확인해 주세요.
- 29CM 화면 현재가 오라클이 범용 JSON-LD와 독립적인지 확인해 주세요.
