### PR TITLE
[chore] NF-93 상품 링크 가져오기 결과 추적 로그 보강

### DIFF
--- a/src/main/java/com/sagongsa/backend/itemimport/ItemImportController.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/ItemImportController.java
@@ -13,6 +13,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,6 +27,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/items")
 @Tag(name = "Item Import", description = "Shopping link preview API before saving an item to wishlist")
 public class ItemImportController {
+
+	private static final Logger log = LoggerFactory.getLogger(ItemImportController.class);
 
 	private final ShoppingLinkImportService shoppingLinkImportService;
 	private final ShoppingImportJobService shoppingImportJobService;
@@ -48,7 +52,22 @@ public class ItemImportController {
 		}
 	)
 	public ShoppingLinkImportResponse importLink(@RequestBody ShoppingLinkImportRequest request) {
-		return shoppingLinkImportService.importLink(request);
+		ShoppingLinkImportResponse response = shoppingLinkImportService.importLink(request);
+		logImportResult(response);
+		return response;
+	}
+
+	private void logImportResult(ShoppingLinkImportResponse response) {
+		var item = response.item();
+		var sourceMetadata = response.sourceMetadata();
+		log.info(
+			"shopping link import completed retrievalStatus={} sourceDomain={} listedPrice={} currencyCode={} extractionMethod={}",
+			response.retrievalStatus(),
+			sourceMetadata == null ? null : sourceMetadata.sourceDomain(),
+			item == null ? null : item.listedPrice(),
+			item == null ? null : item.currencyCode(),
+			sourceMetadata == null ? null : sourceMetadata.extractionMethod()
+		);
 	}
 
 	@PostMapping("/import-jobs")

--- a/src/test/java/com/sagongsa/backend/itemimport/ItemImportControllerTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/ItemImportControllerTest.java
@@ -1,0 +1,82 @@
+package com.sagongsa.backend.itemimport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.sagongsa.backend.domain.enums.ItemCategory;
+import com.sagongsa.backend.domain.enums.ItemInputSource;
+import com.sagongsa.backend.domain.enums.ItemStatus;
+import com.sagongsa.backend.itemimport.job.ShoppingImportJobService;
+import com.sagongsa.backend.itemimport.item.ItemSourceMetadataDraft;
+import com.sagongsa.backend.itemimport.item.SavedItemDraft;
+import com.sagongsa.backend.itemimport.item.ShoppingLinkImportRequest;
+import com.sagongsa.backend.itemimport.item.ShoppingLinkImportResponse;
+import com.sagongsa.backend.itemimport.item.ShoppingLinkImportService;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+@ExtendWith(OutputCaptureExtension.class)
+class ItemImportControllerTest {
+
+	@Test
+	void logsImportResultWithoutProductDetails(CapturedOutput output) {
+		ShoppingLinkImportService service = mock(ShoppingLinkImportService.class);
+		ShoppingImportJobService jobService = mock(ShoppingImportJobService.class);
+		ItemImportController controller = new ItemImportController(service, jobService);
+		ShoppingLinkImportRequest request = new ShoppingLinkImportRequest(
+			ItemInputSource.SHARE,
+			"https://ably.airbridge.io/goods/70247267?tracking_content=secret",
+			null,
+			null,
+			null,
+			null
+		);
+		ShoppingLinkImportResponse response = response();
+		when(service.importLink(request)).thenReturn(response);
+
+		assertThat(controller.importLink(request)).isSameAs(response);
+
+		assertThat(output)
+			.contains("shopping link import completed retrievalStatus=SUCCESS")
+			.contains("sourceDomain=m.a-bly.com")
+			.contains("listedPrice=52110")
+			.contains("currencyCode=KRW")
+			.contains("extractionMethod=ABLY_PRODUCT_META")
+			.doesNotContain("tracking_content=secret")
+			.doesNotContain("테스트 전용 상품명")
+			.doesNotContain("https://cdn.example.com/private-product.jpg");
+	}
+
+	private ShoppingLinkImportResponse response() {
+		SavedItemDraft item = new SavedItemDraft(
+			ItemInputSource.SHARE,
+			"https://ably.airbridge.io/goods/70247267?tracking_content=secret",
+			"https://m.a-bly.com/goods/70247267",
+			"테스트 전용 상품명",
+			null,
+			null,
+			"https://cdn.example.com/private-product.jpg",
+			52110,
+			"KRW",
+			ItemCategory.FASHION,
+			0.35d,
+			false,
+			ItemStatus.SAVED
+		);
+		ItemSourceMetadataDraft sourceMetadata = new ItemSourceMetadataDraft(
+			"m.a-bly.com",
+			"테스트 전용 상품명",
+			null,
+			"52,110원",
+			null,
+			Instant.parse("2026-07-15T00:00:00Z"),
+			"ABLY_PRODUCT_META"
+		);
+		return new ShoppingLinkImportResponse("SUCCESS", item, sourceMetadata, null, List.of());
+	}
+}


### PR DESCRIPTION
# 🧰 Chore PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-93**
- GitHub: Closes #211
- 선행 작업: #210

### 🔒 Close Issue (필수)
- GitHub: Closes #211

## 🧩 한눈에 요약 (필수)
### 무엇을 변경했나?
- [x] 런타임 관측성 로그
- [x] 로그 개인정보 회귀 테스트
- [x] API 스펙 및 상품 추출 로직 변경 없음

### 왜 필요한가?
- QA 백엔드와 배포 웹에서는 에이블리 가격이 정상이나 설치된 Android 앱에서 0원 제보가 남아 있습니다.
- 기존 로그에는 HTTP 상태만 있어 모바일 요청이 반환한 가격을 요청 ID 기준으로 증명할 수 없었습니다.

### 범위(스코프)
- Included: 동기 상품 링크 가져오기 성공 결과의 상태, 도메인, 가격, 통화, 추출 방식
- Not included: 원본 URL/query, 상품명, 이미지 URL, 원본 payload, 인증 정보, 상품 추출 로직 변경

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew test --tests com.sagongsa.backend.itemimport.ItemImportControllerTest --tests com.sagongsa.backend.itemimport.ItemImportApiIntegrationTest --no-daemon --console=plain`
- Result: `BUILD SUCCESSFUL in 1m 36s`

### Smoke / 수동 검증
- 제공된 에이블리 전체 Airbridge URL을 QA API와 배포 웹에서 재현
- 백엔드 응답 및 웹 화면 가격: `52,110원`

### 테스트 공백
- 설치된 Android 바이너리의 실제 응답은 본 PR 배포 후 사용자 재시도 요청을 로그로 확인해야 합니다.

## 🧭 영향 범위 (필수)
- [x] 설정/환경변수 변경 없음
- [x] CI/빌드 파이프라인 영향 없음
- [x] 의존성 변경 없음
- [x] API 응답 스펙 변경 없음

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 성공 요청당 INFO 로그 한 줄이 추가됩니다.
- 상품 URL과 원본 메타데이터는 기록하지 않습니다.

### 롤백
- [x] 단순 revert로 가능

## 💬 리뷰 가이드 (필수)
- 로그 필드가 진단에 필요한 비민감 요약으로만 제한되는지 확인해 주세요.
- API 응답을 변경하지 않고 서비스 결과를 그대로 반환하는지 확인해 주세요.