### PR TITLE
[chore] NF-107 쇼핑 가져오기 워커 상한 24개 확장

### DIFF
--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportProperties.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportProperties.java
@@ -203,7 +203,7 @@ public class ShoppingImportProperties {
 		}
 
 		public void setConcurrency(int concurrency) {
-			this.concurrency = concurrency <= 0 ? 1 : Math.min(concurrency, 16);
+			this.concurrency = concurrency <= 0 ? 1 : Math.min(concurrency, 24);
 		}
 
 		public int getMaxAttempts() {

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportPropertiesTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportPropertiesTest.java
@@ -24,21 +24,21 @@ class ShoppingImportPropertiesTest {
 	}
 
 	@Test
-	void allowsTwelveConcurrentWorkers() {
+	void allowsTwentyFourConcurrentWorkers() {
 		ShoppingImportProperties properties = new ShoppingImportProperties();
 
-		properties.getJobWorker().setConcurrency(12);
+		properties.getJobWorker().setConcurrency(24);
 
-		assertThat(properties.getJobWorker().getConcurrency()).isEqualTo(12);
+		assertThat(properties.getJobWorker().getConcurrency()).isEqualTo(24);
 	}
 
 	@Test
-	void limitsConcurrentWorkersToSixteen() {
+	void limitsConcurrentWorkersToTwentyFour() {
 		ShoppingImportProperties properties = new ShoppingImportProperties();
 
-		properties.getJobWorker().setConcurrency(17);
+		properties.getJobWorker().setConcurrency(25);
 
-		assertThat(properties.getJobWorker().getConcurrency()).isEqualTo(16);
+		assertThat(properties.getJobWorker().getConcurrency()).isEqualTo(24);
 	}
 
 	@Test


### PR DESCRIPTION
# 🧰 Chore PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-107**
- Jira: https://parkjaehong.atlassian.net/browse/NF-107 (있다면)

> PR 제목: `NF-107 쇼핑 가져오기 워커 상한 24개 확장`  
> 브랜치: `chore/NF-107-shopping-import-worker-24`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #240

---

## 🧩 한눈에 요약 (필수)
### 무엇을 변경했나? (인프라/빌드/CI/의존성 등)
- [x] 인프라
- [x] 설정파일
- [ ] 빌드 파일
- [ ] CI
- [ ] 의존성
- [x] 런타임/비즈니스 로직 리팩터링 없음

### 왜 필요한가? (안정성/속도/보안/개발경험)
- 최신 프론트의 비동기 쇼핑 가져오기는 90초 동안 작업 상태를 조회합니다.
- QA 워커 12개 실측을 100명 피크로 환산하면 약 131초가 예상되어 90초 범위를 초과합니다.
- QA에서 워커 24개 후보를 검증할 수 있도록 기존 코드 상한 16개를 24개로 확장합니다.

### 범위(스코프)
- Included: 워커 상한 24개 확장, 24개 허용 및 24개 초과 제한 테스트
- Not included: 저장소 기본 워커 수 변경, API 계약 변경, 운영 서버 설정 변경

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew --no-daemon --console=plain test --tests com.sagongsa.backend.itemimport.item.ShoppingImportPropertiesTest`
- Result: 성공
- Command: `git diff --check`
- Result: 성공

### CI
- 링크/결과: 자동 실행 예정

### Smoke / 수동 검증 (해당 시)
- 시나리오: QA 후보 배포 후 워커 24 런타임 확인 및 100명 동시 요청
- 결과: 테스트 완료 후 PR에 추가 예정

### 테스트 공백(있다면 이유 필수)
- 외부 쇼핑몰 응답과 차단은 코드 단위 테스트로 재현하지 않습니다.

---

## 🧭 영향 범위 (필수)
- [ ] 설정/환경변수 변경 없음
- [x] 설정/환경변수 변경 있음 (항목: QA 후보 `SHOPPING_IMPORT_JOB_CONCURRENCY=24`)
- [x] CI/빌드 파이프라인 영향 없음
- [ ] CI/빌드 파이프라인 영향 있음
- [x] 의존성(dependency) 변경 없음
- [ ] 의존성(dependency) 변경 있음

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 워커 증가로 Chromium 동시 실행, CPU 사용량과 외부 사이트 차단 가능성이 증가할 수 있습니다.
- 큐 처리량은 외부 사이트 지연과 사이트별 제한에 따라 선형으로 증가하지 않을 수 있습니다.

### 롤백
- [x] 단순 revert로 가능
- [ ] 버전 pin/되돌리기 필요
- [x] 배포 롤백 가능
- QA 런타임 환경변수를 기존 12로 되돌리고 이전 아티팩트를 재기동할 수 있습니다.

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/설정: `ShoppingImportProperties.JobWorker#setConcurrency`, `ShoppingImportPropertiesTest`
- 트레이드오프/대안: 기본값은 1로 유지하며 QA 후보에서만 24를 지정합니다.
- 성능/보안/호환성 영향: API 계약 변경 없음. 동기·비동기 요청이 공유하는 큐의 최대 병렬 처리량만 확장합니다.
