### PR TITLE
[feat] NF-104 동기 쇼핑 가져오기 비동기 큐 내부 연동

### DIFF
--- a/src/main/java/com/sagongsa/backend/config/PublicServerSecurityGuard.java
+++ b/src/main/java/com/sagongsa/backend/config/PublicServerSecurityGuard.java
@@ -72,6 +72,12 @@ public class PublicServerSecurityGuard implements ApplicationRunner {
 	}
 
 	private void validateShoppingImportSettings() {
+		if (shoppingImportProperties.getSyncBridge().isEnabled()
+			&& !shoppingImportProperties.getJobWorker().isEnabled()) {
+			throw new IllegalStateException(
+				"app.shopping.import.job-worker.enabled must be true when sync-bridge is enabled"
+			);
+		}
 		if (!shoppingImportProperties.getBrowserFetch().isEnabled()) {
 			throw new IllegalStateException("app.shopping.import.browser-fetch.enabled must be true for private test prod");
 		}

--- a/src/main/java/com/sagongsa/backend/itemimport/ItemImportController.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/ItemImportController.java
@@ -6,7 +6,6 @@ import com.sagongsa.backend.itemimport.job.ShoppingImportJobResponse;
 import com.sagongsa.backend.itemimport.job.ShoppingImportJobService;
 import com.sagongsa.backend.itemimport.item.ShoppingLinkImportRequest;
 import com.sagongsa.backend.itemimport.item.ShoppingLinkImportResponse;
-import com.sagongsa.backend.itemimport.item.ShoppingLinkImportService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -30,14 +29,14 @@ public class ItemImportController {
 
 	private static final Logger log = LoggerFactory.getLogger(ItemImportController.class);
 
-	private final ShoppingLinkImportService shoppingLinkImportService;
+	private final ShoppingImportSyncService shoppingImportSyncService;
 	private final ShoppingImportJobService shoppingImportJobService;
 
 	public ItemImportController(
-		ShoppingLinkImportService shoppingLinkImportService,
+		ShoppingImportSyncService shoppingImportSyncService,
 		ShoppingImportJobService shoppingImportJobService
 	) {
-		this.shoppingLinkImportService = shoppingLinkImportService;
+		this.shoppingImportSyncService = shoppingImportSyncService;
 		this.shoppingImportJobService = shoppingImportJobService;
 	}
 
@@ -48,11 +47,16 @@ public class ItemImportController {
 		responses = {
 			@ApiResponse(responseCode = "200", description = "Import preview generated"),
 			@ApiResponse(responseCode = "400", description = "Invalid import payload"),
-			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication")
+			@ApiResponse(responseCode = "401", description = "Missing or invalid authentication"),
+			@ApiResponse(responseCode = "429", description = "Import queue is full"),
+			@ApiResponse(responseCode = "504", description = "Import is still processing after the synchronous wait limit")
 		}
 	)
-	public ShoppingLinkImportResponse importLink(@RequestBody ShoppingLinkImportRequest request) {
-		ShoppingLinkImportResponse response = shoppingLinkImportService.importLink(request);
+	public ShoppingLinkImportResponse importLink(
+		@Parameter(hidden = true) @CurrentUserId UUID userId,
+		@RequestBody ShoppingLinkImportRequest request
+	) {
+		ShoppingLinkImportResponse response = shoppingImportSyncService.importLink(userId, request);
 		logImportResult(response);
 		return response;
 	}

--- a/src/main/java/com/sagongsa/backend/itemimport/ShoppingImportSyncService.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/ShoppingImportSyncService.java
@@ -1,0 +1,96 @@
+package com.sagongsa.backend.itemimport;
+
+import com.sagongsa.backend.itemimport.item.ShoppingImportProperties;
+import com.sagongsa.backend.itemimport.item.ShoppingLinkImportRequest;
+import com.sagongsa.backend.itemimport.item.ShoppingLinkImportResponse;
+import com.sagongsa.backend.itemimport.item.ShoppingLinkImportService;
+import com.sagongsa.backend.itemimport.job.ShoppingImportJobError;
+import com.sagongsa.backend.itemimport.job.ShoppingImportJobResponse;
+import com.sagongsa.backend.itemimport.job.ShoppingImportJobService;
+import java.time.Duration;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class ShoppingImportSyncService {
+
+	private final ShoppingLinkImportService shoppingLinkImportService;
+	private final ShoppingImportJobService shoppingImportJobService;
+	private final ShoppingImportProperties properties;
+
+	public ShoppingImportSyncService(
+		ShoppingLinkImportService shoppingLinkImportService,
+		ShoppingImportJobService shoppingImportJobService,
+		ShoppingImportProperties properties
+	) {
+		this.shoppingLinkImportService = shoppingLinkImportService;
+		this.shoppingImportJobService = shoppingImportJobService;
+		this.properties = properties;
+	}
+
+	public ShoppingLinkImportResponse importLink(UUID userId, ShoppingLinkImportRequest request) {
+		ShoppingImportProperties.SyncBridge bridge = properties.getSyncBridge();
+		if (!bridge.isEnabled()) {
+			return shoppingLinkImportService.importLink(request);
+		}
+
+		UUID jobId = shoppingImportJobService.submit(userId, request).jobId();
+		long deadline = deadlineAfter(bridge.getWaitTimeout());
+		while (true) {
+			ShoppingImportJobResponse job = shoppingImportJobService.get(userId, jobId);
+			switch (job.status()) {
+				case SUCCEEDED -> {
+					if (job.result() == null) {
+						throw new IllegalStateException("Succeeded shopping import job has no result");
+					}
+					return job.result();
+				}
+				case FAILED -> throw failedJob(job.error());
+				case PENDING, RUNNING -> waitForNextPoll(deadline, bridge.getPollInterval());
+			}
+		}
+	}
+
+	private long deadlineAfter(Duration timeout) {
+		long timeoutNanos = timeout.toNanos();
+		long now = System.nanoTime();
+		return timeoutNanos >= Long.MAX_VALUE - now ? Long.MAX_VALUE : now + timeoutNanos;
+	}
+
+	private void waitForNextPoll(long deadline, Duration pollInterval) {
+		long remainingNanos = deadline - System.nanoTime();
+		if (remainingNanos <= 0) {
+			throw new ResponseStatusException(
+				HttpStatus.GATEWAY_TIMEOUT,
+				"Shopping import is still processing. Retry the same request."
+			);
+		}
+
+		long sleepNanos = Math.min(remainingNanos, pollInterval.toNanos());
+		try {
+			long millis = sleepNanos / 1_000_000;
+			int nanos = (int) (sleepNanos % 1_000_000);
+			Thread.sleep(millis, nanos);
+		} catch (InterruptedException exception) {
+			Thread.currentThread().interrupt();
+			throw new ResponseStatusException(
+				HttpStatus.SERVICE_UNAVAILABLE,
+				"Shopping import wait was interrupted.",
+				exception
+			);
+		}
+	}
+
+	private ResponseStatusException failedJob(ShoppingImportJobError error) {
+		String code = error == null ? "IMPORT_FAILED" : error.code();
+		String message = error == null ? "쇼핑 링크 정보를 가져오지 못했습니다." : error.message();
+		HttpStatus status = switch (code) {
+			case "INVALID_JOB_PAYLOAD", "INVALID_OR_UNSUPPORTED_ITEM" -> HttpStatus.BAD_REQUEST;
+			case "WORKER_INTERRUPTED" -> HttpStatus.SERVICE_UNAVAILABLE;
+			default -> HttpStatus.BAD_GATEWAY;
+		};
+		return new ResponseStatusException(status, message);
+	}
+}

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportProperties.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportProperties.java
@@ -11,6 +11,7 @@ public class ShoppingImportProperties {
 	private int maxResponseBytes = 1_000_000;
 	private final BrowserFetch browserFetch = new BrowserFetch();
 	private final SharedCrawl sharedCrawl = new SharedCrawl();
+	private final SyncBridge syncBridge = new SyncBridge();
 	private final JobWorker jobWorker = new JobWorker();
 	private final KreamProxy kreamProxy = new KreamProxy();
 	private final AblyApi ablyApi = new AblyApi();
@@ -29,6 +30,10 @@ public class ShoppingImportProperties {
 
 	public SharedCrawl getSharedCrawl() {
 		return sharedCrawl;
+	}
+
+	public SyncBridge getSyncBridge() {
+		return syncBridge;
 	}
 
 	public JobWorker getJobWorker() {
@@ -80,6 +85,41 @@ public class ShoppingImportProperties {
 
 		public void setFailureTtl(Duration failureTtl) {
 			this.failureTtl = positiveOrDefault(failureTtl, Duration.ofSeconds(30));
+		}
+
+		private Duration positiveOrDefault(Duration value, Duration fallback) {
+			return value == null || value.isZero() || value.isNegative() ? fallback : value;
+		}
+	}
+
+	public static class SyncBridge {
+
+		private boolean enabled = true;
+		private Duration waitTimeout = Duration.ofSeconds(25);
+		private Duration pollInterval = Duration.ofMillis(500);
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public Duration getWaitTimeout() {
+			return waitTimeout;
+		}
+
+		public void setWaitTimeout(Duration waitTimeout) {
+			this.waitTimeout = positiveOrDefault(waitTimeout, Duration.ofSeconds(25));
+		}
+
+		public Duration getPollInterval() {
+			return pollInterval;
+		}
+
+		public void setPollInterval(Duration pollInterval) {
+			this.pollInterval = positiveOrDefault(pollInterval, Duration.ofMillis(500));
 		}
 
 		private Duration positiveOrDefault(Duration value, Duration fallback) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,6 +81,10 @@ app:
         cache-enabled: ${SHOPPING_IMPORT_CACHE_ENABLED:true}
         success-ttl: ${SHOPPING_IMPORT_CACHE_SUCCESS_TTL:PT5M}
         failure-ttl: ${SHOPPING_IMPORT_CACHE_FAILURE_TTL:PT30S}
+      sync-bridge:
+        enabled: ${SHOPPING_IMPORT_SYNC_QUEUE_ENABLED:true}
+        wait-timeout: ${SHOPPING_IMPORT_SYNC_WAIT_TIMEOUT:PT25S}
+        poll-interval: ${SHOPPING_IMPORT_SYNC_POLL_INTERVAL:PT0.5S}
       job-worker:
         enabled: ${SHOPPING_IMPORT_JOB_WORKER_ENABLED:true}
         max-queue-size: ${SHOPPING_IMPORT_JOB_MAX_QUEUE_SIZE:100}

--- a/src/test/java/com/sagongsa/backend/config/PublicServerSecurityGuardTest.java
+++ b/src/test/java/com/sagongsa/backend/config/PublicServerSecurityGuardTest.java
@@ -77,6 +77,16 @@ class PublicServerSecurityGuardTest {
 	}
 
 	@Test
+	void rejectsEnabledSyncBridgeWithoutJobWorkerInProd() {
+		ShoppingImportProperties shoppingImportProperties = safeShoppingImportProperties();
+		shoppingImportProperties.getJobWorker().setEnabled(false);
+
+		assertThatThrownBy(() -> guard(safeAuthProperties(), shoppingImportProperties, false).run(null))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("job-worker.enabled");
+	}
+
+	@Test
 	void rejectsOversizedShoppingImportResponseLimitInProd() {
 		ShoppingImportProperties shoppingImportProperties = safeShoppingImportProperties();
 		shoppingImportProperties.setMaxResponseBytes(3_000_001);

--- a/src/test/java/com/sagongsa/backend/itemimport/ItemImportApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/ItemImportApiIntegrationTest.java
@@ -10,8 +10,11 @@ import com.sagongsa.backend.itemimport.item.FetchedPage;
 import com.sagongsa.backend.itemimport.item.PageFetcher;
 import com.sagongsa.backend.support.PostgreSqlContainerTest;
 import java.net.URI;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +24,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest(properties = {
@@ -31,6 +35,7 @@ import org.springframework.test.web.servlet.MockMvc;
 class ItemImportApiIntegrationTest extends PostgreSqlContainerTest {
 
 	private static final String IMPORT_LINK_PATH = "/api/v1/items/import-link";
+	private static final String USER_ID_HEADER = "X-User-Id";
 
 	@Autowired
 	private MockMvc mockMvc;
@@ -38,8 +43,15 @@ class ItemImportApiIntegrationTest extends PostgreSqlContainerTest {
 	@Autowired
 	private FakePageFetcher pageFetcher;
 
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	private UUID userId;
+
 	@BeforeEach
 	void setUp() {
+		jdbcTemplate.execute("truncate table users cascade");
+		userId = createUser();
 		pageFetcher.reset();
 	}
 
@@ -61,6 +73,7 @@ class ItemImportApiIntegrationTest extends PostgreSqlContainerTest {
 		);
 
 		mockMvc.perform(post(IMPORT_LINK_PATH)
+				.header(USER_ID_HEADER, userId)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 				{
@@ -87,6 +100,7 @@ class ItemImportApiIntegrationTest extends PostgreSqlContainerTest {
 	@Test
 	void importsDirectInputWithoutUrlThroughApi() throws Exception {
 		mockMvc.perform(post(IMPORT_LINK_PATH)
+				.header(USER_ID_HEADER, userId)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 				{
@@ -115,6 +129,7 @@ class ItemImportApiIntegrationTest extends PostgreSqlContainerTest {
 	@Test
 	void rejectsShareUrlWithUserInfoThroughApi() throws Exception {
 		mockMvc.perform(post(IMPORT_LINK_PATH)
+				.header(USER_ID_HEADER, userId)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 				{
@@ -130,6 +145,7 @@ class ItemImportApiIntegrationTest extends PostgreSqlContainerTest {
 		pageFetcher.stub("https://shop.example.com/products/missing", 404, "<html></html>");
 
 		mockMvc.perform(post(IMPORT_LINK_PATH)
+				.header(USER_ID_HEADER, userId)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 				{
@@ -138,6 +154,18 @@ class ItemImportApiIntegrationTest extends PostgreSqlContainerTest {
 				}
 				"""))
 			.andExpect(status().isBadGateway());
+	}
+
+	private UUID createUser() {
+		UUID id = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"insert into users (id, status, onboarding_status, created_at, updated_at) values (?, 'ACTIVE', 'COMPLETED', ?, ?)",
+			id,
+			now,
+			now
+		);
+		return id;
 	}
 
 	@TestConfiguration

--- a/src/test/java/com/sagongsa/backend/itemimport/ItemImportControllerTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/ItemImportControllerTest.java
@@ -12,9 +12,9 @@ import com.sagongsa.backend.itemimport.item.ItemSourceMetadataDraft;
 import com.sagongsa.backend.itemimport.item.SavedItemDraft;
 import com.sagongsa.backend.itemimport.item.ShoppingLinkImportRequest;
 import com.sagongsa.backend.itemimport.item.ShoppingLinkImportResponse;
-import com.sagongsa.backend.itemimport.item.ShoppingLinkImportService;
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.system.CapturedOutput;
@@ -25,9 +25,10 @@ class ItemImportControllerTest {
 
 	@Test
 	void logsImportResultWithoutProductDetails(CapturedOutput output) {
-		ShoppingLinkImportService service = mock(ShoppingLinkImportService.class);
+		ShoppingImportSyncService service = mock(ShoppingImportSyncService.class);
 		ShoppingImportJobService jobService = mock(ShoppingImportJobService.class);
 		ItemImportController controller = new ItemImportController(service, jobService);
+		UUID userId = UUID.randomUUID();
 		ShoppingLinkImportRequest request = new ShoppingLinkImportRequest(
 			ItemInputSource.SHARE,
 			"https://ably.airbridge.io/goods/70247267?tracking_content=secret",
@@ -37,9 +38,9 @@ class ItemImportControllerTest {
 			null
 		);
 		ShoppingLinkImportResponse response = response();
-		when(service.importLink(request)).thenReturn(response);
+		when(service.importLink(userId, request)).thenReturn(response);
 
-		assertThat(controller.importLink(request)).isSameAs(response);
+		assertThat(controller.importLink(userId, request)).isSameAs(response);
 
 		assertThat(output)
 			.contains("shopping link import completed retrievalStatus=SUCCESS")

--- a/src/test/java/com/sagongsa/backend/itemimport/ShoppingImportJobApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/ShoppingImportJobApiIntegrationTest.java
@@ -45,6 +45,9 @@ import org.springframework.web.server.ResponseStatusException;
 	"app.notification.reminder-worker.enabled=false",
 	"app.notification.trigger-worker.enabled=false",
 	"app.shopping.import.job-worker.enabled=false",
+	"app.shopping.import.sync-bridge.enabled=true",
+	"app.shopping.import.sync-bridge.wait-timeout=PT3S",
+	"app.shopping.import.sync-bridge.poll-interval=PT0.02S",
 	"app.shopping.import.job-worker.max-queue-size=3",
 	"app.shopping.import.job-worker.max-active-per-user=2",
 	"app.shopping.import.job-worker.max-attempts=2",
@@ -116,6 +119,35 @@ class ShoppingImportJobApiIntegrationTest extends PostgreSqlContainerTest {
 			.andExpect(jsonPath("$.result.item.title").value("Noise Canceling Headphones"))
 			.andExpect(jsonPath("$.result.item.listedPrice").value(129000))
 			.andExpect(jsonPath("$.error").doesNotExist());
+	}
+
+	@Test
+	void keepsSynchronousContractWhileProcessingThroughQueue() throws Exception {
+		UUID userId = createUser();
+		pageFetcher.stub(SHOP_URL, productHtml());
+
+		try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+			Future<org.springframework.test.web.servlet.ResultActions> response = executor.submit(() ->
+				mockMvc.perform(post("/api/v1/items/import-link")
+					.header(USER_ID_HEADER, userId)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(requestJson(SHOP_URL)))
+			);
+
+			awaitPendingJob();
+			assertThat(worker.processNextJob()).isTrue();
+
+			response.get(3, TimeUnit.SECONDS)
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.retrievalStatus").value("SUCCESS"))
+				.andExpect(jsonPath("$.item.title").value("Noise Canceling Headphones"));
+		}
+
+		assertThat(pageFetcher.fetchCount(SHOP_URL)).isEqualTo(1);
+		assertThat(jdbcTemplate.queryForObject(
+			"select count(*) from shopping_import_jobs where status = 'SUCCEEDED'",
+			Integer.class
+		)).isEqualTo(1);
 	}
 
 	@Test
@@ -568,6 +600,21 @@ class ShoppingImportJobApiIntegrationTest extends PostgreSqlContainerTest {
 			now
 		);
 		return userId;
+	}
+
+	private void awaitPendingJob() throws InterruptedException {
+		long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+		while (System.nanoTime() < deadline) {
+			Integer count = jdbcTemplate.queryForObject(
+				"select count(*) from shopping_import_jobs where status = 'PENDING'",
+				Integer.class
+			);
+			if (count != null && count > 0) {
+				return;
+			}
+			Thread.sleep(20);
+		}
+		throw new AssertionError("Synchronous import did not enqueue a job");
 	}
 
 	private String productHtml() {

--- a/src/test/java/com/sagongsa/backend/itemimport/ShoppingImportSyncServiceTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/ShoppingImportSyncServiceTest.java
@@ -1,0 +1,116 @@
+package com.sagongsa.backend.itemimport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.sagongsa.backend.domain.enums.ItemInputSource;
+import com.sagongsa.backend.itemimport.item.ShoppingImportProperties;
+import com.sagongsa.backend.itemimport.item.ShoppingLinkImportRequest;
+import com.sagongsa.backend.itemimport.item.ShoppingLinkImportResponse;
+import com.sagongsa.backend.itemimport.item.ShoppingLinkImportService;
+import com.sagongsa.backend.itemimport.job.ShoppingImportJobAcceptedResponse;
+import com.sagongsa.backend.itemimport.job.ShoppingImportJobError;
+import com.sagongsa.backend.itemimport.job.ShoppingImportJobResponse;
+import com.sagongsa.backend.itemimport.job.ShoppingImportJobService;
+import com.sagongsa.backend.itemimport.job.ShoppingImportJobStatus;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+class ShoppingImportSyncServiceTest {
+
+	private final ShoppingLinkImportService directService = mock(ShoppingLinkImportService.class);
+	private final ShoppingImportJobService jobService = mock(ShoppingImportJobService.class);
+	private final ShoppingImportProperties properties = new ShoppingImportProperties();
+	private final ShoppingImportSyncService service = new ShoppingImportSyncService(directService, jobService, properties);
+	private final UUID userId = UUID.randomUUID();
+	private final UUID jobId = UUID.randomUUID();
+	private final ShoppingLinkImportRequest request = new ShoppingLinkImportRequest(
+		ItemInputSource.SHARE,
+		"https://www.musinsa.com/products/6632593",
+		null,
+		null,
+		null,
+		null
+	);
+
+	@BeforeEach
+	void setUp() {
+		when(jobService.submit(userId, request)).thenReturn(
+			new ShoppingImportJobAcceptedResponse(jobId, ShoppingImportJobStatus.PENDING, OffsetDateTime.now())
+		);
+	}
+
+	@Test
+	void returnsCompletedQueueResultWithOriginalResponseType() {
+		ShoppingLinkImportResponse result = new ShoppingLinkImportResponse("SUCCESS", null, null, null, List.of());
+		when(jobService.get(userId, jobId)).thenReturn(job(ShoppingImportJobStatus.SUCCEEDED, result, null));
+
+		assertThat(service.importLink(userId, request)).isSameAs(result);
+		verify(jobService).submit(userId, request);
+		verifyNoInteractions(directService);
+	}
+
+	@Test
+	void fallsBackToDirectImportWhenBridgeIsDisabled() {
+		properties.getSyncBridge().setEnabled(false);
+		ShoppingLinkImportResponse result = new ShoppingLinkImportResponse("SUCCESS", null, null, null, List.of());
+		when(directService.importLink(request)).thenReturn(result);
+
+		assertThat(service.importLink(userId, request)).isSameAs(result);
+		verifyNoInteractions(jobService);
+	}
+
+	@Test
+	void mapsQueueFailureToSynchronousHttpError() {
+		ShoppingImportJobError error = new ShoppingImportJobError(
+			"SHOPPING_PAGE_UNAVAILABLE",
+			"쇼핑 페이지에 일시적으로 접근할 수 없습니다."
+		);
+		when(jobService.get(userId, jobId)).thenReturn(job(ShoppingImportJobStatus.FAILED, null, error));
+
+		assertThatThrownBy(() -> service.importLink(userId, request))
+			.isInstanceOfSatisfying(ResponseStatusException.class, exception ->
+				assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_GATEWAY)
+			);
+	}
+
+	@Test
+	void timesOutWithoutCancellingQueuedJob() {
+		properties.getSyncBridge().setWaitTimeout(Duration.ofNanos(1));
+		properties.getSyncBridge().setPollInterval(Duration.ofNanos(1));
+		when(jobService.get(userId, jobId)).thenReturn(job(ShoppingImportJobStatus.PENDING, null, null));
+
+		assertThatThrownBy(() -> service.importLink(userId, request))
+			.isInstanceOfSatisfying(ResponseStatusException.class, exception ->
+				assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.GATEWAY_TIMEOUT)
+			);
+		verify(jobService).submit(userId, request);
+	}
+
+	private ShoppingImportJobResponse job(
+		ShoppingImportJobStatus status,
+		ShoppingLinkImportResponse result,
+		ShoppingImportJobError error
+	) {
+		return new ShoppingImportJobResponse(
+			jobId,
+			status,
+			result,
+			error,
+			status == ShoppingImportJobStatus.PENDING ? 0 : 1,
+			OffsetDateTime.now(),
+			null,
+			status == ShoppingImportJobStatus.PENDING ? null : OffsetDateTime.now()
+		);
+	}
+}

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportPropertiesTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportPropertiesTest.java
@@ -43,4 +43,24 @@ class ShoppingImportPropertiesTest {
 		assertThat(sharedCrawl.getSuccessTtl()).isEqualTo(Duration.ofMinutes(5));
 		assertThat(sharedCrawl.getFailureTtl()).isEqualTo(Duration.ofSeconds(30));
 	}
+
+	@Test
+	void enablesSyncBridgeWithBoundedWaitByDefault() {
+		ShoppingImportProperties.SyncBridge syncBridge = new ShoppingImportProperties().getSyncBridge();
+
+		assertThat(syncBridge.isEnabled()).isTrue();
+		assertThat(syncBridge.getWaitTimeout()).isEqualTo(Duration.ofSeconds(25));
+		assertThat(syncBridge.getPollInterval()).isEqualTo(Duration.ofMillis(500));
+	}
+
+	@Test
+	void rejectsNonPositiveSyncBridgeDurations() {
+		ShoppingImportProperties.SyncBridge syncBridge = new ShoppingImportProperties().getSyncBridge();
+
+		syncBridge.setWaitTimeout(Duration.ZERO);
+		syncBridge.setPollInterval(Duration.ofMillis(-1));
+
+		assertThat(syncBridge.getWaitTimeout()).isEqualTo(Duration.ofSeconds(25));
+		assertThat(syncBridge.getPollInterval()).isEqualTo(Duration.ofMillis(500));
+	}
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -43,6 +43,8 @@ app:
       enabled: true
   shopping:
     import:
+      sync-bridge:
+        enabled: false
       job-worker:
         enabled: false
       browser-fetch:


### PR DESCRIPTION
# ✨ Feature PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: `NF-104`
- Jira: https://parkjaehong.atlassian.net/browse/NF-104 (있다면)
- GitHub: Related #234
- GitHub: Closes #234

> PR 제목: `NF-104 동기 쇼핑 가져오기 비동기 큐 내부 연동`
> 브랜치: `feat/NF-104-sync-import-queue`

---

## 🧩 이 PR의 변경사항 (필수)

### 이 PR에서 변경한 것
- 기존 `POST /api/v1/items/import-link`의 요청 URL과 성공 응답 형식을 유지합니다.
- 동기 API가 크롤링 서비스를 직접 호출하지 않고 기존 shopping import job 큐에 작업을 접수합니다.
- 동기 연결은 기본 25초 동안 작업 상태를 확인하고, 완료되면 기존 `ShoppingLinkImportResponse`를 반환합니다.
- 기존 동일 상품 요청 병합, 성공 5분·실패 30초 캐시, 워커 동시성 제한, 큐 제한과 운영 지표를 동기 API에서도 공유합니다.
- 시간 초과 시 작업을 취소하지 않아 같은 요청 재시도에서 진행 중 작업 또는 완료 캐시를 재사용합니다.
- 동기 큐 연동 기능, 대기 제한과 조회 간격을 환경변수로 조정하거나 즉시 비활성화할 수 있습니다.
- 운영 profile에서 동기 큐 연동이 켜진 상태로 job worker가 꺼지는 잘못된 설정을 시작 시 차단합니다.

---

## ✅ 이 PR이 커버하는 AC (필수)

### Covers
- [x] AC1: 기존 동기 API의 요청 URL과 성공 응답 스키마가 유지된다.
- [x] AC2: 동기 API가 작업 큐를 통해 처리되어 동일 링크 병합·캐시·워커 제한을 공유한다.
- [x] AC3: 완료·실패·대기시간 초과를 명확히 처리한다.
- [x] AC4: 비동기 job API 동작은 유지된다.
- [x] AC5: 회귀 테스트가 통과한다.

### Not covered
- 프론트엔드의 비동기 job polling 전환은 포함하지 않습니다.
- QA 배포 및 실제 외부 사이트 smoke test는 머지 후 배포 단계에서 수행합니다.

---

## 🧪 테스트 결과 (필수)

### 로컬
```
./gradlew --no-daemon --console=plain test \
  --tests com.sagongsa.backend.itemimport.ShoppingImportSyncServiceTest \
  --tests com.sagongsa.backend.itemimport.ItemImportControllerTest \
  --tests com.sagongsa.backend.itemimport.item.ShoppingImportPropertiesTest \
  --tests com.sagongsa.backend.config.PublicServerSecurityGuardTest \
  --tests com.sagongsa.backend.itemimport.ItemImportApiIntegrationTest \
  --tests com.sagongsa.backend.itemimport.ShoppingImportJobApiIntegrationTest
```
- ✅ 44개 테스트, 실패 0, 오류 0

```
./gradlew --no-daemon --console=plain test
```
- ✅ 630개 테스트, 실패 0, 오류 0, 기존 skip 9

```
git diff --check
```
- ✅ 성공

### CI
- 자동 실행 예정

### Smoke 테스트
- 시나리오: 동기 API 요청을 별도 스레드에서 유지한 상태로 DB의 PENDING 작업을 확인하고 worker를 실행
- 결과: 큐 작업 완료 후 기존 동기 응답 형식과 HTTP 200 반환, 실제 fetch 1회 및 SUCCEEDED 작업 1건 확인

---

## 🧭 영향 범위 체크 (필수)
- [x] API 변경: 요청 URL·본문·성공 응답 스키마 변경 없음. 큐 포화 429와 25초 초과 504 명시
- [ ] DB 변경
- [x] 설정 변경:
  - `SHOPPING_IMPORT_SYNC_QUEUE_ENABLED` (기본 `true`)
  - `SHOPPING_IMPORT_SYNC_WAIT_TIMEOUT` (기본 `PT25S`)
  - `SHOPPING_IMPORT_SYNC_POLL_INTERVAL` (기본 `PT0.5S`)
- [ ] Breaking change

---

## ⚠️ 리스크 & 롤백

### 리스크
- 동기 요청은 완료 또는 25초 제한까지 HTTP 연결과 요청 스레드를 유지합니다.
- 큐 대기가 25초를 넘으면 프론트에는 504가 반환되지만 서버 작업은 계속됩니다.
- 동기 요청마다 최대 500ms 간격의 작업 상태 DB 조회가 발생합니다.

### 롤백
- `SHOPPING_IMPORT_SYNC_QUEUE_ENABLED=false`로 기존 직접 호출 경로를 즉시 복구할 수 있습니다.
- 커밋 revert로 코드 롤백할 수 있으며 DB 롤백은 필요하지 않습니다.

---

## 💬 리뷰 포인트 (필수)
- 집중해서 볼 파일/라인: `ShoppingImportSyncService`, `ItemImportController.importLink`, `ShoppingImportJobApiIntegrationTest.keepsSynchronousContractWhileProcessingThroughQueue`
- 트레이드오프/대안: 프론트 무수정 조건 때문에 HTTP 연결 유지 비용은 남지만 실제 크롤링 동시성은 기존 worker로 제한합니다.
- 성능/보안/호환성 영향: 캐시·동일 링크 병합으로 외부 요청을 줄이고, 운영에서는 인증 사용자 ID로 사용자별 작업을 분리합니다. 기존 성공 응답 계약은 유지됩니다.