### PR TITLE
[chore] NF-105 쇼핑 가져오기 워커 상한 16개 확장

### DIFF
--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportProperties.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportProperties.java
@@ -203,7 +203,7 @@ public class ShoppingImportProperties {
 		}
 
 		public void setConcurrency(int concurrency) {
-			this.concurrency = concurrency <= 0 ? 1 : Math.min(concurrency, 8);
+			this.concurrency = concurrency <= 0 ? 1 : Math.min(concurrency, 16);
 		}
 
 		public int getMaxAttempts() {

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportPropertiesTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportPropertiesTest.java
@@ -24,6 +24,24 @@ class ShoppingImportPropertiesTest {
 	}
 
 	@Test
+	void allowsTwelveConcurrentWorkers() {
+		ShoppingImportProperties properties = new ShoppingImportProperties();
+
+		properties.getJobWorker().setConcurrency(12);
+
+		assertThat(properties.getJobWorker().getConcurrency()).isEqualTo(12);
+	}
+
+	@Test
+	void limitsConcurrentWorkersToSixteen() {
+		ShoppingImportProperties properties = new ShoppingImportProperties();
+
+		properties.getJobWorker().setConcurrency(17);
+
+		assertThat(properties.getJobWorker().getConcurrency()).isEqualTo(16);
+	}
+
+	@Test
 	void enablesSharedCrawlWithShortCacheTtlsByDefault() {
 		ShoppingImportProperties.SharedCrawl sharedCrawl = new ShoppingImportProperties().getSharedCrawl();
 


### PR DESCRIPTION
# 🧰 Chore PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-105**
- Jira: https://parkjaehong.atlassian.net/browse/NF-105 (있다면)

> PR 제목: `NF-105 쇼핑 가져오기 워커 상한 16개 확장`  
> 브랜치: `chore/NF-105-shopping-import-worker-limit`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #236

---

## 🧩 한눈에 요약 (필수)
### 무엇을 변경했나? (인프라/빌드/CI/의존성 등)
- [x] 인프라
- [x] 설정파일
- [ ] 빌드 파일
- [ ] CI
- [ ] 의존성
- [x] 런타임/비즈니스 로직 리팩터링 없음

### 왜 필요한가? (안정성/속도/보안/개발경험)
- 증설 예정 QA 서버에서 `SHOPPING_IMPORT_JOB_CONCURRENCY=12`를 실제로 적용할 수 있도록 기존 8개 상한을 16개로 확장합니다.
- PR #235 이후 기존 동기 API도 동일한 작업 큐를 사용하므로 이 설정이 동기 프론트 요청의 실제 크롤링 병렬도를 제한합니다.

### 범위(스코프)
- Included: 워커 상한 16개 확장, 12개 허용 및 16개 제한 테스트
- Not included: 저장소 기본 워커 수 변경, 서버 사양 변경, 부하 테스트

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew --no-daemon --console=plain test --tests com.sagongsa.backend.itemimport.item.ShoppingImportPropertiesTest`
- Result: 성공
- Command: `git diff --check`
- Result: 성공

### CI
- 링크/결과: 자동 실행 예정

### Smoke / 수동 검증 (해당 시)
- 시나리오: 배포 후 QA 환경변수 12, 서비스 health, 실제 JVM 설정 확인
- 결과: 머지·배포 후 확인 예정

### 테스트 공백(있다면 이유 필수)
- 실제 12개 동시 크롤링 부하 테스트는 이번 설정 배포 범위에 포함하지 않습니다.

---

## 🧭 영향 범위 (필수)
- [ ] 설정/환경변수 변경 없음
- [x] 설정/환경변수 변경 있음 (항목: `SHOPPING_IMPORT_JOB_CONCURRENCY=12`)
- [x] CI/빌드 파이프라인 영향 없음
- [ ] CI/빌드 파이프라인 영향 있음
- [x] 의존성 변경 없음
- [ ] 의존성 변경 있음

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 서버 사양에 비해 워커 수가 크면 CPU·메모리 경합과 외부 사이트 차단 위험이 커질 수 있습니다.
- 동기 API는 25초 대기 제한이 있어 큐 처리량이 증가해도 외부 응답이 느리면 504 가능성은 남습니다.

### 롤백
- [x] 단순 revert로 가능
- [ ] 버전 pin/되돌리기 필요
- [x] 배포 롤백 가능
- QA 환경변수를 기존 값 3으로 되돌린 뒤 서비스를 재시작할 수 있습니다.

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/설정: `ShoppingImportProperties.JobWorker#setConcurrency`, `ShoppingImportPropertiesTest`
- 트레이드오프/대안: 저장소 기본값은 1로 유지하고, 증설 대상 QA에서만 12를 명시합니다.
- 성능/보안/호환성 영향: API 계약 변경 없음. 동기·비동기 요청 모두 같은 큐의 최대 병렬 처리량만 증가합니다.
