### PR TITLE
[fix] NF-94 Android 에이블리 공유 URL 상품 ID 정규화 보완

### DIFF
--- a/src/main/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcher.java
@@ -33,11 +33,12 @@ public class JsoupPageFetcher implements PageFetcher {
 	private static final int DEFAULT_MAX_ATTEMPTS = 2;
 	private static final int DEFAULT_MAX_RESPONSE_BYTES = 1_000_000;
 	private static final int MAX_REDIRECTS = 5;
+	private static final int MAX_NESTED_URL_DECODE_COUNT = 6;
 	private static final int KREAM_API_TIMEOUT_MILLIS = 3_000;
 	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 	private static final Pattern BUNJANG_PRODUCT_PATH_PATTERN = Pattern.compile("^/products/(\\d+)(?:/.*)?$");
 	private static final Pattern KREAM_PRODUCT_PATH_PATTERN = Pattern.compile("^/products/(\\d+)(?:/.*)?$");
-	private static final Pattern ABLY_PRODUCT_PATH_PATTERN = Pattern.compile("^/goods/(\\d+)(?:/.*)?$");
+	private static final Pattern ABLY_PRODUCT_PATH_PATTERN = Pattern.compile("(?:^|/)goods/(\\d+)(?!\\d)");
 	private static final DateTimeFormatter KREAM_CLIENT_DATETIME_FORMATTER =
 		DateTimeFormatter.ofPattern("yyyyMMddHHmmssXX");
 	private static final Pattern JS_HTTP_ASSIGNMENT_PATTERN = Pattern.compile(
@@ -205,6 +206,21 @@ public class JsoupPageFetcher implements PageFetcher {
 			}
 
 			URI finalUri = URI.create(response.url().toString());
+			try {
+				Optional<FetchedPage> ablyProductPage = ablyProductApiPage(finalUri);
+				if (ablyProductPage.isPresent()) {
+					FetchedPage productPage = ablyProductPage.get();
+					return new FetchedPage(
+						uri,
+						productPage.finalUri(),
+						productPage.statusCode(),
+						productPage.contentType(),
+						productPage.body()
+					);
+				}
+			} catch (IOException ignored) {
+				// Continue with the resolved landing page when the product API is unavailable.
+			}
 			Optional<FetchedPage> bunjangProductPage = bunjangProductApiPage(
 				uri,
 				finalUri,
@@ -474,6 +490,7 @@ public class JsoupPageFetcher implements PageFetcher {
 			return Optional.empty();
 		}
 
+		URI productUri = URI.create("https://m.a-bly.com/goods/" + productId.get());
 		URI apiUri = URI.create("https://api.a-bly.com/api/v3/goods/" + productId.get() + "/basic/");
 		ShoppingUrlSafety.validatePublicHost(apiUri);
 		int apiTimeoutMillis = (int) Math.max(1, Math.min(ablyApi.getTimeout().toMillis(), timeoutMillis));
@@ -499,17 +516,38 @@ public class JsoupPageFetcher implements PageFetcher {
 		}
 		enforceBodySize(apiResponse.body());
 		return ablyProductMetadataHtml(apiResponse.body())
-			.map(html -> new FetchedPage(requestedUri, requestedUri, 200, "text/html; charset=UTF-8", html));
+			.map(html -> new FetchedPage(requestedUri, productUri, 200, "text/html; charset=UTF-8", html));
 	}
 
-	private static Optional<String> ablyProductId(URI uri) {
+	static Optional<String> ablyProductId(URI uri) {
 		String host = Optional.ofNullable(uri.getHost()).orElse("").toLowerCase(Locale.ROOT);
-		if (!host.equals("m.a-bly.com")) {
+		if (!host.equals("m.a-bly.com") && !host.equals("ably.airbridge.io")) {
 			return Optional.empty();
 		}
-		String path = Optional.ofNullable(uri.getPath()).orElse("");
-		Matcher matcher = ABLY_PRODUCT_PATH_PATTERN.matcher(path);
-		return matcher.matches() ? Optional.of(matcher.group(1)) : Optional.empty();
+		Optional<String> pathProductId = ablyProductIdFromEncodedValue(uri.getRawPath());
+		return pathProductId.isPresent()
+			? pathProductId
+			: ablyProductIdFromEncodedValue(uri.getRawQuery());
+	}
+
+	private static Optional<String> ablyProductIdFromEncodedValue(String rawValue) {
+		String candidate = rawValue;
+		for (int decodeCount = 0; decodeCount <= MAX_NESTED_URL_DECODE_COUNT && !isBlank(candidate); decodeCount++) {
+			Matcher matcher = ABLY_PRODUCT_PATH_PATTERN.matcher(candidate);
+			if (matcher.find()) {
+				return Optional.of(matcher.group(1));
+			}
+			try {
+				String decoded = urlDecode(candidate);
+				if (decoded.equals(candidate)) {
+					break;
+				}
+				candidate = decoded;
+			} catch (IllegalArgumentException exception) {
+				break;
+			}
+		}
+		return Optional.empty();
 	}
 
 	static Optional<String> ablyProductMetadataHtml(String apiBody) {

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java
@@ -9,6 +9,8 @@ import com.sagongsa.backend.domain.enums.ItemStatus;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,6 +45,9 @@ public class ShoppingLinkImportService {
 	private static final Pattern TWENTY_NINE_CM_DISPLAYED_PRICE_PATTERN = Pattern.compile(
 		"(?s)\"id\"\\s*:\\s*\"pdp_product_price\".{0,500}?\"children\"\\s*:\\s*\\[\"([0-9][0-9,]*)\""
 	);
+	private static final Pattern ABLY_GOODS_PATH_PATTERN = Pattern.compile(
+		"(?:^|/)goods/([0-9]+)(?![0-9])"
+	);
 	private static final Set<String> NOISE_IMAGE_KEYWORDS = Set.of("logo", "icon", "sprite", "badge", "banner");
 	private static final Set<String> TRACKING_QUERY_KEYS = Set.of(
 		"fbclid", "gclid", "igshid", "mc_cid", "mc_eid", "n_media", "n_query", "n_rank", "n_ad_group"
@@ -69,6 +74,7 @@ public class ShoppingLinkImportService {
 		"m.a-bly.com"
 	);
 	private static final double DEFAULT_CATEGORY_CONFIDENCE = 0.35d;
+	private static final int MAX_NESTED_URL_DECODE_COUNT = 6;
 
 	private final PageFetcher pageFetcher;
 	private final ObjectMapper objectMapper;
@@ -237,10 +243,11 @@ public class ShoppingLinkImportService {
 			normalized = rebuildUriWithHost(uri, "zigzag.kr");
 			warnings.add("지그재그 스토어 링크를 공개 상품 경로로 정규화했습니다.");
 		}
-		if ("ably.airbridge.io".equals(host) && uri.getPath() != null
-			&& uri.getPath().matches("/goods/[0-9]+/?")) {
-			String productId = uri.getPath().replaceFirst("^/goods/([0-9]+).*$", "$1");
-			normalized = URI.create("https://m.a-bly.com/goods/" + productId);
+		Optional<String> ablyProductId = "ably.airbridge.io".equals(host)
+			? extractAblyShareProductId(uri)
+			: Optional.empty();
+		if (ablyProductId.isPresent()) {
+			normalized = URI.create("https://m.a-bly.com/goods/" + ablyProductId.get());
 			warnings.add("에이블리 공유 링크를 모바일 상품 경로로 정규화했습니다.");
 		}
 
@@ -253,6 +260,34 @@ public class ShoppingLinkImportService {
 		}
 
 		return new NormalizationResult(normalized, List.copyOf(warnings));
+	}
+
+	private Optional<String> extractAblyShareProductId(URI uri) {
+		Optional<String> pathProductId = extractAblyProductIdFromEncodedValue(uri.getRawPath());
+		if (pathProductId.isPresent()) {
+			return pathProductId;
+		}
+		return extractAblyProductIdFromEncodedValue(uri.getRawQuery());
+	}
+
+	private Optional<String> extractAblyProductIdFromEncodedValue(String rawValue) {
+		String candidate = rawValue;
+		for (int decodeCount = 0; decodeCount <= MAX_NESTED_URL_DECODE_COUNT && !isBlank(candidate); decodeCount++) {
+			Matcher matcher = ABLY_GOODS_PATH_PATTERN.matcher(candidate);
+			if (matcher.find()) {
+				return Optional.of(matcher.group(1));
+			}
+			try {
+				String decoded = URLDecoder.decode(candidate, StandardCharsets.UTF_8);
+				if (decoded.equals(candidate)) {
+					break;
+				}
+				candidate = decoded;
+			} catch (IllegalArgumentException exception) {
+				break;
+			}
+		}
+		return Optional.empty();
 	}
 
 	private ExtractionResult extractFromPage(Document document, FetchedPage page) {

--- a/src/test/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcherTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcherTest.java
@@ -312,6 +312,22 @@ class JsoupPageFetcherTest {
 	}
 
 	@Test
+	void extractsAblyProductIdFromEncodedAirbridgeProductPath() {
+		assertThat(JsoupPageFetcher.ablyProductId(URI.create(
+			"https://ably.airbridge.io/goods%252F70247267%253Ftracking_content%253D59cb49ec48"
+		))).contains("70247267");
+	}
+
+	@Test
+	void extractsAblyProductIdFromNestedAirbridgeDeepLink() {
+		assertThat(JsoupPageFetcher.ablyProductId(URI.create(
+			"https://ably.airbridge.io/redirect?deep_link_value="
+				+ "app%25253A%25252F%25252Fweb%25252Fhttps%2525253A%2525252F%2525252Fm.a-bly.com"
+				+ "%2525252Fgoods%2525252F62561082"
+		))).contains("62561082");
+	}
+
+	@Test
 	void rejectsAblyProductApiMetadataWhenCurrentPriceIsZero() {
 		String apiBody = """
 			{"goods":{"name":"상품","cover_images":["https://example.com/product.jpg"],"price_info":{"thumbnail_price":0}}}

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportServiceTest.java
@@ -823,6 +823,50 @@ class ShoppingLinkImportServiceTest {
 	}
 
 	@Test
+	void normalizesAblyAirbridgeShareLinkWithEncodedProductPath() {
+		String canonicalUrl = "https://m.a-bly.com/goods/70247267";
+		pageFetcher.stub(canonicalUrl, completeProductMetadata("에이블리 인코딩 공유 상품"));
+
+		ShoppingLinkImportResponse response = service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.SHARE,
+				"https://ably.airbridge.io/goods%252F70247267%253Ftracking_content%253D59cb49ec48",
+				null,
+				null,
+				null,
+				null
+			)
+		);
+
+		assertThat(response.item().normalizedUrl()).isEqualTo(canonicalUrl);
+		assertThat(response.item().listedPrice()).isPositive();
+		assertThat(response.warnings()).contains("에이블리 공유 링크를 모바일 상품 경로로 정규화했습니다.");
+	}
+
+	@Test
+	void normalizesAblyAirbridgeShareLinkWithNestedEncodedProductUrl() {
+		String canonicalUrl = "https://m.a-bly.com/goods/62561082";
+		pageFetcher.stub(canonicalUrl, completeProductMetadata("에이블리 중첩 공유 상품"));
+
+		ShoppingLinkImportResponse response = service.importLink(
+			new ShoppingLinkImportRequest(
+				ItemInputSource.SHARE,
+				"https://ably.airbridge.io/redirect?deep_link_value="
+					+ "app%25253A%25252F%25252Fweb%25252Fhttps%2525253A%2525252F%2525252Fm.a-bly.com"
+					+ "%2525252Fgoods%2525252F62561082",
+				null,
+				null,
+				null,
+				null
+			)
+		);
+
+		assertThat(response.item().normalizedUrl()).isEqualTo(canonicalUrl);
+		assertThat(response.item().listedPrice()).isPositive();
+		assertThat(response.warnings()).contains("에이블리 공유 링크를 모바일 상품 경로로 정규화했습니다.");
+	}
+
+	@Test
 	void prefersPositiveAblyProductMetaPriceOverZeroJsonLdPrice() {
 		String url = "https://m.a-bly.com/goods/70247267";
 		pageFetcher.stub(


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-94**
- GitHub: Closes #213
- 선행 작업: #210, #212

### 🔒 Close Issue (필수)
- GitHub: Closes #213

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- Android 앱에서 에이블리 링크를 가져오면 가격이 0원으로 표시됐습니다.
- 운영 로그로 해당 요청의 백엔드 응답이 `retrievalStatus=PARTIAL`, `sourceDomain=ably.airbridge.io`, `listedPrice=null`, `extractionMethod=HTML_META`였음을 확인했습니다.

### 왜 발생했나? (Root Cause)
- 기존 정규화는 Airbridge path가 정확히 `/goods/{숫자}`일 때만 상품 ID를 인식했습니다.
- Android 공유 과정에서 path 또는 중첩 deep link가 반복 인코딩되거나, 짧은 링크 리다이렉트 뒤 Airbridge URL이 드러나면 상품 API 경로를 건너뛰고 랜딩 HTML만 읽었습니다.

### 어떻게 고쳤나?
- Airbridge 호스트의 raw path와 query를 제한된 횟수만큼 디코딩해 숫자 상품 ID를 복원합니다.
- 인코딩 URL을 `m.a-bly.com/goods/{id}`로 정규화합니다.
- 최초 URL에 ID가 없더라도 리다이렉트 최종 URL에서 에이블리 상품 ID가 확인되면 상품 API를 호출합니다.
- 상품 API 결과의 최종 URI를 정규 상품 URL로 유지해 기존 현재가·상품명·이미지 검증을 적용합니다.

## 🧯 재현 & 검증
- 실제 실패 로그: `requestId=e6579acd-1fcd-400e-907a-fa3fed20307c`
- 실제 반환값: `listedPrice=null`
- 반복 인코딩 path 및 중첩 deep link 회귀 테스트 추가
- 리다이렉트 후 Airbridge URL의 상품 ID 추출 경로 추가

## ✅ Acceptance Criteria
- [x] 반복 인코딩된 에이블리 상품 path에서 상품 ID를 복원한다.
- [x] 중첩 Airbridge deep link에서 상품 ID를 복원한다.
- [x] 리다이렉트 최종 URL에서도 에이블리 상품 API 폴백을 적용한다.
- [x] 숫자 상품 ID만 정규 상품 URL에 사용한다.
- [x] 기존 에이블리 및 전체 Jsoup 수집 회귀 테스트가 통과한다.

## 🧪 테스트 / 검증
```text
./gradlew test --tests com.sagongsa.backend.itemimport.item.ShoppingLinkImportServiceTest \
  --tests com.sagongsa.backend.itemimport.item.JsoupPageFetcherTest \
  --no-daemon --console=plain

BUILD SUCCESSFUL in 1m 58s
```

## 🧭 영향 범위
- [x] API 스펙 변경 없음
- [x] DB 스키마 변경 없음
- [x] 환경변수 변경 없음
- [x] 에이블리 공유/리다이렉트 링크 정규화 경로 영향 있음

## 💥 Breaking / Compatibility
- [x] Breaking change 없음

## ⚠️ 리스크 & 롤백
- Airbridge 호스트에 한해서만 상품 ID를 탐색합니다.
- 디코딩 횟수를 최대 6회로 제한하고 숫자 ID만 허용합니다.
- [x] PR revert로 롤백 가능

## 💬 리뷰 가이드
- Airbridge가 아닌 도메인에는 중첩 URL 추출이 적용되지 않는지 확인해 주세요.
- API 실패 시 기존 HTML/브라우저 폴백이 유지되는지 확인해 주세요.