### PR TITLE
[fix] NF-96 N+스토어 상품 수집 전용 프록시 추가

### DIFF
--- a/docs/SHOPPING_BROWSER_FETCHER_OPERATIONS.md
+++ b/docs/SHOPPING_BROWSER_FETCHER_OPERATIONS.md
@@ -40,6 +40,16 @@
 
 - KREAM이 배포 서버의 출구 IP에 빈 5xx를 반환하는 환경에서만 전용 프록시를 활성화한다.
 - `SHOPPING_IMPORT_KREAM_PROXY_ENABLED=true`, `SHOPPING_IMPORT_KREAM_PROXY_TYPE=SOCKS|HTTP`, `SHOPPING_IMPORT_KREAM_PROXY_HOST`, `SHOPPING_IMPORT_KREAM_PROXY_PORT`를 설정한다.
+- 프록시는 KREAM 및 KREAM API 호스트에만 적용되며 다른 쇼핑몰 요청은 기존 출구를 유지한다.
+
+## N+스토어 전용 프록시
+
+- 네이버가 배포 서버의 출구 IP를 로그인 페이지 또는 429 응답으로 전환하는 환경에서만 전용 프록시를 활성화한다.
+- `SHOPPING_IMPORT_NAVER_PROXY_ENABLED=true`, `SHOPPING_IMPORT_NAVER_PROXY_TYPE=SOCKS|HTTP`, `SHOPPING_IMPORT_NAVER_PROXY_HOST`, `SHOPPING_IMPORT_NAVER_PROXY_PORT`를 설정한다.
+- `naver.me`와 네이버 쇼핑 브리지, 스마트스토어/브랜드스토어 상품 요청의 정적 수집과 Playwright 브라우저 폴백에만 적용한다.
+- 로그인 페이지로 리다이렉트된 경우 `url` 파라미터의 원래 상품 주소를 검증·복원해 모바일 상품 페이지로 브라우저 폴백한다.
+- KREAM과 N+스토어 프록시는 인증 없는 내부 프록시를 전제로 하므로 방화벽에서 백엔드 서버 IP만 접근 가능하게 제한한다.
+- 활성화 전후로 동일 상품을 순차/동시 호출해 제목, 양수 가격, 유효 이미지와 429/로그인 리다이렉트 여부를 확인한다.
 
 ## 에이블리 상품 API 폴백
 
@@ -47,9 +57,6 @@
 - `SHOPPING_IMPORT_ABLY_API_ENABLED=true`, `SHOPPING_IMPORT_ABLY_ANONYMOUS_TOKEN`, `SHOPPING_IMPORT_ABLY_API_TIMEOUT=PT5S`를 설정한다.
 - 익명 토큰은 에이블리 웹 상품 페이지가 발급한 값만 사용하고, 저장소와 로그에 커밋하지 않는다.
 - API 설정이 없거나 API 호출이 실패하면 기존 HTML 수집과 브라우저 폴백을 계속 사용한다.
-- 프록시는 KREAM 및 KREAM API 호스트에만 적용되며 다른 쇼핑몰 요청은 기존 출구를 유지한다.
-- 인증 없는 내부 프록시를 전제로 하므로 방화벽에서 백엔드 서버 IP만 접근 가능하게 제한한다.
-- 활성화 전후로 동일 상품을 순차/동시 호출해 제목, 양수 가격, 유효 이미지와 5xx/429 여부를 확인한다.
 
 ## 검증 포인트
 

--- a/src/main/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcher.java
@@ -33,6 +33,7 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 
 	private final ShoppingImportProperties.BrowserFetch properties;
 	private final ShoppingImportProperties.KreamProxy kreamProxy;
+	private final ShoppingImportProperties.NaverProxy naverProxy;
 	private final int maxResponseBytes;
 	private final Supplier<Playwright> playwrightFactory;
 	private final Object browserLock = new Object();
@@ -40,11 +41,23 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 	private Browser browser;
 
 	public BrowserPageFetcher(ShoppingImportProperties.BrowserFetch properties) {
-		this(properties, Playwright::create, 1_000_000, new ShoppingImportProperties.KreamProxy());
+		this(
+			properties,
+			Playwright::create,
+			1_000_000,
+			new ShoppingImportProperties.KreamProxy(),
+			new ShoppingImportProperties.NaverProxy()
+		);
 	}
 
 	public BrowserPageFetcher(ShoppingImportProperties.BrowserFetch properties, int maxResponseBytes) {
-		this(properties, Playwright::create, maxResponseBytes, new ShoppingImportProperties.KreamProxy());
+		this(
+			properties,
+			Playwright::create,
+			maxResponseBytes,
+			new ShoppingImportProperties.KreamProxy(),
+			new ShoppingImportProperties.NaverProxy()
+		);
 	}
 
 	public BrowserPageFetcher(
@@ -52,23 +65,40 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 		int maxResponseBytes,
 		ShoppingImportProperties.KreamProxy kreamProxy
 	) {
-		this(properties, Playwright::create, maxResponseBytes, kreamProxy);
+		this(properties, Playwright::create, maxResponseBytes, kreamProxy, new ShoppingImportProperties.NaverProxy());
+	}
+
+	public BrowserPageFetcher(
+		ShoppingImportProperties.BrowserFetch properties,
+		int maxResponseBytes,
+		ShoppingImportProperties.KreamProxy kreamProxy,
+		ShoppingImportProperties.NaverProxy naverProxy
+	) {
+		this(properties, Playwright::create, maxResponseBytes, kreamProxy, naverProxy);
 	}
 
 	BrowserPageFetcher(ShoppingImportProperties.BrowserFetch properties, Supplier<Playwright> playwrightFactory) {
-		this(properties, playwrightFactory, 1_000_000, new ShoppingImportProperties.KreamProxy());
+		this(
+			properties,
+			playwrightFactory,
+			1_000_000,
+			new ShoppingImportProperties.KreamProxy(),
+			new ShoppingImportProperties.NaverProxy()
+		);
 	}
 
 	BrowserPageFetcher(
 		ShoppingImportProperties.BrowserFetch properties,
 		Supplier<Playwright> playwrightFactory,
 		int maxResponseBytes,
-		ShoppingImportProperties.KreamProxy kreamProxy
+		ShoppingImportProperties.KreamProxy kreamProxy,
+		ShoppingImportProperties.NaverProxy naverProxy
 	) {
 		this.properties = properties;
 		this.playwrightFactory = playwrightFactory;
 		this.maxResponseBytes = maxResponseBytes <= 0 ? 1_000_000 : maxResponseBytes;
 		this.kreamProxy = kreamProxy == null ? new ShoppingImportProperties.KreamProxy() : kreamProxy;
+		this.naverProxy = naverProxy == null ? new ShoppingImportProperties.NaverProxy() : naverProxy;
 	}
 
 	@Override
@@ -189,6 +219,8 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 		}
 		if (kreamProxy.isConfigured() && isKreamUri(uri)) {
 			options.setProxy(kreamProxy.browserServer());
+		} else if (naverProxy.isConfigured() && isNaverShoppingUri(uri)) {
+			options.setProxy(naverProxy.browserServer());
 		}
 		return options;
 	}
@@ -201,6 +233,18 @@ public class BrowserPageFetcher implements PageFetcher, AutoCloseable {
 	private boolean isKreamUri(URI uri) {
 		String host = Optional.ofNullable(uri.getHost()).orElse("").toLowerCase(Locale.ROOT);
 		return host.equals("kream.co.kr") || host.endsWith(".kream.co.kr");
+	}
+
+	private boolean isNaverShoppingUri(URI uri) {
+		String host = Optional.ofNullable(uri.getHost()).orElse("").toLowerCase(Locale.ROOT);
+		return host.equals("naver.me")
+			|| host.equals("app.shopping.naver.com")
+			|| host.equals("shopping.naver.com")
+			|| host.equals("m.shopping.naver.com")
+			|| host.equals("smartstore.naver.com")
+			|| host.equals("m.smartstore.naver.com")
+			|| host.equals("brand.naver.com")
+			|| host.equals("m.brand.naver.com");
 	}
 
 	private void waitForNetworkIdle(Page page) {

--- a/src/main/java/com/sagongsa/backend/itemimport/item/FallbackPageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/FallbackPageFetcher.java
@@ -2,6 +2,8 @@ package com.sagongsa.backend.itemimport.item;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Optional;
 import org.springframework.http.HttpStatusCode;
@@ -42,10 +44,36 @@ public class FallbackPageFetcher implements PageFetcher, AutoCloseable {
 	}
 
 	private URI fallbackUri(URI originalUri, FetchedPage page) {
+		Optional<URI> naverLoginTarget = naverLoginTarget(page.finalUri());
+		if (naverLoginTarget.isPresent()) {
+			return mobileNaverUri(naverLoginTarget.get());
+		}
 		if (isKnownErrorShell(page) || isNaverProductUri(page.finalUri())) {
 			return mobileNaverUri(page.finalUri());
 		}
 		return originalUri;
+	}
+
+	private Optional<URI> naverLoginTarget(URI uri) {
+		String host = Optional.ofNullable(uri.getHost()).orElse("").toLowerCase(Locale.ROOT);
+		String path = Optional.ofNullable(uri.getPath()).orElse("");
+		String rawQuery = uri.getRawQuery();
+		if (!host.equals("nid.naver.com") || !path.endsWith("/nidlogin.login") || rawQuery == null) {
+			return Optional.empty();
+		}
+		for (String parameter : rawQuery.split("&")) {
+			int separator = parameter.indexOf('=');
+			if (separator <= 0 || !parameter.substring(0, separator).equals("url")) {
+				continue;
+			}
+			try {
+				URI target = URI.create(URLDecoder.decode(parameter.substring(separator + 1), StandardCharsets.UTF_8));
+				return isNaverProductUri(target) ? Optional.of(target) : Optional.empty();
+			} catch (IllegalArgumentException exception) {
+				return Optional.empty();
+			}
+		}
+		return Optional.empty();
 	}
 
 	private boolean isNaverProductUri(URI uri) {
@@ -73,6 +101,7 @@ public class FallbackPageFetcher implements PageFetcher, AutoCloseable {
 	private boolean isKnownErrorShell(FetchedPage page) {
 		String host = Optional.ofNullable(page.finalUri().getHost()).orElse("").toLowerCase(Locale.ROOT);
 		String body = Optional.ofNullable(page.body()).orElse("");
+		boolean naverLoginShell = naverLoginTarget(page.finalUri()).isPresent();
 		boolean naverErrorShell = (host.equals("brand.naver.com") || host.equals("smartstore.naver.com"))
 			&& (body.contains("시스템오류") || body.contains("에러페이지"));
 		boolean ablyChallengeShell = host.equals("m.a-bly.com")
@@ -81,7 +110,7 @@ public class FallbackPageFetcher implements PageFetcher, AutoCloseable {
 				|| body.contains("challenge-error-text")
 				|| body.contains("/cdn-cgi/challenge-platform/")
 				|| body.contains("Enable JavaScript and cookies to continue"));
-		return naverErrorShell || ablyChallengeShell;
+		return naverLoginShell || naverErrorShell || ablyChallengeShell;
 	}
 
 	private boolean shouldFallback(HttpStatusCode statusCode) {

--- a/src/main/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcher.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.net.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
@@ -64,6 +65,7 @@ public class JsoupPageFetcher implements PageFetcher {
 	private final int maxAttempts;
 	private final int maxResponseBytes;
 	private final ShoppingImportProperties.KreamProxy kreamProxy;
+	private final ShoppingImportProperties.NaverProxy naverProxy;
 	private final ShoppingImportProperties.AblyApi ablyApi;
 
 	public JsoupPageFetcher() {
@@ -83,7 +85,23 @@ public class JsoupPageFetcher implements PageFetcher {
 		ShoppingImportProperties.KreamProxy kreamProxy,
 		ShoppingImportProperties.AblyApi ablyApi
 	) {
-		this(DEFAULT_TIMEOUT_MILLIS, DEFAULT_MAX_ATTEMPTS, maxResponseBytes, kreamProxy, ablyApi);
+		this(
+			DEFAULT_TIMEOUT_MILLIS,
+			DEFAULT_MAX_ATTEMPTS,
+			maxResponseBytes,
+			kreamProxy,
+			new ShoppingImportProperties.NaverProxy(),
+			ablyApi
+		);
+	}
+
+	JsoupPageFetcher(
+		int maxResponseBytes,
+		ShoppingImportProperties.KreamProxy kreamProxy,
+		ShoppingImportProperties.NaverProxy naverProxy,
+		ShoppingImportProperties.AblyApi ablyApi
+	) {
+		this(DEFAULT_TIMEOUT_MILLIS, DEFAULT_MAX_ATTEMPTS, maxResponseBytes, kreamProxy, naverProxy, ablyApi);
 	}
 
 	JsoupPageFetcher(int timeoutMillis, int maxAttempts) {
@@ -110,10 +128,29 @@ public class JsoupPageFetcher implements PageFetcher {
 		ShoppingImportProperties.KreamProxy kreamProxy,
 		ShoppingImportProperties.AblyApi ablyApi
 	) {
+		this(
+			timeoutMillis,
+			maxAttempts,
+			maxResponseBytes,
+			kreamProxy,
+			new ShoppingImportProperties.NaverProxy(),
+			ablyApi
+		);
+	}
+
+	JsoupPageFetcher(
+		int timeoutMillis,
+		int maxAttempts,
+		int maxResponseBytes,
+		ShoppingImportProperties.KreamProxy kreamProxy,
+		ShoppingImportProperties.NaverProxy naverProxy,
+		ShoppingImportProperties.AblyApi ablyApi
+	) {
 		this.timeoutMillis = timeoutMillis <= 0 ? DEFAULT_TIMEOUT_MILLIS : timeoutMillis;
 		this.maxAttempts = maxAttempts <= 0 ? DEFAULT_MAX_ATTEMPTS : maxAttempts;
 		this.maxResponseBytes = maxResponseBytes <= 0 ? DEFAULT_MAX_RESPONSE_BYTES : maxResponseBytes;
 		this.kreamProxy = kreamProxy == null ? new ShoppingImportProperties.KreamProxy() : kreamProxy;
+		this.naverProxy = naverProxy == null ? new ShoppingImportProperties.NaverProxy() : naverProxy;
 		this.ablyApi = ablyApi == null ? new ShoppingImportProperties.AblyApi() : ablyApi;
 	}
 
@@ -181,7 +218,7 @@ public class JsoupPageFetcher implements PageFetcher {
 				.ignoreHttpErrors(true)
 				.timeout(timeoutMillis)
 				.maxBodySize(maxResponseBytes);
-			applyKreamProxy(connection, currentUri);
+			applyShoppingProxy(connection, currentUri);
 			Connection.Response response = connection.execute();
 
 			if (isRedirect(response.statusCode())) {
@@ -594,9 +631,35 @@ public class JsoupPageFetcher implements PageFetcher {
 		}
 	}
 
+	private void applyShoppingProxy(Connection connection, URI uri) {
+		shoppingProxy(uri).ifPresent(connection::proxy);
+	}
+
+	Optional<Proxy> shoppingProxy(URI uri) {
+		if (kreamProxy.isConfigured() && isKreamHost(uri)) {
+			return Optional.of(kreamProxy.javaProxy());
+		}
+		if (naverProxy.isConfigured() && isNaverShoppingHost(uri)) {
+			return Optional.of(naverProxy.javaProxy());
+		}
+		return Optional.empty();
+	}
+
 	private static boolean isKreamHost(URI uri) {
 		String host = Optional.ofNullable(uri.getHost()).orElse("").toLowerCase(Locale.ROOT);
 		return host.equals("kream.co.kr") || host.endsWith(".kream.co.kr");
+	}
+
+	private static boolean isNaverShoppingHost(URI uri) {
+		String host = Optional.ofNullable(uri.getHost()).orElse("").toLowerCase(Locale.ROOT);
+		return host.equals("naver.me")
+			|| host.equals("app.shopping.naver.com")
+			|| host.equals("shopping.naver.com")
+			|| host.equals("m.shopping.naver.com")
+			|| host.equals("smartstore.naver.com")
+			|| host.equals("m.smartstore.naver.com")
+			|| host.equals("brand.naver.com")
+			|| host.equals("m.brand.naver.com");
 	}
 
 	static Optional<String> kreamProductMetadataHtml(String apiBody) {

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportConfig.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportConfig.java
@@ -12,16 +12,19 @@ public class ShoppingImportConfig {
 	public PageFetcher pageFetcher(ShoppingImportProperties properties) {
 		ShoppingImportProperties.BrowserFetch browserFetch = properties.getBrowserFetch();
 		ShoppingImportProperties.KreamProxy kreamProxy = properties.getKreamProxy();
+		ShoppingImportProperties.NaverProxy naverProxy = properties.getNaverProxy();
 		kreamProxy.validate();
+		naverProxy.validate();
 		JsoupPageFetcher jsoupPageFetcher = new JsoupPageFetcher(
 			properties.getMaxResponseBytes(),
 			kreamProxy,
+			naverProxy,
 			properties.getAblyApi()
 		);
 		if (browserFetch.isEnabled()) {
 			return new FallbackPageFetcher(
 				jsoupPageFetcher,
-				new BrowserPageFetcher(browserFetch, properties.getMaxResponseBytes(), kreamProxy)
+				new BrowserPageFetcher(browserFetch, properties.getMaxResponseBytes(), kreamProxy, naverProxy)
 			);
 		}
 		return jsoupPageFetcher;

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportProperties.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportProperties.java
@@ -12,6 +12,7 @@ public class ShoppingImportProperties {
 	private final BrowserFetch browserFetch = new BrowserFetch();
 	private final JobWorker jobWorker = new JobWorker();
 	private final KreamProxy kreamProxy = new KreamProxy();
+	private final NaverProxy naverProxy = new NaverProxy();
 	private final AblyApi ablyApi = new AblyApi();
 
 	public int getMaxResponseBytes() {
@@ -32,6 +33,10 @@ public class ShoppingImportProperties {
 
 	public KreamProxy getKreamProxy() {
 		return kreamProxy;
+	}
+
+	public NaverProxy getNaverProxy() {
+		return naverProxy;
 	}
 
 	public AblyApi getAblyApi() {
@@ -204,6 +209,71 @@ public class ShoppingImportProperties {
 		void validate() {
 			if (enabled && !isConfigured()) {
 				throw new IllegalStateException("KREAM proxy requires a host and a valid port");
+			}
+		}
+
+		Proxy javaProxy() {
+			Proxy.Type proxyType = type == Type.HTTP ? Proxy.Type.HTTP : Proxy.Type.SOCKS;
+			return new Proxy(proxyType, InetSocketAddress.createUnresolved(host, port));
+		}
+
+		String browserServer() {
+			String scheme = type == Type.HTTP ? "http" : "socks5";
+			return scheme + "://" + host + ":" + port;
+		}
+
+		public enum Type {
+			HTTP,
+			SOCKS
+		}
+	}
+
+	public static class NaverProxy {
+
+		private boolean enabled;
+		private Type type = Type.SOCKS;
+		private String host;
+		private int port = 1080;
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public Type getType() {
+			return type;
+		}
+
+		public void setType(Type type) {
+			this.type = type == null ? Type.SOCKS : type;
+		}
+
+		public String getHost() {
+			return host;
+		}
+
+		public void setHost(String host) {
+			this.host = host == null ? null : host.trim();
+		}
+
+		public int getPort() {
+			return port;
+		}
+
+		public void setPort(int port) {
+			this.port = port;
+		}
+
+		boolean isConfigured() {
+			return enabled && host != null && !host.isBlank() && port > 0 && port <= 65_535;
+		}
+
+		void validate() {
+			if (enabled && !isConfigured()) {
+				throw new IllegalStateException("NAVER shopping proxy requires a host and a valid port");
 			}
 		}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -91,6 +91,11 @@ app:
         type: ${SHOPPING_IMPORT_KREAM_PROXY_TYPE:SOCKS}
         host: ${SHOPPING_IMPORT_KREAM_PROXY_HOST:}
         port: ${SHOPPING_IMPORT_KREAM_PROXY_PORT:1080}
+      naver-proxy:
+        enabled: ${SHOPPING_IMPORT_NAVER_PROXY_ENABLED:false}
+        type: ${SHOPPING_IMPORT_NAVER_PROXY_TYPE:SOCKS}
+        host: ${SHOPPING_IMPORT_NAVER_PROXY_HOST:}
+        port: ${SHOPPING_IMPORT_NAVER_PROXY_PORT:1080}
       ably-api:
         enabled: ${SHOPPING_IMPORT_ABLY_API_ENABLED:true}
         anonymous-token: ${SHOPPING_IMPORT_ABLY_ANONYMOUS_TOKEN:}

--- a/src/test/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcherTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcherTest.java
@@ -18,17 +18,26 @@ import org.junit.jupiter.api.Test;
 class BrowserPageFetcherTest {
 
 	@Test
-	void appliesConfiguredProxyOnlyToKreamContext() {
+	void appliesEachConfiguredProxyOnlyToItsShoppingContext() {
 		ShoppingImportProperties.BrowserFetch browserFetch = new ShoppingImportProperties.BrowserFetch();
 		ShoppingImportProperties.KreamProxy kreamProxy = new ShoppingImportProperties.KreamProxy();
 		kreamProxy.setEnabled(true);
 		kreamProxy.setType(ShoppingImportProperties.KreamProxy.Type.SOCKS);
 		kreamProxy.setHost("127.0.0.1");
 		kreamProxy.setPort(18080);
-		BrowserPageFetcher fetcher = new BrowserPageFetcher(browserFetch, 1_000_000, kreamProxy);
+		ShoppingImportProperties.NaverProxy naverProxy = new ShoppingImportProperties.NaverProxy();
+		naverProxy.setEnabled(true);
+		naverProxy.setType(ShoppingImportProperties.NaverProxy.Type.HTTP);
+		naverProxy.setHost("naver-proxy.internal");
+		naverProxy.setPort(3128);
+		BrowserPageFetcher fetcher = new BrowserPageFetcher(browserFetch, 1_000_000, kreamProxy, naverProxy);
 
 		assertThat(fetcher.contextOptions(URI.create("https://kream.co.kr/products/444045")).proxy.server)
 			.isEqualTo("socks5://127.0.0.1:18080");
+		assertThat(fetcher.contextOptions(URI.create("https://naver.me/5imjsySn")).proxy.server)
+			.isEqualTo("http://naver-proxy.internal:3128");
+		assertThat(fetcher.contextOptions(URI.create("https://m.smartstore.naver.com/edithshop/products/13581698411")).proxy.server)
+			.isEqualTo("http://naver-proxy.internal:3128");
 		assertThat(fetcher.contextOptions(URI.create("https://zigzag.kr/catalog/products/1")).proxy)
 			.isNull();
 	}

--- a/src/test/java/com/sagongsa/backend/itemimport/item/FallbackPageFetcherTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/FallbackPageFetcherTest.java
@@ -74,6 +74,35 @@ class FallbackPageFetcherTest {
 	}
 
 	@Test
+	void restoresSmartStoreProductFromNaverLoginRedirectBeforeBrowserFallback() {
+		URI originalUri = URI.create("https://naver.me/5imjsySn");
+		URI loginUri = URI.create(
+			"https://nid.naver.com/nidlogin.login?url="
+				+ "https%3A%2F%2Fsmartstore.naver.com%2Fedithshop%2Fproducts%2F13581698411%3Ftr%3Dnshfum"
+		);
+		AtomicReference<URI> fallbackRequest = new AtomicReference<>();
+		FallbackPageFetcher fetcher = new FallbackPageFetcher(
+			requestedUri -> new FetchedPage(
+				requestedUri,
+				loginUri,
+				200,
+				"text/html",
+				"<html><title>NAVER 로그인</title></html>"
+			),
+			requestedUri -> {
+				fallbackRequest.set(requestedUri);
+				return new FetchedPage(requestedUri, requestedUri, 200, "text/html", "<html>rendered</html>");
+			}
+		);
+
+		fetcher.fetch(originalUri);
+
+		assertThat(fallbackRequest.get()).isEqualTo(
+			URI.create("https://m.smartstore.naver.com/edithshop/products/13581698411?tr=nshfum")
+		);
+	}
+
+	@Test
 	void usesBrowserFallbackForAblyCloudflareChallengeShell() {
 		URI uri = URI.create("https://m.a-bly.com/goods/70247267");
 		AtomicReference<URI> fallbackRequest = new AtomicReference<>();

--- a/src/test/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcherTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/JsoupPageFetcherTest.java
@@ -2,12 +2,43 @@ package com.sagongsa.backend.itemimport.item;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.URI;
 import org.junit.jupiter.api.Test;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 
 class JsoupPageFetcherTest {
+
+	@Test
+	void appliesNaverProxyOnlyToNaverShoppingRequests() {
+		ShoppingImportProperties.NaverProxy naverProxy = new ShoppingImportProperties.NaverProxy();
+		naverProxy.setEnabled(true);
+		naverProxy.setType(ShoppingImportProperties.NaverProxy.Type.HTTP);
+		naverProxy.setHost("naver-proxy.internal");
+		naverProxy.setPort(3128);
+		JsoupPageFetcher fetcher = new JsoupPageFetcher(
+			1_000_000,
+			new ShoppingImportProperties.KreamProxy(),
+			naverProxy,
+			new ShoppingImportProperties.AblyApi()
+		);
+
+		Proxy proxy = fetcher.shoppingProxy(URI.create("https://naver.me/5imjsySn")).orElseThrow();
+
+		assertThat(proxy.type()).isEqualTo(Proxy.Type.HTTP);
+		assertThat((InetSocketAddress) proxy.address()).satisfies(address -> {
+			assertThat(address.getHostString()).isEqualTo("naver-proxy.internal");
+			assertThat(address.getPort()).isEqualTo(3128);
+		});
+		assertThat(fetcher.shoppingProxy(URI.create("https://m.smartstore.naver.com/shop/products/1")))
+			.isPresent();
+		assertThat(fetcher.shoppingProxy(URI.create("https://nid.naver.com/nidlogin.login")))
+			.isEmpty();
+		assertThat(fetcher.shoppingProxy(URI.create("https://store.zigzag.kr/catalog/products/1")))
+			.isEmpty();
+	}
 
 	@Test
 	void resolvesAppsFlyerOneLinkStoreLinkToProductPage() {

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportConfigTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportConfigTest.java
@@ -69,6 +69,26 @@ class ShoppingImportConfigTest {
 	}
 
 	@Test
+	void bindsNaverProxySettings() {
+		contextRunner
+			.withPropertyValues(
+				"app.shopping.import.naver-proxy.enabled=true",
+				"app.shopping.import.naver-proxy.type=http",
+				"app.shopping.import.naver-proxy.host=naver-proxy.internal",
+				"app.shopping.import.naver-proxy.port=3128"
+			)
+			.run(context -> {
+				assertThat(context).hasNotFailed();
+				ShoppingImportProperties.NaverProxy proxy = context.getBean(ShoppingImportProperties.class)
+					.getNaverProxy();
+				assertThat(proxy.isEnabled()).isTrue();
+				assertThat(proxy.getType()).isEqualTo(ShoppingImportProperties.NaverProxy.Type.HTTP);
+				assertThat(proxy.getHost()).isEqualTo("naver-proxy.internal");
+				assertThat(proxy.getPort()).isEqualTo(3128);
+			});
+	}
+
+	@Test
 	void bindsAblyApiSettingsWithoutExposingThemToOtherFetchers() {
 		contextRunner
 			.withPropertyValues(
@@ -90,6 +110,13 @@ class ShoppingImportConfigTest {
 	void rejectsEnabledKreamProxyWithoutHost() {
 		contextRunner
 			.withPropertyValues("app.shopping.import.kream-proxy.enabled=true")
+			.run(context -> assertThat(context).hasFailed());
+	}
+
+	@Test
+	void rejectsEnabledNaverProxyWithoutHost() {
+		contextRunner
+			.withPropertyValues("app.shopping.import.naver-proxy.enabled=true")
 			.run(context -> assertThat(context).hasFailed());
 	}
 }


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 Tracking

- Jira Key: `NF-96`
- Closes #217

## 📝 작업 요약

- N+스토어 수집 전용 HTTP/SOCKS 프록시 설정을 추가했습니다.
- 정적 Jsoup 요청과 Playwright Chromium 브라우저 폴백 모두 동일한 네이버 전용 프록시를 사용합니다.
- 네이버 로그인 페이지로 리다이렉트되면 검증된 원래 스마트스토어/브랜드스토어 상품 URL을 복원해 모바일 상품 페이지로 재시도합니다.

## 🔍 원인

- QA 서버 출구 IP에서 네이버 상품 페이지 요청이 `429` 또는 `nid.naver.com` 로그인 페이지로 전환되었습니다.
- 기존 브라우저 폴백은 로그인 페이지를 정상 `200` 응답으로 판단했고, 원래 상품 URL로 복귀하지 못했습니다.

## ✅ 해결

- `SHOPPING_IMPORT_NAVER_PROXY_ENABLED`, `TYPE`, `HOST`, `PORT` 설정을 추가했습니다.
- 프록시 적용 대상을 `naver.me`, 네이버 쇼핑 브리지, 스마트스토어/브랜드스토어 상품 호스트로 제한했습니다.
- 로그인 URL의 `url` 파라미터가 실제 네이버 상품 URL일 때만 복원하도록 제한했습니다.
- 프록시 미설정 시 기존 수집 경로를 그대로 유지합니다.

## 🧪 검증

- [x] 정적 수집에서 네이버 쇼핑 호스트에만 전용 프록시 적용
- [x] Playwright 컨텍스트에서 네이버 쇼핑 호스트에만 전용 프록시 적용
- [x] 로그인 리다이렉트에서 상품 URL 복원 및 모바일 호스트 전환
- [x] 프록시 설정 바인딩 및 잘못된 설정의 기동 실패
- [x] `./gradlew check`

## ⚠️ 배포 설정

QA/운영에서 실제 우회 효과를 확인하려면 인증 없는 내부 프록시 주소를 런타임 환경에 별도로 설정해야 합니다.

```text
SHOPPING_IMPORT_NAVER_PROXY_ENABLED=true
SHOPPING_IMPORT_NAVER_PROXY_TYPE=SOCKS
SHOPPING_IMPORT_NAVER_PROXY_HOST=<proxy-host>
SHOPPING_IMPORT_NAVER_PROXY_PORT=<proxy-port>
```

프록시 주소나 자격 증명은 저장소와 로그에 남기지 않습니다.

## 👀 리뷰 가이드

- 네이버 전용 프록시가 다른 쇼핑몰 및 `nid.naver.com` 요청에 적용되지 않는지 확인 부탁드립니다.
- 로그인 URL에서 복원한 대상이 스마트스토어/브랜드스토어 상품 URL로 제한되는지 확인 부탁드립니다.
