### PR TITLE
[fix] NF-92 에이블리 GCP 상품 API 폴백 추가

### DIFF
--- a/docs/SHOPPING_BROWSER_FETCHER_OPERATIONS.md
+++ b/docs/SHOPPING_BROWSER_FETCHER_OPERATIONS.md
@@ -40,6 +40,13 @@
 
 - KREAM이 배포 서버의 출구 IP에 빈 5xx를 반환하는 환경에서만 전용 프록시를 활성화한다.
 - `SHOPPING_IMPORT_KREAM_PROXY_ENABLED=true`, `SHOPPING_IMPORT_KREAM_PROXY_TYPE=SOCKS|HTTP`, `SHOPPING_IMPORT_KREAM_PROXY_HOST`, `SHOPPING_IMPORT_KREAM_PROXY_PORT`를 설정한다.
+
+## 에이블리 상품 API 폴백
+
+- GCP 등 서버 egress에서 `m.a-bly.com` 보안 확인이 완료되지 않으면 웹 페이지 렌더링 대신 에이블리 상품 API를 사용한다.
+- `SHOPPING_IMPORT_ABLY_API_ENABLED=true`, `SHOPPING_IMPORT_ABLY_ANONYMOUS_TOKEN`, `SHOPPING_IMPORT_ABLY_API_TIMEOUT=PT5S`를 설정한다.
+- 익명 토큰은 에이블리 웹 상품 페이지가 발급한 값만 사용하고, 저장소와 로그에 커밋하지 않는다.
+- API 설정이 없거나 API 호출이 실패하면 기존 HTML 수집과 브라우저 폴백을 계속 사용한다.
 - 프록시는 KREAM 및 KREAM API 호스트에만 적용되며 다른 쇼핑몰 요청은 기존 출구를 유지한다.
 - 인증 없는 내부 프록시를 전제로 하므로 방화벽에서 백엔드 서버 IP만 접근 가능하게 제한한다.
 - 활성화 전후로 동일 상품을 순차/동시 호출해 제목, 양수 가격, 유효 이미지와 5xx/429 여부를 확인한다.

--- a/src/main/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcher.java
@@ -37,6 +37,7 @@ public class JsoupPageFetcher implements PageFetcher {
 	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 	private static final Pattern BUNJANG_PRODUCT_PATH_PATTERN = Pattern.compile("^/products/(\\d+)(?:/.*)?$");
 	private static final Pattern KREAM_PRODUCT_PATH_PATTERN = Pattern.compile("^/products/(\\d+)(?:/.*)?$");
+	private static final Pattern ABLY_PRODUCT_PATH_PATTERN = Pattern.compile("^/goods/(\\d+)(?:/.*)?$");
 	private static final DateTimeFormatter KREAM_CLIENT_DATETIME_FORMATTER =
 		DateTimeFormatter.ofPattern("yyyyMMddHHmmssXX");
 	private static final Pattern JS_HTTP_ASSIGNMENT_PATTERN = Pattern.compile(
@@ -62,6 +63,7 @@ public class JsoupPageFetcher implements PageFetcher {
 	private final int maxAttempts;
 	private final int maxResponseBytes;
 	private final ShoppingImportProperties.KreamProxy kreamProxy;
+	private final ShoppingImportProperties.AblyApi ablyApi;
 
 	public JsoupPageFetcher() {
 		this(DEFAULT_MAX_RESPONSE_BYTES);
@@ -72,7 +74,15 @@ public class JsoupPageFetcher implements PageFetcher {
 	}
 
 	JsoupPageFetcher(int maxResponseBytes, ShoppingImportProperties.KreamProxy kreamProxy) {
-		this(DEFAULT_TIMEOUT_MILLIS, DEFAULT_MAX_ATTEMPTS, maxResponseBytes, kreamProxy);
+		this(maxResponseBytes, kreamProxy, new ShoppingImportProperties.AblyApi());
+	}
+
+	JsoupPageFetcher(
+		int maxResponseBytes,
+		ShoppingImportProperties.KreamProxy kreamProxy,
+		ShoppingImportProperties.AblyApi ablyApi
+	) {
+		this(DEFAULT_TIMEOUT_MILLIS, DEFAULT_MAX_ATTEMPTS, maxResponseBytes, kreamProxy, ablyApi);
 	}
 
 	JsoupPageFetcher(int timeoutMillis, int maxAttempts) {
@@ -89,14 +99,34 @@ public class JsoupPageFetcher implements PageFetcher {
 		int maxResponseBytes,
 		ShoppingImportProperties.KreamProxy kreamProxy
 	) {
+		this(timeoutMillis, maxAttempts, maxResponseBytes, kreamProxy, new ShoppingImportProperties.AblyApi());
+	}
+
+	JsoupPageFetcher(
+		int timeoutMillis,
+		int maxAttempts,
+		int maxResponseBytes,
+		ShoppingImportProperties.KreamProxy kreamProxy,
+		ShoppingImportProperties.AblyApi ablyApi
+	) {
 		this.timeoutMillis = timeoutMillis <= 0 ? DEFAULT_TIMEOUT_MILLIS : timeoutMillis;
 		this.maxAttempts = maxAttempts <= 0 ? DEFAULT_MAX_ATTEMPTS : maxAttempts;
 		this.maxResponseBytes = maxResponseBytes <= 0 ? DEFAULT_MAX_RESPONSE_BYTES : maxResponseBytes;
 		this.kreamProxy = kreamProxy == null ? new ShoppingImportProperties.KreamProxy() : kreamProxy;
+		this.ablyApi = ablyApi == null ? new ShoppingImportProperties.AblyApi() : ablyApi;
 	}
 
 	@Override
 	public FetchedPage fetch(URI uri) {
+		try {
+			Optional<FetchedPage> ablyProductPage = ablyProductApiPage(uri);
+			if (ablyProductPage.isPresent()) {
+				return ablyProductPage.get();
+			}
+		} catch (IOException ignored) {
+			// Continue with the regular HTML and browser fallback path.
+		}
+
 		try {
 			Optional<FetchedPage> kreamProductPage = kreamProductApiPage(uri);
 			if (kreamProductPage.isPresent()) {
@@ -436,6 +466,78 @@ public class JsoupPageFetcher implements PageFetcher {
 		enforceBodySize(apiResponse.body());
 		return kreamProductMetadataHtml(apiResponse.body())
 			.map(html -> new FetchedPage(requestedUri, requestedUri, 200, "text/html; charset=UTF-8", html));
+	}
+
+	private Optional<FetchedPage> ablyProductApiPage(URI requestedUri) throws IOException {
+		Optional<String> productId = ablyProductId(requestedUri);
+		if (productId.isEmpty() || !ablyApi.isConfigured()) {
+			return Optional.empty();
+		}
+
+		URI apiUri = URI.create("https://api.a-bly.com/api/v3/goods/" + productId.get() + "/basic/");
+		ShoppingUrlSafety.validatePublicHost(apiUri);
+		int apiTimeoutMillis = (int) Math.max(1, Math.min(ablyApi.getTimeout().toMillis(), timeoutMillis));
+		Connection.Response apiResponse = Jsoup.connect(apiUri.toString())
+			.userAgent(ANDROID_USER_AGENT)
+			.header("Accept", "application/json, text/plain, */*")
+			.header("Accept-Language", "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7")
+			.header("Origin", "https://m.a-bly.com")
+			.header("Referer", requestedUri.toString())
+			.header("X-Anonymous-Token", ablyApi.getAnonymousToken())
+			.header("X-Device-Id", UUID.randomUUID().toString())
+			.header("X-Web-Type", "Web")
+			.header("X-Device-Type", "MobileWeb")
+			.header("X-App-Version", "0.1.0")
+			.ignoreContentType(true)
+			.ignoreHttpErrors(true)
+			.timeout(apiTimeoutMillis)
+			.maxBodySize(maxResponseBytes)
+			.execute();
+
+		if (apiResponse.statusCode() >= 400) {
+			return Optional.empty();
+		}
+		enforceBodySize(apiResponse.body());
+		return ablyProductMetadataHtml(apiResponse.body())
+			.map(html -> new FetchedPage(requestedUri, requestedUri, 200, "text/html; charset=UTF-8", html));
+	}
+
+	private static Optional<String> ablyProductId(URI uri) {
+		String host = Optional.ofNullable(uri.getHost()).orElse("").toLowerCase(Locale.ROOT);
+		if (!host.equals("m.a-bly.com")) {
+			return Optional.empty();
+		}
+		String path = Optional.ofNullable(uri.getPath()).orElse("");
+		Matcher matcher = ABLY_PRODUCT_PATH_PATTERN.matcher(path);
+		return matcher.matches() ? Optional.of(matcher.group(1)) : Optional.empty();
+	}
+
+	static Optional<String> ablyProductMetadataHtml(String apiBody) {
+		if (apiBody == null || apiBody.isBlank()) {
+			return Optional.empty();
+		}
+		try {
+			JsonNode goods = OBJECT_MAPPER.readTree(apiBody).path("goods");
+			String title = jsonText(goods, "name");
+			String price = jsonText(goods, "price_info", "thumbnail_price");
+			String imageUrl = firstJsonArrayText(goods.path("cover_images"));
+			String brandName = jsonText(goods, "market", "name");
+			if (isBlank(title) || isBlank(price) || isBlank(imageUrl) || "0".equals(price)) {
+				return Optional.empty();
+			}
+
+			StringBuilder html = new StringBuilder("<!doctype html><html><head>");
+			html.append("<title>").append(escapeHtml(title)).append("</title>");
+			appendPropertyMeta(html, "og:title", title);
+			appendPropertyMeta(html, "og:image", imageUrl);
+			appendPropertyMeta(html, "product:price:amount", price);
+			appendPropertyMeta(html, "product:price:currency", "KRW");
+			appendPropertyMeta(html, "kakao:commerce:brand_name", brandName);
+			html.append("</head><body></body></html>");
+			return Optional.of(html.toString());
+		} catch (JsonProcessingException exception) {
+			return Optional.empty();
+		}
 	}
 
 	private static Optional<String> kreamProductId(URI uri) {

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportConfig.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportConfig.java
@@ -13,7 +13,11 @@ public class ShoppingImportConfig {
 		ShoppingImportProperties.BrowserFetch browserFetch = properties.getBrowserFetch();
 		ShoppingImportProperties.KreamProxy kreamProxy = properties.getKreamProxy();
 		kreamProxy.validate();
-		JsoupPageFetcher jsoupPageFetcher = new JsoupPageFetcher(properties.getMaxResponseBytes(), kreamProxy);
+		JsoupPageFetcher jsoupPageFetcher = new JsoupPageFetcher(
+			properties.getMaxResponseBytes(),
+			kreamProxy,
+			properties.getAblyApi()
+		);
 		if (browserFetch.isEnabled()) {
 			return new FallbackPageFetcher(
 				jsoupPageFetcher,

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportProperties.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportProperties.java
@@ -12,6 +12,7 @@ public class ShoppingImportProperties {
 	private final BrowserFetch browserFetch = new BrowserFetch();
 	private final JobWorker jobWorker = new JobWorker();
 	private final KreamProxy kreamProxy = new KreamProxy();
+	private final AblyApi ablyApi = new AblyApi();
 
 	public int getMaxResponseBytes() {
 		return maxResponseBytes;
@@ -31,6 +32,45 @@ public class ShoppingImportProperties {
 
 	public KreamProxy getKreamProxy() {
 		return kreamProxy;
+	}
+
+	public AblyApi getAblyApi() {
+		return ablyApi;
+	}
+
+	public static class AblyApi {
+
+		private boolean enabled = true;
+		private String anonymousToken;
+		private Duration timeout = Duration.ofSeconds(5);
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public String getAnonymousToken() {
+			return anonymousToken;
+		}
+
+		public void setAnonymousToken(String anonymousToken) {
+			this.anonymousToken = anonymousToken == null ? null : anonymousToken.trim();
+		}
+
+		public Duration getTimeout() {
+			return timeout;
+		}
+
+		public void setTimeout(Duration timeout) {
+			this.timeout = timeout == null ? Duration.ofSeconds(5) : timeout;
+		}
+
+		boolean isConfigured() {
+			return enabled && anonymousToken != null && !anonymousToken.isBlank();
+		}
 	}
 
 	public static class JobWorker {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -90,6 +90,10 @@ app:
         type: ${SHOPPING_IMPORT_KREAM_PROXY_TYPE:SOCKS}
         host: ${SHOPPING_IMPORT_KREAM_PROXY_HOST:}
         port: ${SHOPPING_IMPORT_KREAM_PROXY_PORT:1080}
+      ably-api:
+        enabled: ${SHOPPING_IMPORT_ABLY_API_ENABLED:true}
+        anonymous-token: ${SHOPPING_IMPORT_ABLY_ANONYMOUS_TOKEN:}
+        timeout: ${SHOPPING_IMPORT_ABLY_API_TIMEOUT:PT5S}
       browser-fetch:
         enabled: ${SHOPPING_IMPORT_BROWSER_FETCH_ENABLED:true}
         timeout: ${SHOPPING_IMPORT_BROWSER_FETCH_TIMEOUT:PT30S}

--- a/src/test/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcherTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcherTest.java
@@ -278,4 +278,45 @@ class JsoupPageFetcherTest {
 		assertThat(document.selectFirst("meta[property=kakao:commerce:brand_name]").attr("content"))
 			.isEqualTo("나이키");
 	}
+
+	@Test
+	void buildsAblyProductMetadataHtmlFromPublicProductApiResponse() {
+		String apiBody = """
+			{
+			  "goods": {
+			    "sno": 70247267,
+			    "name": "made 엣지 올브러쉬 부츠컷 데님",
+			    "cover_images": ["https://d3ha2047wt6x28.cloudfront.net/product.jpg"],
+			    "price_info": {
+			      "consumer": 65000,
+			      "thumbnail_price": 52110
+			    },
+			    "market": {"name": "홀리"}
+			  }
+			}
+			""";
+
+		String html = JsoupPageFetcher.ablyProductMetadataHtml(apiBody).orElseThrow();
+		Document document = Jsoup.parse(html);
+
+		assertThat(document.selectFirst("meta[property=og:title]").attr("content"))
+			.isEqualTo("made 엣지 올브러쉬 부츠컷 데님");
+		assertThat(document.selectFirst("meta[property=product:price:amount]").attr("content"))
+			.isEqualTo("52110");
+		assertThat(document.selectFirst("meta[property=product:price:currency]").attr("content"))
+			.isEqualTo("KRW");
+		assertThat(document.selectFirst("meta[property=og:image]").attr("content"))
+			.isEqualTo("https://d3ha2047wt6x28.cloudfront.net/product.jpg");
+		assertThat(document.selectFirst("meta[property=kakao:commerce:brand_name]").attr("content"))
+			.isEqualTo("홀리");
+	}
+
+	@Test
+	void rejectsAblyProductApiMetadataWhenCurrentPriceIsZero() {
+		String apiBody = """
+			{"goods":{"name":"상품","cover_images":["https://example.com/product.jpg"],"price_info":{"thumbnail_price":0}}}
+			""";
+
+		assertThat(JsoupPageFetcher.ablyProductMetadataHtml(apiBody)).isEmpty();
+	}
 }

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportConfigTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportConfigTest.java
@@ -69,6 +69,24 @@ class ShoppingImportConfigTest {
 	}
 
 	@Test
+	void bindsAblyApiSettingsWithoutExposingThemToOtherFetchers() {
+		contextRunner
+			.withPropertyValues(
+				"app.shopping.import.ably-api.enabled=true",
+				"app.shopping.import.ably-api.anonymous-token=test-anonymous-token",
+				"app.shopping.import.ably-api.timeout=PT4S"
+			)
+			.run(context -> {
+				assertThat(context).hasNotFailed();
+				ShoppingImportProperties.AblyApi ablyApi = context.getBean(ShoppingImportProperties.class)
+					.getAblyApi();
+				assertThat(ablyApi.isEnabled()).isTrue();
+				assertThat(ablyApi.getAnonymousToken()).isEqualTo("test-anonymous-token");
+				assertThat(ablyApi.getTimeout()).isEqualTo(Duration.ofSeconds(4));
+			});
+	}
+
+	@Test
 	void rejectsEnabledKreamProxyWithoutHost() {
 		contextRunner
 			.withPropertyValues("app.shopping.import.kream-proxy.enabled=true")


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-92**
- GitHub: Closes #209
- 선행 작업: #208

### 🔒 Close Issue (필수)
- GitHub: Closes #209

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- 로컬에서는 에이블리 상품명·가격·이미지가 정상 추출됐지만, GCP QA 서버에서는 보안 확인 화면이 반복되어 제보 상품 3건이 502로 실패했습니다.
- 그 결과 앱에서는 기존의 `0원` 결과가 그대로 남거나 재가져오기에 실패했습니다.

### 왜 발생했나? (Root Cause)
- GCP 서버 출구 IP에서는 에이블리 상품 페이지를 브라우저로 열어도 Cloudflare 보안 확인을 완료하지 못했습니다.
- HTML과 브라우저 폴백 모두 같은 상품 페이지 접근에 의존해 서버 환경에서 회복할 수 없었습니다.

### 어떻게 고쳤나?
- 에이블리 상품 링크는 웹 페이지가 사용하는 상품 기본정보 API를 먼저 호출합니다.
- 상품명, `thumbnail_price`, 첫 대표 이미지를 기존 메타 추출 형식으로 변환합니다.
- 양수 가격·상품명·이미지가 모두 있을 때만 성공으로 인정합니다.
- API 설정이 없거나 호출이 실패하면 기존 HTML/브라우저 폴백을 유지합니다.
- 익명 토큰은 환경변수로만 주입하며 저장소와 로그에 남기지 않습니다.

## 🧯 재현 & 검증
- 에이블리 `70247267`: `52,110원`
- 에이블리 `62561082`: `28,310원`
- 에이블리 `70219189`: `17,700원`
- 세 상품 모두 API HTTP 200과 상품명·양수 원화 가격·대표 이미지 응답을 확인했습니다.
- [x] 회귀 테스트 추가

## ✅ Acceptance Criteria (AC)
- [x] GCP QA 환경에서 에이블리 보안 확인 페이지에 의존하지 않는다.
- [x] 제보 상품 3건이 `0`이 아닌 현재가를 반환한다.
- [x] 상품명·원화 가격·상품 이미지가 모두 있을 때만 성공한다.
- [x] 민감한 익명 토큰이 코드와 로그에 노출되지 않는다.

## 🧪 테스트 / 검증
```text
./gradlew test --tests 'com.sagongsa.backend.itemimport.item.JsoupPageFetcherTest' \
  --tests 'com.sagongsa.backend.itemimport.item.ShoppingImportConfigTest' \
  --tests 'com.sagongsa.backend.itemimport.item.ShoppingLinkImportServiceTest' \
  --no-daemon --console=plain
BUILD SUCCESSFUL in 1m 32s

./gradlew test --tests 'com.sagongsa.backend.itemimport.item.*' --no-daemon --console=plain
BUILD SUCCESSFUL in 28s
```

## 🧭 영향 범위
- [x] API 스펙 변경 없음
- [x] DB 스키마 변경 없음
- [x] 에이블리 링크 수집 경로 영향 있음
- [x] 환경변수 `SHOPPING_IMPORT_ABLY_ANONYMOUS_TOKEN` 추가

## 💥 Breaking / Compatibility
- [x] Breaking change 없음

## ⚠️ 리스크 & 롤백
- 에이블리 상품 API 또는 익명 세션 정책이 변경되면 토큰 갱신이나 응답 매핑 보완이 필요할 수 있습니다.
- API 실패 시 기존 HTML/브라우저 경로로 자동 폴백합니다.
- [x] PR revert 및 환경변수 제거로 롤백 가능

## 💬 리뷰 가이드
- API 응답의 `thumbnail_price`를 현재가로 선택하는지 확인해 주세요.
- 가격 0 또는 필수 상품 정보 누락을 성공 처리하지 않는지 확인해 주세요.
- 익명 토큰이 설정과 로그 밖으로 노출되지 않는지 확인해 주세요.
