### PR TITLE
[chore] NF-106 QA 배포 파일 자동 정리 및 JVM 힙 확장

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -152,6 +152,35 @@ jobs:
             return 1
           }
 
+          prune_deploy_artifacts() {
+            mapfile -t jar_backups < <(
+              find "$APP_DIR/build/libs" -maxdepth 1 -type f \
+                -name "$JAR_NAME.bak.*" -printf '%T@ %p\n' \
+                | sort -nr \
+                | cut -d' ' -f2-
+            )
+            if ((${#jar_backups[@]} > 2)); then
+              printf 'removing old jar backup: %s\n' "${jar_backups[@]:2}"
+              rm -- "${jar_backups[@]:2}"
+            fi
+
+            find "$APP_DIR/build/libs" -maxdepth 1 -type f \
+              \( -name "$JAR_NAME.candidate-*" -o -name "$JAR_NAME.pre-worker12-test.*" \) \
+              -print -delete
+
+            if [ -d "$APP_DIR/releases" ]; then
+              mapfile -t manual_releases < <(
+                find "$APP_DIR/releases" -maxdepth 1 -type f -name '*.jar' -printf '%T@ %p\n' \
+                  | sort -nr \
+                  | cut -d' ' -f2-
+              )
+              if ((${#manual_releases[@]} > 1)); then
+                printf 'removing old manual release: %s\n' "${manual_releases[@]:1}"
+                rm -- "${manual_releases[@]:1}"
+              fi
+            fi
+          }
+
           fail_preflight() {
             echo "::error::$1"
             exit 1
@@ -415,6 +444,8 @@ jobs:
           echo "8080 main metrics OK"
           curl -skfsS "https://$CADDY_SITE/health"
           echo
+          prune_deploy_artifacts
+          df -h /
           free -h
           echo "deploy finished"
           REMOTE_DEPLOY


### PR DESCRIPTION
# 🧰 Chore PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-106**
- Jira: https://parkjaehong.atlassian.net/browse/NF-106 (있다면)

> PR 제목: `NF-106 QA 배포 파일 자동 정리 및 JVM 힙 확장`  
> 브랜치: `chore/NF-106-qa-artifact-retention`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #238

---

## 🧩 한눈에 요약 (필수)
### 무엇을 변경했나? (인프라/빌드/CI/의존성 등)
- [x] 인프라
- [x] 설정파일
- [ ] 빌드 파일
- [x] CI
- [ ] 의존성
- [x] 런타임/비즈니스 로직 리팩터링 없음

### 왜 필요한가? (안정성/속도/보안/개발경험)
- QA 배포 시 약 340MB JAR 백업이 무제한 누적되어 20GB 디스크 사용률이 86%까지 증가했습니다.
- 쇼핑 가져오기 워커 12개 운영에 비해 메인 JVM 최대 힙이 512MB로 제한되어 있었습니다.

### 범위(스코프)
- Included: 성공 배포 후 최신 JAR 백업 2개 보존, candidate·수동 테스트 JAR 정리, releases 최신 1개 보존
- 운영 반영: 오래된 JAR 정리, JVM `-Xms512m -Xmx2g` 적용
- Not included: Playwright 캐시·Gradle 캐시·swap 삭제, 부하 테스트

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: 임시 디렉터리에 백업 3개, candidate, 수동 테스트 JAR, release 2개를 생성해 보존 함수와 같은 명령 실행
- Result: 백업 2개, release 1개만 남고 candidate·수동 테스트 JAR은 0개인 것 확인
- Command: `git diff --check`
- Result: 성공

### CI
- 링크/결과: 자동 실행 예정

### Smoke / 수동 검증 (해당 시)
- 시나리오: QA 오래된 JAR 삭제 후 JVM drop-in 적용 및 서비스 재시작
- 결과: 디스크 86% → 46%, 약 7.85GB 확보, 내부 health UP, 워커 12 유지, 실제 JVM 인자 `-Xms512m -Xmx2g` 확인

### 테스트 공백(있다면 이유 필수)
- 부하 테스트는 운영 설정·정리 작업 범위에 포함하지 않습니다.

---

## 🧭 영향 범위 (필수)
- [ ] 설정/환경변수 변경 없음
- [x] 설정/환경변수 변경 있음 (메인 JVM `-Xms512m -Xmx2g`)
- [ ] CI/빌드 파이프라인 영향 없음
- [x] CI/빌드 파이프라인 영향 있음 (배포 완료 후 artifact retention)
- [x] 의존성 변경 없음
- [ ] 의존성 변경 있음

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 롤백 가능한 JAR은 최신 2개로 제한됩니다.
- 파일 보존 패턴을 잘못 지정하면 필요한 파일이 삭제될 수 있어 활성 JAR은 삭제 대상에서 제외했습니다.

### 롤백
- [x] 단순 revert로 가능
- [ ] 버전 pin/되돌리기 필요
- [x] 배포 롤백 가능
- JVM drop-in 제거 후 daemon-reload와 서비스 재시작으로 기존 512MB 설정으로 복구할 수 있습니다.

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/설정: `.github/workflows/deploy-qa.yml`의 `prune_deploy_artifacts`
- 트레이드오프/대안: 디스크 무제한 증설 대신 즉시 롤백 가능한 최신 백업 2개만 유지합니다.
- 성능/보안/호환성 영향: API 영향 없음. 정리 함수는 모든 최종 health 검증 성공 후에만 실행됩니다.
