### PR TITLE
[fix] NF-103 기회비용 가격 근접 항목 우선 선택

### DIFF
--- a/src/main/java/com/sagongsa/backend/wishlist/OpportunityCostService.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/OpportunityCostService.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
@@ -59,8 +60,18 @@ public class OpportunityCostService {
 			return fallback(normalizedPrice, sourceCategory, items, HIGH_PRICE_FALLBACK_ITEM_ID, HIGH_PRICE_FALLBACK_MESSAGE);
 		}
 
-		CalculatedOpportunityCostItem selected = randomValue(candidates);
+		CalculatedOpportunityCostItem selected = selectCandidate(candidates, normalizedPrice);
 		return response(normalizedPrice, sourceCategory, selected.item(), selected.calculatedCount(), null);
+	}
+
+	private CalculatedOpportunityCostItem selectCandidate(
+		List<CalculatedOpportunityCostItem> candidates,
+		int price
+	) {
+		return candidates.stream()
+			.filter(candidate -> candidate.calculatedCount() == 1)
+			.min(Comparator.comparingLong(candidate -> Math.abs((long) candidate.item().unitPrice() - price)))
+			.orElseGet(() -> randomValue(candidates));
 	}
 
 	private int validatePrice(Integer price) {

--- a/src/test/java/com/sagongsa/backend/wishlist/OpportunityCostApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/OpportunityCostApiIntegrationTest.java
@@ -34,6 +34,19 @@ class OpportunityCostApiIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void returnsChickenForReportedMusinsaPrice() throws Exception {
+		mockMvc.perform(get("/api/v1/wishlist/opportunity-cost")
+				.queryParam("price", "25500")
+				.queryParam("category", "FASHION"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.result.itemId").value("ITEM_03"))
+			.andExpect(jsonPath("$.result.calculatedCount").value(1))
+			.andExpect(jsonPath("$.result.displayTitle").value("황금올리브 치킨 🍗"))
+			.andExpect(jsonPath("$.result.displayMessage")
+				.value("이 상품 1개를 아끼면, 바삭한 황금올리브 치킨을 먹을 수 있어요! 🍗"));
+	}
+
+	@Test
 	void supportsPlanningPathAlias() throws Exception {
 		mockMvc.perform(get("/api/v1/wishes/opportunity-cost")
 				.queryParam("price", "35000")

--- a/src/test/java/com/sagongsa/backend/wishlist/OpportunityCostServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/OpportunityCostServiceTest.java
@@ -28,6 +28,21 @@ class OpportunityCostServiceTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void selectsClosestSingleCountItemForDemoPriceBands() {
+		OpportunityCostResponse youtube = opportunityCostService.calculate(15_000, "FASHION");
+		OpportunityCostResponse chicken = opportunityCostService.calculate(25_500, "FASHION");
+
+		assertThat(youtube.result().itemId()).isEqualTo("ITEM_02");
+		assertThat(youtube.result().calculatedCount()).isEqualTo(1);
+		assertThat(youtube.result().displayMessage())
+			.isEqualTo("이 상품 1개를 아끼면, 광고 없이 유튜브 프리미엄을 1달 볼 수 있어요! 📺");
+		assertThat(chicken.result().itemId()).isEqualTo("ITEM_03");
+		assertThat(chicken.result().calculatedCount()).isEqualTo(1);
+		assertThat(chicken.result().displayMessage())
+			.isEqualTo("이 상품 1개를 아끼면, 바삭한 황금올리브 치킨을 먹을 수 있어요! 🍗");
+	}
+
+	@Test
 	void expandsCandidateCountToTwentyWhenPrimaryPoolIsEmpty() {
 		OpportunityCostResponse response = opportunityCostService.calculate(5_000, "LIVING");
 


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-103**
- Jira: https://parkjaehong.atlassian.net/browse/NF-103 (있다면)

> PR 제목: `NF-103 기회비용 가격 근접 항목 우선 선택`
> 브랜치: `fix/NF-103-opportunity-cost-price-match`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #232

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- 25,000원대 패션 상품의 기회비용에서 15,000원 기준 유튜브 프리미엄을 포함한 여러 후보가 랜덤으로 반환됐습니다.
- 같은 상품도 화면 진입마다 기회비용 결과가 바뀌어 데모 문구를 보장할 수 없었습니다.

### 왜 발생했나? (Root Cause)
- 가격과 카테고리로 1~15개 환산 후보군을 만든 뒤 후보의 단가 근접도를 고려하지 않고 무작위로 하나를 선택했습니다.

### 어떻게 고쳤나?
- 1개로 환산되는 후보가 있으면 요청 가격과 단가 차이가 가장 작은 항목을 우선 선택합니다.
- 1개 후보가 없을 때는 기존 후보 랜덤 선택과 1~20개 확대·저가/고가 fallback을 유지합니다.
- 15,000원은 유튜브 프리미엄, 제보된 무신사 가격 25,500원은 황금올리브 치킨으로 고정되는 서비스·API 회귀 테스트를 추가했습니다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법
- Steps: `GET /api/v1/wishlist/opportunity-cost?price=25500&category=FASHION` 호출
- 기대 결과: `ITEM_03`, `calculatedCount=1`, 황금올리브 치킨 문구 반환
- 기존 실제 결과: 유튜브 프리미엄을 포함한 5개 후보 중 하나를 랜덤 반환

### 재발 방지
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [ ] 런북/문서 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] AC1: 15,000원 `FASHION` 요청은 유튜브 프리미엄 1달을 반환한다.
- [x] AC2: 25,500원 `FASHION` 요청은 황금올리브 치킨 1마리를 반환한다.
- [x] AC3: 기존 카테고리 제외 규칙과 후보 확대·fallback 동작을 유지한다.

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew test --tests 'com.sagongsa.backend.wishlist.OpportunityCostServiceTest' --tests 'com.sagongsa.backend.wishlist.OpportunityCostApiIntegrationTest' --no-daemon --console=plain`
- Result: BUILD SUCCESSFUL
- Command: `./gradlew test --tests 'com.sagongsa.backend.wishlist.*' --no-daemon --console=plain`
- Result: BUILD SUCCESSFUL, 80 tests, failures 0, errors 0
- Command: `git diff --check`
- Result: 성공

### CI
- 링크/결과: 자동 실행 예정

### Smoke / 수동 검증
- 시나리오: 제보된 무신사 상품 가격 `25,500`, 카테고리 `FASHION` API 요청
- 결과: API 통합 테스트에서 `ITEM_03`, `1개`, 황금올리브 치킨 문구 반환 확인

### 테스트 공백
- QA 배포 후 앱 화면 확인은 머지·배포 범위에 포함하지 않았습니다.

---

## 🧭 영향 범위 (필수)
- [x] API 스펙 변경 없음
- [x] DB 스키마 변경 없음
- [x] 설정/환경변수 변경 없음
- [x] 캐시/큐/외부 연동 영향 없음

---

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음

---

## 🚀 배포/릴리즈
### Feature Flag
- [x] 사용 안함

### 모니터링/알림
- 확인: QA 앱에서 15,000원·25,500원 패션 상품 기회비용 문구
- 에러/로그 키워드: opportunity-cost

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 1개 환산 후보가 여러 개일 때 결과가 랜덤에서 가격 최인접 항목으로 바뀝니다.

### 롤백
- [x] 배포 롤백 가능
- [x] 데이터 롤백 불필요

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직: `OpportunityCostService.selectCandidate`, 15,000원·25,500원 회귀 테스트
- 트레이드오프/대안: 전체 후보 랜덤 정책은 유지하되 1개 환산 후보에만 가격 근접 우선순위를 적용했습니다.
- 성능/보안/호환성 영향: 최대 15개 seed 후보의 메모리 정렬 없는 최소값 탐색으로 성능 영향은 미미하며 API 계약 변경은 없습니다.
