### PR TITLE
NF-98 Chore: 쇼핑 가져오기 사용자별 활성 작업 1건 제한

### DIFF
--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportProperties.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportProperties.java
@@ -77,7 +77,7 @@ public class ShoppingImportProperties {
 
 		private boolean enabled = true;
 		private int maxQueueSize = 100;
-		private int maxActivePerUser = 3;
+		private int maxActivePerUser = 1;
 		private int concurrency = 1;
 		private int maxAttempts = 2;
 		private long fixedDelayMs = 500;
@@ -106,7 +106,7 @@ public class ShoppingImportProperties {
 		}
 
 		public void setMaxActivePerUser(int maxActivePerUser) {
-			this.maxActivePerUser = maxActivePerUser <= 0 ? 3 : maxActivePerUser;
+			this.maxActivePerUser = maxActivePerUser <= 0 ? 1 : maxActivePerUser;
 		}
 
 		public int getConcurrency() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,7 +79,7 @@ app:
       job-worker:
         enabled: ${SHOPPING_IMPORT_JOB_WORKER_ENABLED:true}
         max-queue-size: ${SHOPPING_IMPORT_JOB_MAX_QUEUE_SIZE:100}
-        max-active-per-user: ${SHOPPING_IMPORT_JOB_MAX_ACTIVE_PER_USER:3}
+        max-active-per-user: ${SHOPPING_IMPORT_JOB_MAX_ACTIVE_PER_USER:1}
         concurrency: ${SHOPPING_IMPORT_JOB_CONCURRENCY:1}
         max-attempts: ${SHOPPING_IMPORT_JOB_MAX_ATTEMPTS:2}
         fixed-delay-ms: ${SHOPPING_IMPORT_JOB_FIXED_DELAY_MS:500}

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportPropertiesTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportPropertiesTest.java
@@ -1,0 +1,24 @@
+package com.sagongsa.backend.itemimport.item;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ShoppingImportPropertiesTest {
+
+	@Test
+	void limitsActiveJobsToOnePerUserByDefault() {
+		ShoppingImportProperties properties = new ShoppingImportProperties();
+
+		assertThat(properties.getJobWorker().getMaxActivePerUser()).isEqualTo(1);
+	}
+
+	@Test
+	void fallsBackToOneWhenMaxActivePerUserIsNotPositive() {
+		ShoppingImportProperties properties = new ShoppingImportProperties();
+
+		properties.getJobWorker().setMaxActivePerUser(0);
+
+		assertThat(properties.getJobWorker().getMaxActivePerUser()).isEqualTo(1);
+	}
+}


### PR DESCRIPTION
# 🧰 Chore PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-98**
- Jira: https://parkjaehong.atlassian.net/browse/NF-98

### 🔒 Close Issue (필수)
- GitHub: Closes #221

## 🧩 한눈에 요약 (필수)

### 무엇을 변경했나? (인프라/빌드/CI/의존성 등)
- [ ] 인프라
- [x] 설정파일
- [ ] 빌드 파일
- [ ] CI
- [ ] 의존성
- [x] 런타임/비즈니스 로직 리팩터링 없음

### 왜 필요한가? (안정성/속도/보안/개발경험)
- 최신 FE에는 여러 상품을 동시에 가져오는 배치 기능이 없다.
- 한 사용자의 반복 공유나 중복 호출이 전역 큐를 점유하지 않도록 활성 작업을 1건으로 제한한다.

### 범위(스코프)
- Included: 사용자별 `PENDING + RUNNING` 작업 기본 상한 `3 → 1`, 코드 fallback 일치, 회귀 테스트
- Not included: 서버 전체 워커 동시성, 전역 큐 크기, FE 흐름 변경

## 🧪 테스트 / 검증 (필수)

### 로컬
- Command: `./gradlew test --tests 'com.sagongsa.backend.itemimport.item.ShoppingImportPropertiesTest' --tests 'com.sagongsa.backend.itemimport.ShoppingImportJobApiIntegrationTest'`
- Result: `BUILD SUCCESSFUL`

### CI
- 링크/결과: PR 생성 후 자동 실행

### Smoke / 수동 검증 (해당 시)
- 시나리오: 최신 FE `develop`의 상품 가져오기 진입 및 상태 관리 확인
- 결과: 배치/다중 가져오기 기능 없음. 단일 추가 패널과 단일 import 상태 사용

### 테스트 공백(있다면 이유 필수)
- QA 서버 배포는 이 PR 범위에 포함하지 않는다.

## 🧭 영향 범위 (필수)
- [ ] 설정/환경변수 변경 없음
- [x] 설정/환경변수 변경 있음 (항목: `SHOPPING_IMPORT_JOB_MAX_ACTIVE_PER_USER` 기본값)
- [x] CI/빌드 파이프라인 영향 없음
- [ ] CI/빌드 파이프라인 영향 있음
- [x] 의존성(dependency) 변경 없음
- [ ] 의존성(dependency) 변경 있음

## ⚠️ 리스크 & 롤백 (필수)

### 리스크
- 한 사용자가 서로 다른 두 상품을 첫 작업 완료 전에 요청하면 두 번째 요청은 `429 Too Many Requests`를 받는다.
- 동일 요청은 활성 job 재사용 검사가 먼저 실행되므로 기존 job을 그대로 반환한다.

### 롤백
- [x] 단순 revert로 가능
- [ ] 버전 pin/되돌리기 필요
- [ ] 배포 롤백 필요

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/설정: `ShoppingImportProperties.JobWorker`, `application.yml`
- 트레이드오프/대안: 사용자당 2~3건 허용보다 큐 공정성을 우선한다.
- 성능/보안/호환성 영향: 서버 전체 worker 3개 운영 설정에는 영향이 없다.
