### PR TITLE
[fix] NF-95 웹 데모 reviewer 로그인 403 수정

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -250,9 +250,12 @@ jobs:
           fi
 
           if [ "${APP_REVIEWER_TOKEN_ENABLED:-true}" != "false" ]; then
+            require_reviewer_seed
+          fi
+
+          if [ "${APP_REVIEWER_TOKEN_ENABLED:-true}" != "false" ] && [ "${APP_REVIEWER_TOKEN_REQUIRE_SECRET:-false}" = "true" ]; then
             require_env APP_REVIEWER_TOKEN_SECRET
             require_secret_length APP_REVIEWER_TOKEN_SECRET
-            require_reviewer_seed
           fi
 
           if [ "${SHOPPING_IMPORT_BROWSER_FETCH_ENABLED:-true}" != "true" ]; then

--- a/src/main/java/com/sagongsa/backend/auth/AuthApiController.java
+++ b/src/main/java/com/sagongsa/backend/auth/AuthApiController.java
@@ -106,10 +106,11 @@ public class AuthApiController {
 	@PostMapping("/reviewer-token")
 	@Operation(
 		summary = "Issue app reviewer token",
-		description = "Issues a regular user JWT token pair for the fixed app review account after validating the reviewer secret.",
+		description = "Issues a regular user JWT token pair for the fixed app review account. "
+			+ "Reviewer secret validation is applied only when enabled by server configuration.",
 		responses = {
 			@ApiResponse(responseCode = "200", description = "Reviewer token pair issued"),
-			@ApiResponse(responseCode = "403", description = "Reviewer token secret is missing or invalid"),
+			@ApiResponse(responseCode = "403", description = "Required reviewer token secret is missing or invalid"),
 			@ApiResponse(responseCode = "429", description = "Too many reviewer token requests"),
 			@ApiResponse(responseCode = "500", description = "Reviewer account seed data is missing")
 		}
@@ -146,7 +147,8 @@ public class AuthApiController {
 		}
 
 		reviewerTokenRateLimiter.assertAllowed(request.getRemoteAddr());
-		if (!StringUtils.hasText(properties.getSecret()) || !constantTimeEquals(properties.getSecret(), reviewerToken)) {
+		if (properties.isRequireSecret()
+			&& (!StringUtils.hasText(properties.getSecret()) || !constantTimeEquals(properties.getSecret(), reviewerToken))) {
 			log.warn("App reviewer token rejected from remoteAddress={}", request.getRemoteAddr());
 			throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Invalid reviewer token secret");
 		}

--- a/src/main/java/com/sagongsa/backend/config/AppAuthProperties.java
+++ b/src/main/java/com/sagongsa/backend/config/AppAuthProperties.java
@@ -64,6 +64,7 @@ public class AppAuthProperties {
 	public static class ReviewerToken {
 
 		private boolean enabled = true;
+		private boolean requireSecret;
 		private String secret = "";
 		private int rateLimitMaxAttempts = 10;
 		private Duration rateLimitWindow = Duration.ofMinutes(10);
@@ -74,6 +75,14 @@ public class AppAuthProperties {
 
 		public void setEnabled(boolean enabled) {
 			this.enabled = enabled;
+		}
+
+		public boolean isRequireSecret() {
+			return requireSecret;
+		}
+
+		public void setRequireSecret(boolean requireSecret) {
+			this.requireSecret = requireSecret;
 		}
 
 		public String getSecret() {

--- a/src/main/java/com/sagongsa/backend/config/PublicServerSecurityGuard.java
+++ b/src/main/java/com/sagongsa/backend/config/PublicServerSecurityGuard.java
@@ -56,7 +56,7 @@ public class PublicServerSecurityGuard implements ApplicationRunner {
 			throw new IllegalStateException("app.auth.allowed-redirect-uri-prefixes must not include localhost in prod");
 		}
 		validateShoppingImportSettings();
-		if (authProperties.getReviewerToken().isEnabled()) {
+		if (authProperties.getReviewerToken().isEnabled() && authProperties.getReviewerToken().isRequireSecret()) {
 			requireStrongSecret("APP_REVIEWER_TOKEN_SECRET", authProperties.getReviewerToken().getSecret());
 		}
 	}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,6 +12,7 @@ app:
       enabled: false
     reviewer-token:
       enabled: ${APP_REVIEWER_TOKEN_ENABLED:true}
+      require-secret: ${APP_REVIEWER_TOKEN_REQUIRE_SECRET:false}
       secret: ${APP_REVIEWER_TOKEN_SECRET:}
   shopping:
     import:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,6 +61,7 @@ app:
     allowed-redirect-uri-prefixes: ${APP_ALLOWED_REDIRECT_URI_PREFIXES:sagongsa404://auth/callback,http://localhost/auth/callback,http://127.0.0.1/auth/callback,https://localhost/auth/callback,https://127.0.0.1/auth/callback}
     reviewer-token:
       enabled: ${APP_REVIEWER_TOKEN_ENABLED:true}
+      require-secret: ${APP_REVIEWER_TOKEN_REQUIRE_SECRET:false}
       secret: ${APP_REVIEWER_TOKEN_SECRET:}
       rate-limit-max-attempts: ${APP_REVIEWER_TOKEN_RATE_LIMIT_MAX_ATTEMPTS:10}
       rate-limit-window: ${APP_REVIEWER_TOKEN_RATE_LIMIT_WINDOW:PT10M}

--- a/src/test/java/com/sagongsa/backend/auth/AppReviewerAuthIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/auth/AppReviewerAuthIntegrationTest.java
@@ -8,9 +8,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sagongsa.backend.config.AppAuthProperties;
 import com.sagongsa.backend.support.PostgreSqlContainerTest;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,8 +48,12 @@ class AppReviewerAuthIntegrationTest extends PostgreSqlContainerTest {
 	@Autowired
 	private JdbcTemplate jdbcTemplate;
 
+	@Autowired
+	private AppAuthProperties appAuthProperties;
+
 	@BeforeEach
 	void ensureReviewerAccount() {
+		appAuthProperties.getReviewerToken().setRequireSecret(false);
 		jdbcTemplate.update(
 			"""
 			insert into users (id, status, onboarding_status, created_at, updated_at, withdrawn_at)
@@ -92,10 +98,14 @@ class AppReviewerAuthIntegrationTest extends PostgreSqlContainerTest {
 		);
 	}
 
+	@AfterEach
+	void restoreReviewerTokenConfiguration() {
+		appAuthProperties.getReviewerToken().setRequireSecret(false);
+	}
+
 	@Test
 	void issuesReviewerTokenInProdProfileAndAuthenticatesAsReviewer() throws Exception {
-		MvcResult tokenResult = mockMvc.perform(post("/api/auth/reviewer-token")
-				.header("X-Reviewer-Token", REVIEWER_TOKEN_SECRET))
+		MvcResult tokenResult = mockMvc.perform(post("/api/auth/reviewer-token"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.tokenType").value("Bearer"))
 			.andExpect(jsonPath("$.accessToken").isString())
@@ -128,9 +138,24 @@ class AppReviewerAuthIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
-	void rejectsReviewerTokenIssueWithoutReviewerSecretHeader() throws Exception {
+	void rejectsMissingAndInvalidReviewerSecretHeaderWhenRequired() throws Exception {
+		appAuthProperties.getReviewerToken().setRequireSecret(true);
+
 		mockMvc.perform(post("/api/auth/reviewer-token"))
 			.andExpect(status().isForbidden());
+		mockMvc.perform(post("/api/auth/reviewer-token")
+				.header("X-Reviewer-Token", "invalid-reviewer-token"))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	void issuesReviewerTokenWithValidSecretHeaderWhenRequired() throws Exception {
+		appAuthProperties.getReviewerToken().setRequireSecret(true);
+
+		mockMvc.perform(post("/api/auth/reviewer-token")
+				.header("X-Reviewer-Token", REVIEWER_TOKEN_SECRET))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.tokenType").value("Bearer"));
 	}
 
 	@Test

--- a/src/test/java/com/sagongsa/backend/config/PublicServerSecurityGuardTest.java
+++ b/src/test/java/com/sagongsa/backend/config/PublicServerSecurityGuardTest.java
@@ -40,6 +40,16 @@ class PublicServerSecurityGuardTest {
 	}
 
 	@Test
+	void acceptsPublicReviewerDemoWithoutSecretInProd() {
+		AppAuthProperties authProperties = safeAuthProperties();
+		authProperties.getReviewerToken().setRequireSecret(false);
+		authProperties.getReviewerToken().setSecret("");
+
+		assertThatCode(() -> guard(authProperties, safeShoppingImportProperties(), false).run(null))
+			.doesNotThrowAnyException();
+	}
+
+	@Test
 	void rejectsTrustedHeaderInProd() {
 		assertThatThrownBy(() -> guard(safeAuthProperties(), safeShoppingImportProperties(), true).run(null))
 			.isInstanceOf(IllegalStateException.class)
@@ -90,6 +100,7 @@ class PublicServerSecurityGuardTest {
 		AppAuthProperties authProperties = new AppAuthProperties();
 		authProperties.setJwtSecret("private-test-jwt-secret-with-strong-length");
 		authProperties.setAllowedRedirectUriPrefixes(List.of("sagongsa404://auth/callback"));
+		authProperties.getReviewerToken().setRequireSecret(true);
 		authProperties.getReviewerToken().setSecret("private-test-reviewer-token-secret-long");
 		return authProperties;
 	}


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-95**
- GitHub: Closes #215

> PR 제목: `NF-95 웹 데모 reviewer 로그인 403 수정`  
> 브랜치: `fix/NF-95-reviewer-demo-login`

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- 웹 데모 화면에서 로고를 연속 클릭하면 헤더 없는 `POST /api/auth/reviewer-token`이 호출됩니다.
- CORS preflight는 성공하지만 실제 POST는 403을 반환해 고정 reviewer 계정 로그인이 실패했습니다.

### 왜 발생했나? (Root Cause)
- Spring Security는 해당 POST를 `permitAll`로 허용하고 있었습니다.
- 컨트롤러가 `X-Reviewer-Token` secret을 항상 필수 검증해, 비밀값 입력 없이 동작해야 하는 공개 데모 흐름과 API 계약이 충돌했습니다.

### 어떻게 고쳤나?
- `APP_REVIEWER_TOKEN_REQUIRE_SECRET` 설정을 추가했습니다.
- 기본값 `false`에서는 헤더 없이 제한된 고정 reviewer 계정 JWT를 발급합니다.
- `true`에서는 기존처럼 secret 누락·불일치를 403으로 거부하고 배포 전 강한 secret 설정을 검사합니다.
- 기존 rate limit, reviewer seed 검사, `ROLE_USER` 권한은 유지했습니다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법
- Steps: 허용된 웹 origin에서 헤더 없이 `POST /api/auth/reviewer-token` 호출
- 기대 결과: 고정 reviewer 계정의 access/refresh token 발급
- 실제 결과(수정 전): 403 Forbidden

### 재발 방지
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [x] 배포 preflight 설정 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] AC1: secret 검증 비활성화 시 헤더 없는 POST가 JWT pair를 반환한다.
- [x] AC2: secret 검증 활성화 시 헤더 누락·불일치를 403으로 거부한다.
- [x] AC3: secret 검증 활성화 시 유효한 헤더 요청은 기존처럼 성공한다.
- [x] AC4: 고정 reviewer 계정은 기존 `ROLE_USER`만 유지한다.
- [x] AC5: rate limit과 reviewer seed 배포 검사는 유지한다.

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- `./gradlew test --tests 'com.sagongsa.backend.auth.AppReviewerAuthIntegrationTest' --tests 'com.sagongsa.backend.config.PublicServerSecurityGuardTest' --tests 'com.sagongsa.backend.auth.AuthApiControllerTest' --no-daemon`: 성공
- `./gradlew test --no-daemon`: 597 tests, failures 0, errors 0, skipped 9
- `git diff --check`: 통과

### CI
- 자동 실행 예정

### Smoke / 수동 검증
- 시나리오: 공개 모드의 헤더 없는 로그인, 보호 모드의 누락·오류·정상 secret 요청
- 결과: 각각 200, 403, 403, 200 확인

### 테스트 공백
- QA 런타임 검증은 PR 병합·배포 후 수행합니다.

---

## 🧭 영향 범위 (필수)
- [x] API 스펙 변경 있음: reviewer-token secret 검증을 설정 가능하게 변경
- [x] DB 스키마 변경 없음
- [x] 설정/환경변수 변경 있음: `APP_REVIEWER_TOKEN_REQUIRE_SECRET`
- [x] 캐시/큐/외부 연동 영향 없음

---

## 💥 Breaking / Compatibility (필수)
- [x] 기존 secret 헤더 요청 호환 유지
- [x] 기본 동작은 헤더 필수에서 공개 데모 로그인으로 변경

---

## 🚀 배포/릴리즈 (해당 시 필수)
### Feature Flag
- [x] 사용함 → `APP_REVIEWER_TOKEN_REQUIRE_SECRET=false`가 기본 공개 데모 모드
- 보호 모드가 필요한 환경은 `APP_REVIEWER_TOKEN_REQUIRE_SECRET=true`와 강한 `APP_REVIEWER_TOKEN_SECRET`을 함께 설정합니다.

### 모니터링/알림
- 정상 로그: `App reviewer token issued`
- 거부 로그: `App reviewer token rejected`
- 과도한 요청: HTTP 429

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 공개 데모 모드에서는 API 경로를 아는 누구나 제한된 reviewer 계정 토큰을 발급할 수 있습니다.
- 해당 계정은 관리자 권한이 아닌 기존 `ROLE_USER`이며, 이 공개 접근은 데모 요구사항에 따른 의도된 동작입니다.

### 롤백
- [x] `APP_REVIEWER_TOKEN_REQUIRE_SECRET=true`로 즉시 보호 모드 전환 가능
- [x] 배포 롤백 가능
- [x] DB 롤백 불필요

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직: `AuthApiController.assertReviewerTokenAllowed`, `PublicServerSecurityGuard`, `deploy-qa.yml`
- 트레이드오프/대안: 공개 웹 번들에 secret을 넣지 않고, 서버 설정으로 공개 데모와 보호 모드를 선택합니다.
- 보안/호환성 영향: 공개 모드는 고정 `ROLE_USER` 계정과 rate limit으로 범위를 제한하며 기존 secret 기반 호출도 호환됩니다.
