### PR TITLE
[fix] NF-101 올리브영 크롤링 시작 간격 적용

### DIFF
--- a/docs/SHOPPING_IMPORT_SHARED_CRAWL_OPERATIONS.md
+++ b/docs/SHOPPING_IMPORT_SHARED_CRAWL_OPERATIONS.md
@@ -27,6 +27,9 @@
 | `SHOPPING_IMPORT_CACHE_ENABLED` | `true` | 완료된 성공·실패 결과 단기 재사용 |
 | `SHOPPING_IMPORT_CACHE_SUCCESS_TTL` | `PT5M` | 성공 결과 TTL |
 | `SHOPPING_IMPORT_CACHE_FAILURE_TTL` | `PT30S` | 실패 결과 TTL |
+| `SHOPPING_IMPORT_OLIVEYOUNG_INTERVAL_ENABLED` | `true` | 올리브영 요청 시작 간격 사용 여부 |
+| `SHOPPING_IMPORT_OLIVEYOUNG_MIN_START_INTERVAL` | `PT2S` | 올리브영 요청 최소 시작 간격 |
+| `SHOPPING_IMPORT_OLIVEYOUNG_MAX_START_INTERVAL` | `PT3S` | 올리브영 요청 최대 시작 간격 |
 | `MANAGEMENT_SERVER_ADDRESS` | `127.0.0.1` | 관리 endpoint bind 주소 |
 | `MANAGEMENT_SERVER_PORT` | `9090` | 관리 endpoint 포트 |
 

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportConfig.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportConfig.java
@@ -18,12 +18,17 @@ public class ShoppingImportConfig {
 			kreamProxy,
 			properties.getAblyApi()
 		);
+		PageFetcher delegate = jsoupPageFetcher;
 		if (browserFetch.isEnabled()) {
-			return new FallbackPageFetcher(
+			delegate = new FallbackPageFetcher(
 				jsoupPageFetcher,
 				new BrowserPageFetcher(browserFetch, properties.getMaxResponseBytes(), kreamProxy)
 			);
 		}
-		return jsoupPageFetcher;
+		ShoppingImportProperties.SiteThrottle.OliveYoung oliveYoung = properties
+			.getSiteThrottle()
+			.getOliveYoung();
+		oliveYoung.validate();
+		return new SiteIntervalPageFetcher(delegate, oliveYoung);
 	}
 }

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportProperties.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportProperties.java
@@ -11,6 +11,7 @@ public class ShoppingImportProperties {
 	private int maxResponseBytes = 1_000_000;
 	private final BrowserFetch browserFetch = new BrowserFetch();
 	private final SharedCrawl sharedCrawl = new SharedCrawl();
+	private final SiteThrottle siteThrottle = new SiteThrottle();
 	private final JobWorker jobWorker = new JobWorker();
 	private final KreamProxy kreamProxy = new KreamProxy();
 	private final AblyApi ablyApi = new AblyApi();
@@ -29,6 +30,10 @@ public class ShoppingImportProperties {
 
 	public SharedCrawl getSharedCrawl() {
 		return sharedCrawl;
+	}
+
+	public SiteThrottle getSiteThrottle() {
+		return siteThrottle;
 	}
 
 	public JobWorker getJobWorker() {
@@ -84,6 +89,58 @@ public class ShoppingImportProperties {
 
 		private Duration positiveOrDefault(Duration value, Duration fallback) {
 			return value == null || value.isZero() || value.isNegative() ? fallback : value;
+		}
+	}
+
+	public static class SiteThrottle {
+
+		private final OliveYoung oliveYoung = new OliveYoung();
+
+		public OliveYoung getOliveYoung() {
+			return oliveYoung;
+		}
+
+		public static class OliveYoung {
+
+			private boolean enabled = true;
+			private Duration minStartInterval = Duration.ofSeconds(2);
+			private Duration maxStartInterval = Duration.ofSeconds(3);
+
+			public boolean isEnabled() {
+				return enabled;
+			}
+
+			public void setEnabled(boolean enabled) {
+				this.enabled = enabled;
+			}
+
+			public Duration getMinStartInterval() {
+				return minStartInterval;
+			}
+
+			public void setMinStartInterval(Duration minStartInterval) {
+				this.minStartInterval = positiveOrDefault(minStartInterval, Duration.ofSeconds(2));
+			}
+
+			public Duration getMaxStartInterval() {
+				return maxStartInterval;
+			}
+
+			public void setMaxStartInterval(Duration maxStartInterval) {
+				this.maxStartInterval = positiveOrDefault(maxStartInterval, Duration.ofSeconds(3));
+			}
+
+			void validate() {
+				if (enabled && maxStartInterval.compareTo(minStartInterval) < 0) {
+					throw new IllegalStateException(
+						"Olive Young max start interval must be greater than or equal to min start interval"
+					);
+				}
+			}
+
+			private Duration positiveOrDefault(Duration value, Duration fallback) {
+				return value == null || value.isZero() || value.isNegative() ? fallback : value;
+			}
 		}
 	}
 

--- a/src/main/java/com/sagongsa/backend/itemimport/item/SiteIntervalPageFetcher.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/SiteIntervalPageFetcher.java
@@ -1,0 +1,97 @@
+package com.sagongsa.backend.itemimport.item;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+final class SiteIntervalPageFetcher implements PageFetcher {
+
+	private final PageFetcher delegate;
+	private final boolean oliveYoungEnabled;
+	private final long minIntervalNanos;
+	private final long maxIntervalNanos;
+	private final LongSupplier nanoTime;
+	private final Sleeper sleeper;
+	private final LongSupplier intervalNanos;
+	private long nextOliveYoungStartNanos;
+
+	SiteIntervalPageFetcher(
+		PageFetcher delegate,
+		ShoppingImportProperties.SiteThrottle.OliveYoung properties
+	) {
+		this(
+			delegate,
+			properties,
+			System::nanoTime,
+			TimeUnit.NANOSECONDS::sleep,
+			() -> randomInterval(properties.getMinStartInterval(), properties.getMaxStartInterval())
+		);
+	}
+
+	SiteIntervalPageFetcher(
+		PageFetcher delegate,
+		ShoppingImportProperties.SiteThrottle.OliveYoung properties,
+		LongSupplier nanoTime,
+		Sleeper sleeper,
+		LongSupplier intervalNanos
+	) {
+		this.delegate = delegate;
+		this.oliveYoungEnabled = properties.isEnabled();
+		this.minIntervalNanos = properties.getMinStartInterval().toNanos();
+		this.maxIntervalNanos = properties.getMaxStartInterval().toNanos();
+		this.nanoTime = nanoTime;
+		this.sleeper = sleeper;
+		this.intervalNanos = intervalNanos;
+	}
+
+	@Override
+	public FetchedPage fetch(URI uri) {
+		if (oliveYoungEnabled && isOliveYoung(uri)) {
+			waitForStartInterval();
+		}
+		return delegate.fetch(uri);
+	}
+
+	private synchronized void waitForStartInterval() {
+		long now = nanoTime.getAsLong();
+		long delayNanos = Math.max(0, nextOliveYoungStartNanos - now);
+		try {
+			if (delayNanos > 0) {
+				sleeper.sleep(delayNanos);
+			}
+		} catch (InterruptedException exception) {
+			Thread.currentThread().interrupt();
+			throw new ResponseStatusException(
+				HttpStatus.SERVICE_UNAVAILABLE,
+				"Shopping page request interval wait was interrupted",
+				exception
+			);
+		}
+		long selectedInterval = Math.max(minIntervalNanos, Math.min(maxIntervalNanos, intervalNanos.getAsLong()));
+		nextOliveYoungStartNanos = nanoTime.getAsLong() + selectedInterval;
+	}
+
+	private boolean isOliveYoung(URI uri) {
+		String host = uri == null || uri.getHost() == null ? "" : uri.getHost().toLowerCase(Locale.ROOT);
+		return host.equals("oliveyoung.co.kr") || host.endsWith(".oliveyoung.co.kr");
+	}
+
+	private static long randomInterval(Duration min, Duration max) {
+		long minNanos = min.toNanos();
+		long maxNanos = max.toNanos();
+		if (minNanos == maxNanos) {
+			return minNanos;
+		}
+		return ThreadLocalRandom.current().nextLong(minNanos, maxNanos + 1);
+	}
+
+	@FunctionalInterface
+	interface Sleeper {
+		void sleep(long nanos) throws InterruptedException;
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,6 +81,11 @@ app:
         cache-enabled: ${SHOPPING_IMPORT_CACHE_ENABLED:true}
         success-ttl: ${SHOPPING_IMPORT_CACHE_SUCCESS_TTL:PT5M}
         failure-ttl: ${SHOPPING_IMPORT_CACHE_FAILURE_TTL:PT30S}
+      site-throttle:
+        olive-young:
+          enabled: ${SHOPPING_IMPORT_OLIVEYOUNG_INTERVAL_ENABLED:true}
+          min-start-interval: ${SHOPPING_IMPORT_OLIVEYOUNG_MIN_START_INTERVAL:PT2S}
+          max-start-interval: ${SHOPPING_IMPORT_OLIVEYOUNG_MAX_START_INTERVAL:PT3S}
       job-worker:
         enabled: ${SHOPPING_IMPORT_JOB_WORKER_ENABLED:true}
         max-queue-size: ${SHOPPING_IMPORT_JOB_MAX_QUEUE_SIZE:100}

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportConfigTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportConfigTest.java
@@ -15,7 +15,7 @@ class ShoppingImportConfigTest {
 	void usesFallbackPageFetcherByDefault() {
 		contextRunner.run(context -> {
 			assertThat(context).hasSingleBean(PageFetcher.class);
-			assertThat(context.getBean(PageFetcher.class)).isInstanceOf(FallbackPageFetcher.class);
+			assertThat(context.getBean(PageFetcher.class)).isInstanceOf(SiteIntervalPageFetcher.class);
 		});
 	}
 
@@ -25,7 +25,7 @@ class ShoppingImportConfigTest {
 			.withPropertyValues("app.shopping.import.browser-fetch.enabled=false")
 			.run(context -> {
 				assertThat(context).hasSingleBean(PageFetcher.class);
-				assertThat(context.getBean(PageFetcher.class)).isInstanceOf(JsoupPageFetcher.class);
+				assertThat(context.getBean(PageFetcher.class)).isInstanceOf(SiteIntervalPageFetcher.class);
 			});
 	}
 
@@ -39,7 +39,7 @@ class ShoppingImportConfigTest {
 			)
 			.run(context -> {
 				assertThat(context).hasSingleBean(PageFetcher.class);
-				assertThat(context.getBean(PageFetcher.class)).isInstanceOf(FallbackPageFetcher.class);
+				assertThat(context.getBean(PageFetcher.class)).isInstanceOf(SiteIntervalPageFetcher.class);
 				assertThat(context.getBean(ShoppingImportProperties.class)
 					.getMaxResponseBytes()).isEqualTo(65536);
 				assertThat(context.getBean(ShoppingImportProperties.class)
@@ -104,6 +104,35 @@ class ShoppingImportConfigTest {
 				assertThat(sharedCrawl.getSuccessTtl()).isEqualTo(Duration.ofMinutes(1));
 				assertThat(sharedCrawl.getFailureTtl()).isEqualTo(Duration.ofSeconds(15));
 			});
+	}
+
+	@Test
+	void bindsOliveYoungRequestIntervalSettings() {
+		contextRunner
+			.withPropertyValues(
+				"app.shopping.import.site-throttle.olive-young.enabled=true",
+				"app.shopping.import.site-throttle.olive-young.min-start-interval=PT2S",
+				"app.shopping.import.site-throttle.olive-young.max-start-interval=PT3S"
+			)
+			.run(context -> {
+				ShoppingImportProperties.SiteThrottle.OliveYoung oliveYoung = context
+					.getBean(ShoppingImportProperties.class)
+					.getSiteThrottle()
+					.getOliveYoung();
+				assertThat(oliveYoung.isEnabled()).isTrue();
+				assertThat(oliveYoung.getMinStartInterval()).isEqualTo(Duration.ofSeconds(2));
+				assertThat(oliveYoung.getMaxStartInterval()).isEqualTo(Duration.ofSeconds(3));
+			});
+	}
+
+	@Test
+	void rejectsOliveYoungMaxIntervalBelowMinInterval() {
+		contextRunner
+			.withPropertyValues(
+				"app.shopping.import.site-throttle.olive-young.min-start-interval=PT3S",
+				"app.shopping.import.site-throttle.olive-young.max-start-interval=PT2S"
+			)
+			.run(context -> assertThat(context).hasFailed());
 	}
 
 	@Test

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportPropertiesTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportPropertiesTest.java
@@ -43,4 +43,15 @@ class ShoppingImportPropertiesTest {
 		assertThat(sharedCrawl.getSuccessTtl()).isEqualTo(Duration.ofMinutes(5));
 		assertThat(sharedCrawl.getFailureTtl()).isEqualTo(Duration.ofSeconds(30));
 	}
+
+	@Test
+	void enablesOliveYoungTwoToThreeSecondStartIntervalByDefault() {
+		ShoppingImportProperties.SiteThrottle.OliveYoung oliveYoung = new ShoppingImportProperties()
+			.getSiteThrottle()
+			.getOliveYoung();
+
+		assertThat(oliveYoung.isEnabled()).isTrue();
+		assertThat(oliveYoung.getMinStartInterval()).isEqualTo(Duration.ofSeconds(2));
+		assertThat(oliveYoung.getMaxStartInterval()).isEqualTo(Duration.ofSeconds(3));
+	}
 }

--- a/src/test/java/com/sagongsa/backend/itemimport/item/SiteIntervalPageFetcherTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/SiteIntervalPageFetcherTest.java
@@ -1,0 +1,74 @@
+package com.sagongsa.backend.itemimport.item;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+class SiteIntervalPageFetcherTest {
+
+	@Test
+	void spacesOnlyOliveYoungRequestStartsByReservedInterval() {
+		AtomicLong nowNanos = new AtomicLong();
+		List<Long> sleeps = new ArrayList<>();
+		AtomicInteger fetches = new AtomicInteger();
+		SiteIntervalPageFetcher fetcher = new SiteIntervalPageFetcher(
+			uri -> {
+				fetches.incrementAndGet();
+				return page(uri);
+			},
+			properties(true),
+			nowNanos::get,
+			nanos -> {
+				sleeps.add(nanos);
+				nowNanos.addAndGet(nanos);
+			},
+			() -> Duration.ofMillis(2_500).toNanos()
+		);
+
+		fetcher.fetch(URI.create("https://www.oliveyoung.co.kr/store/goods/1"));
+		fetcher.fetch(URI.create("https://www.musinsa.com/products/1"));
+		fetcher.fetch(URI.create("https://m.oliveyoung.co.kr/store/goods/2"));
+		fetcher.fetch(URI.create("https://oliveyoung.co.kr/store/goods/3"));
+
+		assertThat(fetches).hasValue(4);
+		assertThat(sleeps).containsExactly(
+			Duration.ofMillis(2_500).toNanos(),
+			Duration.ofMillis(2_500).toNanos()
+		);
+	}
+
+	@Test
+	void doesNotWaitWhenOliveYoungIntervalIsDisabled() {
+		AtomicInteger sleeps = new AtomicInteger();
+		SiteIntervalPageFetcher fetcher = new SiteIntervalPageFetcher(
+			SiteIntervalPageFetcherTest::page,
+			properties(false),
+			System::nanoTime,
+			nanos -> sleeps.incrementAndGet(),
+			() -> Duration.ofSeconds(2).toNanos()
+		);
+
+		fetcher.fetch(URI.create("https://www.oliveyoung.co.kr/store/goods/1"));
+		fetcher.fetch(URI.create("https://www.oliveyoung.co.kr/store/goods/2"));
+
+		assertThat(sleeps).hasValue(0);
+	}
+
+	private static ShoppingImportProperties.SiteThrottle.OliveYoung properties(boolean enabled) {
+		ShoppingImportProperties.SiteThrottle.OliveYoung properties = new ShoppingImportProperties.SiteThrottle.OliveYoung();
+		properties.setEnabled(enabled);
+		properties.setMinStartInterval(Duration.ofSeconds(2));
+		properties.setMaxStartInterval(Duration.ofSeconds(3));
+		return properties;
+	}
+
+	private static FetchedPage page(URI uri) {
+		return new FetchedPage(uri, uri, 200, "text/html", "<html></html>");
+	}
+}


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크
- Tracking Key: `NF-101`
- Jira: https://parkjaehong.atlassian.net/browse/NF-101
- GitHub: Closes #227
- 관련 테스트: NF-97 사용자 100명 쇼핑 가져오기 부하 테스트

## 📝 작업 요약
- 올리브영 외부 요청의 실제 시작 시점 사이에 2~3초 간격을 적용합니다.
- 첫 올리브영 요청은 즉시 실행하고, 동시에 진입한 후속 요청은 순서대로 시작 간격을 확보합니다.
- 다른 쇼핑몰과 전체 worker 동시성에는 간격을 적용하지 않습니다.
- 환경변수로 기능과 최소·최대 간격을 즉시 조정할 수 있습니다.

## 🔍 원인
- QA 사용자 100명 테스트에서 올리브영 대표 크롤링 3건이 거의 동시에 시작된 뒤 HTTP 403이 발생했습니다.
- 요청 병합으로 동일 상품 중복 크롤링은 제거됐지만 서로 다른 올리브영 상품의 동시 시작은 제한하지 않았습니다.

## ✅ Acceptance Criteria
- [x] 올리브영 첫 요청은 즉시 실행되고 후속 요청 시작 간격은 2~3초입니다.
- [x] 동시 진입한 올리브영 요청도 시작 시점이 겹치지 않습니다.
- [x] 올리브영 외 사이트에는 지연이 적용되지 않습니다.
- [x] 환경변수로 비활성화하고 최소·최대 간격을 조정할 수 있습니다.
- [ ] 머지·QA 배포 후 사용자 100명·요청 100건을 동일 조건으로 재측정합니다.

## 🧪 검증
```text
./gradlew test
BUILD SUCCESSFUL
```
- 올리브영 연속 요청의 2.5초 간격 단위 테스트
- 다른 사이트 무지연 단위 테스트
- 기능 비활성화 단위 테스트
- 설정 바인딩과 잘못된 최소·최대 구간 검증
- 전체 테스트 통과

## 🧭 영향 범위
- [x] API/DB 스키마 변경 없음
- [x] 올리브영 외부 요청 시작 시점에만 영향
- [x] 전체 worker 수와 캐시·요청 병합 유지
- [x] Breaking change 없음

## ⚙️ 환경변수
- `SHOPPING_IMPORT_OLIVEYOUNG_INTERVAL_ENABLED=true`
- `SHOPPING_IMPORT_OLIVEYOUNG_MIN_START_INTERVAL=PT2S`
- `SHOPPING_IMPORT_OLIVEYOUNG_MAX_START_INTERVAL=PT3S`

## ⚠️ 리스크 & 롤백
- 간격을 기다리는 올리브영 작업이 worker를 점유해 전체 queue 대기시간이 일부 늘 수 있습니다.
- `SHOPPING_IMPORT_OLIVEYOUNG_INTERVAL_ENABLED=false`로 즉시 비활성화하거나 PR을 revert할 수 있습니다.
