### PR TITLE
[fix] NF-109 마이페이지 게시글·투표 목록 N+1 쿼리 최적화

### DIFF
--- a/src/main/java/com/sagongsa/backend/domain/social/PostVoteRepository.java
+++ b/src/main/java/com/sagongsa/backend/domain/social/PostVoteRepository.java
@@ -18,10 +18,33 @@ public interface PostVoteRepository extends JpaRepository<PostVote, UUID> {
 	@Query("SELECT v FROM PostVote v WHERE v.post.id IN :postIds AND v.user.id = :userId")
 	List<PostVote> findByPostIdsAndUserId(@Param("postIds") List<UUID> postIds, @Param("userId") UUID userId);
 
-	@Query("SELECT v FROM PostVote v WHERE v.user.id = :userId AND v.canceledAt IS NULL AND v.post.deletedAt IS NULL AND v.post.moderationStatus = com.sagongsa.backend.domain.enums.ModerationStatus.ACTIVE ORDER BY v.createdAt DESC")
+	@Query("""
+		SELECT v
+		FROM PostVote v
+		JOIN FETCH v.post p
+		JOIN FETCH p.user
+		LEFT JOIN FETCH p.item
+		WHERE v.user.id = :userId
+		  AND v.canceledAt IS NULL
+		  AND p.deletedAt IS NULL
+		  AND p.moderationStatus = com.sagongsa.backend.domain.enums.ModerationStatus.ACTIVE
+		ORDER BY v.createdAt DESC
+		""")
 	List<PostVote> findActiveByUserId(@Param("userId") UUID userId, Pageable pageable);
 
-	@Query("SELECT v FROM PostVote v WHERE v.user.id = :userId AND v.canceledAt IS NULL AND v.post.deletedAt IS NULL AND v.post.moderationStatus = com.sagongsa.backend.domain.enums.ModerationStatus.ACTIVE AND v.createdAt < :cursor ORDER BY v.createdAt DESC")
+	@Query("""
+		SELECT v
+		FROM PostVote v
+		JOIN FETCH v.post p
+		JOIN FETCH p.user
+		LEFT JOIN FETCH p.item
+		WHERE v.user.id = :userId
+		  AND v.canceledAt IS NULL
+		  AND p.deletedAt IS NULL
+		  AND p.moderationStatus = com.sagongsa.backend.domain.enums.ModerationStatus.ACTIVE
+		  AND v.createdAt < :cursor
+		ORDER BY v.createdAt DESC
+		""")
 	List<PostVote> findActiveByUserIdBefore(@Param("userId") UUID userId, @Param("cursor") Instant cursor, Pageable pageable);
 
 	@Modifying

--- a/src/main/java/com/sagongsa/backend/mypage/MypageService.java
+++ b/src/main/java/com/sagongsa/backend/mypage/MypageService.java
@@ -10,6 +10,7 @@ import com.sagongsa.backend.domain.budget.BudgetCycleRepository;
 import com.sagongsa.backend.domain.enums.ItemCategory;
 import com.sagongsa.backend.domain.enums.ItemStatus;
 import com.sagongsa.backend.domain.enums.ModerationStatus;
+import com.sagongsa.backend.domain.enums.PostVoteType;
 import com.sagongsa.backend.domain.item.SavedItemRepository;
 import com.sagongsa.backend.domain.notification.DevicePushTokenRepository;
 import com.sagongsa.backend.domain.social.FeedPostRepository;
@@ -443,12 +444,13 @@ class MypageService {
 		Map<UUID, Long> commentCounts = countVisibleCommentsByPostIds(
 			posts.stream().map(post -> post.getId()).toList(),
 			blockedIds);
+		Map<UUID, PostVoteType> activeVotes = findActiveVotesByPostIds(
+			posts.stream().map(post -> post.getId()).toList(),
+			userId);
 
 		var items = posts.stream().map(post -> {
 			long cc = commentCounts.getOrDefault(post.getId(), 0L);
-			var myVote = postVoteRepository.findByPostIdAndUserId(post.getId(), userId)
-				.filter(PostVote::isActive).map(PostVote::getVoteType).orElse(null);
-			return PostResponse.of(post, myNickname, cc, myVote, userId);
+			return PostResponse.of(post, myNickname, cc, activeVotes.get(post.getId()), userId);
 		}).toList();
 
 		Instant nextCursor = hasMore && !posts.isEmpty() ? posts.get(posts.size() - 1).getCreatedAt() : null;
@@ -497,5 +499,13 @@ class MypageService {
 			: postCommentRepository.countVisibleByPostIdsExcludingBlockers(postIds, blockedIds);
 		return counts.stream()
 			.collect(Collectors.toMap(PostCommentCount::postId, PostCommentCount::commentCount));
+	}
+
+	private Map<UUID, PostVoteType> findActiveVotesByPostIds(List<UUID> postIds, UUID userId) {
+		if (postIds.isEmpty()) return Collections.emptyMap();
+
+		return postVoteRepository.findByPostIdsAndUserId(postIds, userId).stream()
+			.filter(PostVote::isActive)
+			.collect(Collectors.toMap(vote -> vote.getPost().getId(), PostVote::getVoteType));
 	}
 }

--- a/src/main/resources/db/migration/V24__add_post_votes_user_active_created_index.sql
+++ b/src/main/resources/db/migration/V24__add_post_votes_user_active_created_index.sql
@@ -1,0 +1,3 @@
+create index idx_post_votes_user_active_created
+    on post_votes(user_id, created_at desc)
+    where canceled_at is null;

--- a/src/test/java/com/sagongsa/backend/mypage/MypageQueryCountIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/mypage/MypageQueryCountIntegrationTest.java
@@ -1,0 +1,156 @@
+package com.sagongsa.backend.mypage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sagongsa.backend.social.PostListResponse;
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import jakarta.persistence.EntityManagerFactory;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@SpringBootTest
+class MypageQueryCountIntegrationTest extends PostgreSqlContainerTest {
+
+	private static final int POST_COUNT = 20;
+
+	@Autowired
+	private MypageService mypageService;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private EntityManagerFactory entityManagerFactory;
+
+	private Statistics statistics;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.execute("truncate table users cascade");
+		statistics = entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+		statistics.setStatisticsEnabled(true);
+		statistics.clear();
+	}
+
+	@Test
+	void 내_게시글_목록은_게시글_수와_무관하게_고정된_쿼리로_조회한다() {
+		UUID userId = insertUser();
+		for (int i = 0; i < POST_COUNT; i++) {
+			UUID itemId = insertItem(userId, i);
+			UUID postId = insertPost(userId, itemId, i);
+			insertVote(userId, postId);
+		}
+
+		statistics.clear();
+		PostListResponse response = mypageService.getMyPosts(userId, null, POST_COUNT);
+		long queryCount = statistics.getPrepareStatementCount();
+
+		assertThat(response.posts()).hasSize(POST_COUNT);
+		assertThat(queryCount).isEqualTo(5);
+	}
+
+	@Test
+	void 투표한_게시글_목록은_게시글_수와_무관하게_고정된_쿼리로_조회한다() {
+		UUID viewerId = insertUser();
+		for (int i = 0; i < POST_COUNT; i++) {
+			UUID authorId = insertUser();
+			UUID itemId = insertItem(authorId, i);
+			UUID postId = insertPost(authorId, itemId, i);
+			insertVote(viewerId, postId);
+		}
+
+		statistics.clear();
+		PostListResponse response = mypageService.getMyVotedPosts(
+			viewerId,
+			Instant.now().plusSeconds(60),
+			POST_COUNT);
+		long queryCount = statistics.getPrepareStatementCount();
+
+		assertThat(response.posts()).hasSize(POST_COUNT);
+		assertThat(queryCount).isEqualTo(4);
+	}
+
+	@Test
+	void 사용자별_활성_투표_최신순_인덱스가_적용된다() {
+		Boolean exists = jdbcTemplate.queryForObject(
+			"""
+			select exists (
+			    select 1
+			    from pg_indexes
+			    where schemaname = current_schema()
+			      and tablename = 'post_votes'
+			      and indexname = 'idx_post_votes_user_active_created'
+			)
+			""",
+			Boolean.class);
+
+		assertThat(exists).isTrue();
+	}
+
+	private UUID insertUser() {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"insert into users (id, status, onboarding_status, created_at, updated_at) values (?, 'ACTIVE', 'COMPLETED', ?, ?)",
+			userId, now, now);
+		jdbcTemplate.update(
+			"insert into user_profiles (user_id, nickname, mascot_name, timezone, created_at, updated_at) values (?, '너굴이', '너구리', 'Asia/Seoul', ?, ?)",
+			userId, now, now);
+		return userId;
+	}
+
+	private UUID insertItem(UUID userId, int sequence) {
+		UUID itemId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).plusSeconds(sequence);
+		jdbcTemplate.update(
+			"""
+			insert into saved_items (
+			    id, user_id, input_source, original_url, normalized_url, title,
+			    listed_price, currency_code, category, category_locked_by_user,
+			    status, created_at, updated_at
+			) values (?, ?, 'DIRECT_INPUT', ?, ?, ?, ?, 'KRW', 'ETC', false, 'SAVED', ?, ?)
+			""",
+			itemId,
+			userId,
+			"https://example.com/item/" + itemId,
+			"https://example.com/item/" + itemId,
+			"상품 " + sequence,
+			10_000 + sequence,
+			now,
+			now);
+		return itemId;
+	}
+
+	private UUID insertPost(UUID userId, UUID itemId, int sequence) {
+		UUID postId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC).plusSeconds(sequence);
+		jdbcTemplate.update(
+			"""
+			insert into feed_posts (
+			    id, user_id, item_id, title, body, go_count, stop_count, created_at, updated_at
+			) values (?, ?, ?, ?, '내용', 0, 0, ?, ?)
+			""",
+			postId, userId, itemId, "게시글 " + sequence, now, now);
+		return postId;
+	}
+
+	private void insertVote(UUID userId, UUID postId) {
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		jdbcTemplate.update(
+			"""
+			insert into post_votes (
+			    id, post_id, user_id, vote_type, created_at, updated_at
+			) values (?, ?, ?, 'GO', ?, ?)
+			""",
+			UUID.randomUUID(), postId, userId, now, now);
+	}
+}


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-109**
- Jira: 없음

> PR 제목: `NF-109 마이페이지 게시글·투표 목록 N+1 쿼리 최적화`  
> 브랜치: `fix/NF-109-mypage-query-optimization`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #244

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- `GET /api/v1/users/me/posts`가 게시글마다 내 투표를 개별 조회했습니다.
- `GET /api/v1/users/me/votes`가 각 투표의 게시글과 상품을 지연 로딩했습니다.
- 20건 기준 내 게시글 24회, 투표 목록 44회의 쿼리가 실행됐습니다.

### 왜 발생했나? (Root Cause)
- 내 게시글 응답 변환 루프 안에서 `findByPostIdAndUserId()`를 호출했습니다.
- 사용자별 투표 목록 JPQL이 `PostVote`만 조회하고 응답에 필요한 `post`, `post.user`, `post.item`을 함께 로딩하지 않았습니다.
- 사용자별 활성 투표 최신순 조회에 맞는 `post_votes(user_id, created_at)` 인덱스가 없었습니다.

### 어떻게 고쳤나?
- 기존 `findByPostIdsAndUserId()`를 재사용해 페이지 내 투표를 한 번에 조회하고 게시글 ID별 Map으로 변환합니다.
- 사용자별 활성 투표 쿼리가 `post`, `post.user`, `post.item`을 fetch join하도록 변경합니다.
- `post_votes(user_id, created_at desc) where canceled_at is null` 부분 인덱스를 Flyway V24로 추가합니다.
- 20건 조회의 Hibernate prepared statement 수와 인덱스 적용을 검증하는 PostgreSQL 통합 테스트를 추가합니다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법
- Steps:
  1. 사용자에게 상품이 연결된 게시글과 활성 투표를 20건 생성합니다.
  2. Hibernate statistics를 초기화합니다.
  3. 내 게시글과 내가 투표한 게시글 목록을 각각 조회합니다.
- 수정 전: 내 게시글 24회, 투표 목록 44회
- 수정 후: 내 게시글 5회, 투표 목록 4회

### 재발 방지
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [ ] 런북/문서 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] AC1: 내 게시글 목록의 투표 조회가 게시글별 쿼리 대신 단일 배치 쿼리로 실행된다.
- [x] AC2: 투표 목록의 게시글·작성자·상품이 목록 쿼리에서 함께 로딩된다.
- [x] AC3: 20건 기준 쿼리 수가 내 게시글 5회, 투표 목록 4회로 고정된다.
- [x] AC4: 사용자별 활성 투표 최신순 부분 인덱스가 Flyway로 적용된다.
- [x] AC5: 기존 커서 페이징, 댓글 수, 차단 사용자 필터, 내 투표 응답 동작이 유지된다.

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew --no-daemon --console=plain test --tests 'com.sagongsa.backend.mypage.MypageQueryCountIntegrationTest' --tests 'com.sagongsa.backend.mypage.MypageApiIntegrationTest' --tests 'com.sagongsa.backend.social.SocialFeedCommentCountIntegrationTest'`
- Result: BUILD SUCCESSFUL
- Command: `./gradlew --no-daemon --console=plain test && ./gradlew --no-daemon --console=plain jacocoTestReport`
- Result: BUILD SUCCESSFUL, 635 tests, failures 0, errors 0, 기존 skip 9
- Command: `git diff --check`
- Result: 성공

### CI
- 링크/결과: PR 생성 후 자동 실행

### Smoke / 수동 검증
- 시나리오: PostgreSQL에 20개 게시글·상품·투표를 구성하고 일반 목록 및 커서 목록 조회
- 결과: 응답 20건 유지, 내 게시글 5회·투표 목록 4회, V24 인덱스 존재 확인

### 테스트 공백
- QA 배포 후 실제 요청 지연과 운영 실행계획 비교는 머지·배포 이후 확인이 필요합니다.

---

## 🧭 영향 범위 (필수)
- [x] API 스펙 변경 없음
- [ ] API 스펙 변경 있음
- [ ] DB 스키마 변경 없음
- [x] DB 스키마 변경 있음 (V24 부분 인덱스 1개 추가)
- [x] 설정/환경변수 변경 없음
- [x] 캐시/큐/외부 연동 영향 없음

---

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음
- [ ] Breaking change 있음

---

## 🚀 배포/릴리즈
### Feature Flag
- [x] 사용 안함

### 모니터링/알림
- 확인할 지표: `/api/v1/users/me/posts`, `/api/v1/users/me/votes` 응답시간과 DB 쿼리 수
- 확인할 실행계획: `idx_post_votes_user_active_created` 사용 여부

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 배포 시 `post_votes` 부분 인덱스 생성 동안 테이블 규모에 비례한 I/O와 짧은 쓰기 잠금이 발생할 수 있습니다.
- fetch join으로 한 쿼리의 선택 컬럼은 늘지만 전체 DB 왕복 횟수는 크게 감소합니다.

### 롤백
- [x] 배포 롤백 가능
- [x] 코드 revert 가능
- [x] 인덱스는 후속 migration의 `drop index if exists idx_post_votes_user_active_created`로 제거 가능

---

## 📸 증빙
- 20건 쿼리 수: 내 게시글 `24 → 5`, 투표 목록 `44 → 4`
- 전체 테스트: 635개, 실패 0, 오류 0, 기존 skip 9

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직: `MypageService#findActiveVotesByPostIds`, `PostVoteRepository#findActiveByUserId*`, V24 migration, `MypageQueryCountIntegrationTest`
- 트레이드오프/대안: 전용 projection 대신 기존 응답 변환 구조를 유지하면서 배치 조회와 to-one fetch join만 적용해 변경 범위를 줄였습니다.
- 성능/보안/호환성 영향: API 계약과 권한 동작은 동일하며 목록 크기에 비례하던 추가 DB round trip을 제거합니다.
