### PR TITLE
[fix] NF-108 쇼핑 가져오기 빈 큐 폴링 최적화

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ QA/운영 서버에서 활성화하려면 Firebase 서비스 계정 JSON을 레�
 | `SHOPPING_IMPORT_JOB_MAX_ACTIVE_PER_USER` | `3` | 사용자별 활성 작업 상한입니다. |
 | `SHOPPING_IMPORT_JOB_MAX_ATTEMPTS` | `2` | 중단된 작업의 최대 claim 횟수입니다. |
 | `SHOPPING_IMPORT_JOB_FIXED_DELAY_MS` | `500` | worker의 다음 작업 확인 간격입니다. |
+| `SHOPPING_IMPORT_JOB_RECOVERY_DELAY_MS` | `60000` | 중단된 `RUNNING` 작업의 복구 확인 주기입니다. |
 | `SHOPPING_IMPORT_JOB_CLEANUP_DELAY_MS` | `3600000` | 완료 작업 정리 주기입니다. |
 | `SHOPPING_IMPORT_JOB_STALE_TIMEOUT` | `PT5M` | 이 시간을 넘긴 `RUNNING` 작업을 중단된 작업으로 판단합니다. |
 | `SHOPPING_IMPORT_JOB_RETENTION` | `P7D` | 완료/실패 작업 결과 보관기간입니다. |

--- a/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportProperties.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/item/ShoppingImportProperties.java
@@ -170,6 +170,7 @@ public class ShoppingImportProperties {
 		private int concurrency = 1;
 		private int maxAttempts = 2;
 		private long fixedDelayMs = 500;
+		private long recoveryDelayMs = 60_000;
 		private long cleanupDelayMs = 3_600_000;
 		private Duration staleTimeout = Duration.ofMinutes(5);
 		private Duration retention = Duration.ofDays(7);
@@ -220,6 +221,14 @@ public class ShoppingImportProperties {
 
 		public void setFixedDelayMs(long fixedDelayMs) {
 			this.fixedDelayMs = fixedDelayMs <= 0 ? 500 : fixedDelayMs;
+		}
+
+		public long getRecoveryDelayMs() {
+			return recoveryDelayMs;
+		}
+
+		public void setRecoveryDelayMs(long recoveryDelayMs) {
+			this.recoveryDelayMs = recoveryDelayMs <= 0 ? 60_000 : recoveryDelayMs;
 		}
 
 		public long getCleanupDelayMs() {

--- a/src/main/java/com/sagongsa/backend/itemimport/job/ShoppingImportJobScheduler.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/job/ShoppingImportJobScheduler.java
@@ -36,10 +36,22 @@ class ShoppingImportJobScheduler {
 		scheduler = "shoppingImportTaskScheduler"
 	)
 	void processNextJob() {
+		if (!worker.hasClaimableJob()) {
+			return;
+		}
+
 		CompletableFuture<?>[] workers = IntStream.range(0, properties.getJobWorker().getConcurrency())
 			.mapToObj(ignored -> CompletableFuture.runAsync(worker::processNextJob, workerExecutor))
 			.toArray(CompletableFuture[]::new);
 		CompletableFuture.allOf(workers).join();
+	}
+
+	@Scheduled(
+		fixedDelayString = "${app.shopping.import.job-worker.recovery-delay-ms:60000}",
+		scheduler = "shoppingImportTaskScheduler"
+	)
+	void recoverStaleJobs() {
+		worker.recoverStaleJobs();
 	}
 
 	@Scheduled(

--- a/src/main/java/com/sagongsa/backend/itemimport/job/ShoppingImportJobWorker.java
+++ b/src/main/java/com/sagongsa/backend/itemimport/job/ShoppingImportJobWorker.java
@@ -48,7 +48,6 @@ public class ShoppingImportJobWorker {
 	}
 
 	public boolean processNextJob() {
-		recoverStaleJobs();
 		ClaimedJob job = transactionTemplate.execute(status -> claimNextJob());
 		if (job == null) {
 			return false;
@@ -82,6 +81,23 @@ public class ShoppingImportJobWorker {
 			);
 		}
 		return true;
+	}
+
+	public boolean hasClaimableJob() {
+		Boolean claimable = jdbcTemplate.queryForObject(
+			"""
+			select exists (
+				select 1
+				from shopping_import_jobs
+				where leader_job_id is null
+				  and status = 'PENDING'
+				  and attempt_count < ?
+			)
+			""",
+			Boolean.class,
+			properties.getJobWorker().getMaxAttempts()
+		);
+		return Boolean.TRUE.equals(claimable);
 	}
 
 	public int cleanupExpiredJobs() {
@@ -159,11 +175,12 @@ public class ShoppingImportJobWorker {
 		return job;
 	}
 
-	private void recoverStaleJobs() {
+	public int recoverStaleJobs() {
 		Integer recovered = transactionTemplate.execute(status -> recoverStaleJobsInTransaction());
 		if (recovered != null && recovered > 0) {
 			log.warn("recovered stale shopping import jobs count={}", recovered);
 		}
+		return recovered == null ? 0 : recovered;
 	}
 
 	private int recoverStaleJobsInTransaction() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -92,6 +92,7 @@ app:
         concurrency: ${SHOPPING_IMPORT_JOB_CONCURRENCY:1}
         max-attempts: ${SHOPPING_IMPORT_JOB_MAX_ATTEMPTS:2}
         fixed-delay-ms: ${SHOPPING_IMPORT_JOB_FIXED_DELAY_MS:500}
+        recovery-delay-ms: ${SHOPPING_IMPORT_JOB_RECOVERY_DELAY_MS:60000}
         cleanup-delay-ms: ${SHOPPING_IMPORT_JOB_CLEANUP_DELAY_MS:3600000}
         stale-timeout: ${SHOPPING_IMPORT_JOB_STALE_TIMEOUT:PT5M}
         retention: ${SHOPPING_IMPORT_JOB_RETENTION:P7D}

--- a/src/test/java/com/sagongsa/backend/itemimport/ShoppingImportJobApiIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/ShoppingImportJobApiIntegrationTest.java
@@ -248,6 +248,21 @@ class ShoppingImportJobApiIntegrationTest extends PostgreSqlContainerTest {
 	}
 
 	@Test
+	void reportsOnlyPendingLeaderAsClaimable() throws Exception {
+		assertThat(worker.hasClaimableJob()).isFalse();
+		UUID jobId = submittedJobId(createUser(), SHOP_URL, "PENDING");
+
+		assertThat(worker.hasClaimableJob()).isTrue();
+
+		jdbcTemplate.update(
+			"update shopping_import_jobs set status = 'RUNNING', started_at = now(), updated_at = now() where id = ?",
+			jobId
+		);
+
+		assertThat(worker.hasClaimableJob()).isFalse();
+	}
+
+	@Test
 	void reusesActiveJobForDuplicateRequest() throws Exception {
 		UUID userId = createUser();
 
@@ -456,6 +471,7 @@ class ShoppingImportJobApiIntegrationTest extends PostgreSqlContainerTest {
 			old
 		);
 
+		assertThat(worker.recoverStaleJobs()).isEqualTo(1);
 		assertThat(worker.processNextJob()).isTrue();
 
 		mockMvc.perform(get(JOBS_PATH + "/" + jobId).header(USER_ID_HEADER, userId))
@@ -469,6 +485,7 @@ class ShoppingImportJobApiIntegrationTest extends PostgreSqlContainerTest {
 		UUID userId = createUser();
 		UUID jobId = insertStaleRunningJob(userId, 2, "1".repeat(64));
 
+		assertThat(worker.recoverStaleJobs()).isEqualTo(1);
 		assertThat(worker.processNextJob()).isFalse();
 
 		mockMvc.perform(get(JOBS_PATH + "/" + jobId).header(USER_ID_HEADER, userId))
@@ -491,6 +508,7 @@ class ShoppingImportJobApiIntegrationTest extends PostgreSqlContainerTest {
 			old
 		);
 
+		assertThat(worker.recoverStaleJobs()).isEqualTo(1);
 		assertThat(worker.processNextJob()).isFalse();
 
 		for (Map.Entry<UUID, UUID> job : Map.of(

--- a/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportPropertiesTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/item/ShoppingImportPropertiesTest.java
@@ -42,6 +42,17 @@ class ShoppingImportPropertiesTest {
 	}
 
 	@Test
+	void usesOneMinuteStaleRecoveryIntervalByDefault() {
+		ShoppingImportProperties.JobWorker jobWorker = new ShoppingImportProperties().getJobWorker();
+
+		assertThat(jobWorker.getRecoveryDelayMs()).isEqualTo(60_000);
+
+		jobWorker.setRecoveryDelayMs(0);
+
+		assertThat(jobWorker.getRecoveryDelayMs()).isEqualTo(60_000);
+	}
+
+	@Test
 	void enablesSharedCrawlWithShortCacheTtlsByDefault() {
 		ShoppingImportProperties.SharedCrawl sharedCrawl = new ShoppingImportProperties().getSharedCrawl();
 

--- a/src/test/java/com/sagongsa/backend/itemimport/job/ShoppingImportJobSchedulerTest.java
+++ b/src/test/java/com/sagongsa/backend/itemimport/job/ShoppingImportJobSchedulerTest.java
@@ -2,6 +2,7 @@ package com.sagongsa.backend.itemimport.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -23,6 +24,7 @@ class ShoppingImportJobSchedulerTest {
 		properties.getJobWorker().setConcurrency(2);
 		CountDownLatch started = new CountDownLatch(2);
 		CountDownLatch release = new CountDownLatch(1);
+		when(worker.hasClaimableJob()).thenReturn(true);
 		when(worker.processNextJob()).thenAnswer(invocation -> {
 			started.countDown();
 			assertThat(release.await(2, TimeUnit.SECONDS)).isTrue();
@@ -46,5 +48,44 @@ class ShoppingImportJobSchedulerTest {
 		}
 
 		verify(worker, times(2)).processNextJob();
+	}
+
+	@Test
+	void skipsWorkerFanOutWhenQueueHasNoClaimableJob() {
+		ShoppingImportJobWorker worker = mock(ShoppingImportJobWorker.class);
+		ShoppingImportProperties properties = new ShoppingImportProperties();
+		ExecutorService workerExecutor = Executors.newSingleThreadExecutor();
+		when(worker.hasClaimableJob()).thenReturn(false);
+
+		try (workerExecutor) {
+			ShoppingImportJobScheduler scheduler = new ShoppingImportJobScheduler(
+				worker,
+				properties,
+				workerExecutor
+			);
+
+			scheduler.processNextJob();
+		}
+
+		verify(worker).hasClaimableJob();
+		verify(worker, never()).processNextJob();
+	}
+
+	@Test
+	void recoversStaleJobsOnIndependentSchedule() {
+		ShoppingImportJobWorker worker = mock(ShoppingImportJobWorker.class);
+		ShoppingImportProperties properties = new ShoppingImportProperties();
+
+		try (ExecutorService workerExecutor = Executors.newSingleThreadExecutor()) {
+			ShoppingImportJobScheduler scheduler = new ShoppingImportJobScheduler(
+				worker,
+				properties,
+				workerExecutor
+			);
+
+			scheduler.recoverStaleJobs();
+		}
+
+		verify(worker).recoverStaleJobs();
 	}
 }


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-108**
- Jira: 없음

> PR 제목: `NF-108 쇼핑 가져오기 빈 큐 폴링 최적화`  
> 브랜치: `fix/NF-108-shopping-import-idle-polling`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #242

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- 쇼핑 가져오기 큐가 비어 있어도 500ms마다 설정된 동시성만큼 워커를 fan-out했습니다.
- QA 동시성 24 환경에서 빈 `shopping_import_jobs` 테이블에 약 90~95회의 순차 스캔/초가 지속됐습니다.

### 왜 발생했나? (Root Cause)
- 스케줄러가 대기 작업 존재 여부를 확인하지 않고 매 주기 모든 워커를 실행했습니다.
- 각 워커가 작업 선점 전에 stale 복구 쿼리까지 실행해, 한 주기에 동시성 × 2개의 빈 테이블 조회가 발생했습니다.

### 어떻게 고쳤나?
- 스케줄러가 claim 가능한 `PENDING` 리더 작업 존재 여부를 한 번 확인하고, 없으면 worker fan-out을 생략합니다.
- stale 복구를 개별 워커 경로에서 제거하고 기본 60초 주기의 독립 스케줄로 분리합니다.
- 실제 작업이 있을 때의 기존 `FOR UPDATE SKIP LOCKED` 병렬 선점 로직은 유지합니다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법(가능하면)
- Steps:
  1. 쇼핑 가져오기 워커 동시성을 24로 설정합니다.
  2. `shopping_import_jobs`를 빈 상태로 둡니다.
  3. PostgreSQL `pg_stat_user_tables`의 `seq_scan` 변화를 관찰합니다.
- 기대 결과: 빈 큐에서는 고정 주기당 존재 여부 조회 1회만 수행합니다.
- 실제 결과(수정 전): 30초 `seq_scan +2,789`(약 92.9회/초), 별도 10초 표본 `+901`, 읽은 행 `+0`.

### 재발 방지(있다면)
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [x] 런북/문서 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] AC1: claim 가능한 작업이 없으면 worker fan-out을 수행하지 않는다.
- [x] AC2: stale 작업 복구를 개별 worker 실행과 분리해 한 번만 주기 실행한다.
- [x] AC3: 기존 동시 선점, stale 재시도/실패 전파, 쇼핑 가져오기 API 통합 테스트가 통과한다.

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew test --tests 'com.sagongsa.backend.itemimport.job.ShoppingImportJobSchedulerTest' --tests 'com.sagongsa.backend.itemimport.item.ShoppingImportPropertiesTest'`
- Result: BUILD SUCCESSFUL
- Command: `./gradlew test --tests 'com.sagongsa.backend.itemimport.ShoppingImportJobApiIntegrationTest'`
- Result: BUILD SUCCESSFUL
- Command: `./gradlew test && ./gradlew jacocoTestReport`
- Result: BUILD SUCCESSFUL

### CI
- 링크/결과: PR 생성 후 자동 실행

### Smoke / 수동 검증
- 시나리오: 빈 큐에서 스케줄러가 worker를 호출하지 않는지 단위 테스트, PostgreSQL에서 claim 가능 조건과 stale 복구/재시도를 통합 테스트
- 결과: 통과

### 테스트 공백(있다면 이유 필수)
- QA 배포 전이므로 수정 후 실제 `seq_scan` 전/후 비교는 배포 후 확인이 필요합니다. 코드 경로상 빈 큐 조회는 약 96회/초에서 약 2회/초로 약 98% 감소할 것으로 예상합니다.

---

## 🧭 영향 범위 (필수)
- [x] API 스펙 변경 없음
- [ ] API 스펙 변경 있음 (요약: )
- [x] DB 스키마 변경 없음
- [ ] DB 스키마 변경 있음 (마이그레이션/락/시간: )
- [ ] 설정/환경변수 변경 없음
- [x] 설정/환경변수 변경 있음 (항목: 선택 환경변수 `SHOPPING_IMPORT_JOB_RECOVERY_DELAY_MS`, 기본 60000ms)
- [ ] 캐시/큐/외부 연동 영향 없음
- [x] 캐시/큐/외부 연동 영향 있음 (요약: 빈 큐 polling과 stale 작업 복구 주기 변경)

---

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음
- [ ] Breaking change 있음 → 무엇이 깨지는지 / 마이그레이션 / 롤아웃 전략:

---

## 🚀 배포/릴리즈 (해당 시 필수)
### Feature Flag
- [x] 사용 안함
- [ ] 사용함 → Flag/기본값/롤아웃:

### 모니터링/알림
- 확인할 대시보드/지표: `shopping_import_jobs`의 `seq_scan`, DB 커밋 수, 큐 대기 작업 수, worker 성공/실패 로그
- 에러/로그 키워드: `recovered stale shopping import jobs`, `shopping import job failed`

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- stale 작업은 기존처럼 500ms마다 확인하지 않고 기본 60초마다 확인하므로, stale timeout 도달 후 실제 복구가 최대 약 60초 늦어질 수 있습니다.
- 작업 등록 직후 빈 큐 확인과 경합하면 다음 500ms polling 주기에 처리될 수 있으며 기존 polling 간격 범위 안입니다.

### 롤백
- [x] 플래그/설정으로 우회 가능 (`SHOPPING_IMPORT_JOB_RECOVERY_DELAY_MS`로 복구 주기 조정)
- [x] 배포 롤백(이전 태그/이미지) 가능
- [ ] 데이터 롤백/역마이그레이션 필요 (절차: )

---

## 📸 증빙 (선택)
- 스크린샷/로그/메트릭 링크: GitHub Issue #242의 수정 전 실측값 참고
- 전/후 비교(가능하면): 수정 전 약 92.9 seq scan/초 → 수정 후 예상 약 2 seq scan/초

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직: `ShoppingImportJobScheduler#processNextJob`, `ShoppingImportJobWorker#hasClaimableJob`, `ShoppingImportJobWorker#recoverStaleJobs`
- 트레이드오프/대안: 빈 큐 지수 backoff나 batch claim 대신, 동작 변경이 작은 단일 idle gate와 stale 복구 분리를 선택했습니다.
- 성능/보안/호환성 영향: 빈 큐 DB 조회 약 98% 감소 예상, 보안·API·DB 스키마 호환성 영향 없음
