### PR TITLE
[fix] NF-112 위시리스트 사용자 검증 중복 조회 최적화

### DIFF
--- a/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
+++ b/src/main/java/com/sagongsa/backend/wishlist/WishlistService.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.springframework.dao.DuplicateKeyException;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -366,28 +367,22 @@ public class WishlistService {
 	}
 
 	private void ensureWishlistUserAllowed(UUID userId) {
-		Boolean exists = jdbcTemplate.queryForObject(
-			"select exists(select 1 from users where id = ?)",
-			Boolean.class,
-			userId
-		);
-		if (!Boolean.TRUE.equals(exists)) {
+		Boolean allowed;
+		try {
+			allowed = jdbcTemplate.queryForObject(
+				"""
+				select status = 'ACTIVE' and onboarding_status = 'COMPLETED'
+				from users
+				where id = ?
+				""",
+				Boolean.class,
+				userId
+			);
+		}
+		catch (EmptyResultDataAccessException exception) {
 			throw new WishlistItemNotFoundException("User was not found.");
 		}
 
-		Boolean allowed = jdbcTemplate.queryForObject(
-			"""
-			select exists(
-				select 1
-				from users
-				where id = ?
-				  and status = 'ACTIVE'
-				  and onboarding_status = 'COMPLETED'
-			)
-			""",
-			Boolean.class,
-			userId
-		);
 		if (!Boolean.TRUE.equals(allowed)) {
 			throw new WishlistForbiddenException("Wishlist can be used only by active users who completed onboarding.");
 		}

--- a/src/test/java/com/sagongsa/backend/wishlist/WishlistServiceUserValidationTest.java
+++ b/src/test/java/com/sagongsa/backend/wishlist/WishlistServiceUserValidationTest.java
@@ -1,0 +1,67 @@
+package com.sagongsa.backend.wishlist;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+class WishlistServiceUserValidationTest {
+
+	@Test
+	void validatesUserAccessWithSingleJdbcCall() {
+		JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+		UUID userId = UUID.randomUUID();
+		when(jdbcTemplate.queryForObject(contains("from users"), eq(Boolean.class), eq(userId)))
+			.thenReturn(Boolean.TRUE);
+		WishlistService wishlistService = new WishlistService(jdbcTemplate, new ObjectMapper());
+
+		assertThatThrownBy(() -> wishlistService.create(userId, null))
+			.isInstanceOf(BadRequestException.class);
+
+		verify(jdbcTemplate, times(1))
+			.queryForObject(contains("from users"), eq(Boolean.class), eq(userId));
+		verifyNoMoreInteractions(jdbcTemplate);
+	}
+
+	@Test
+	void mapsMissingUserToNotFoundWithoutASecondJdbcCall() {
+		JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+		UUID userId = UUID.randomUUID();
+		when(jdbcTemplate.queryForObject(contains("from users"), eq(Boolean.class), eq(userId)))
+			.thenThrow(new EmptyResultDataAccessException(1));
+		WishlistService wishlistService = new WishlistService(jdbcTemplate, new ObjectMapper());
+
+		assertThatThrownBy(() -> wishlistService.create(userId, null))
+			.isInstanceOf(WishlistItemNotFoundException.class);
+
+		verify(jdbcTemplate, times(1))
+			.queryForObject(contains("from users"), eq(Boolean.class), eq(userId));
+		verifyNoMoreInteractions(jdbcTemplate);
+	}
+
+	@Test
+	void mapsDisallowedUserToForbiddenWithoutASecondJdbcCall() {
+		JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+		UUID userId = UUID.randomUUID();
+		when(jdbcTemplate.queryForObject(contains("from users"), eq(Boolean.class), eq(userId)))
+			.thenReturn(Boolean.FALSE);
+		WishlistService wishlistService = new WishlistService(jdbcTemplate, new ObjectMapper());
+
+		assertThatThrownBy(() -> wishlistService.create(userId, null))
+			.isInstanceOf(WishlistForbiddenException.class);
+
+		verify(jdbcTemplate, times(1))
+			.queryForObject(contains("from users"), eq(Boolean.class), eq(userId));
+		verifyNoMoreInteractions(jdbcTemplate);
+	}
+}


### PR DESCRIPTION
# 🐛 Bugfix PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-112**
- Jira: 없음

> PR 제목: `[fix] NF-112 위시리스트 사용자 검증 중복 조회 최적화`  
> 브랜치: `fix/NF-112-wishlist-user-validation-query`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #248

---

## 🧩 한눈에 요약 (필수)
### 어떤 버그였나?
- 위시리스트 요청마다 동일한 사용자 PK를 존재 확인과 사용 가능 상태 확인으로 나누어 2회 조회했습니다.

### 왜 발생했나? (Root Cause)
- 사용자 미존재(404)와 비활성·온보딩 미완료(403)를 구분하기 위해 각각 별도 SQL을 실행했습니다.

### 어떻게 고쳤나?
- 사용자 행에서 활성·온보딩 완료 여부를 단일 SQL로 조회합니다.
- 조회 결과가 없으면 기존 404, 허용 상태가 아니면 기존 403을 유지합니다.
- 허용·미존재·비허용 경로가 각각 JDBC 조회 1회인지 회귀 테스트로 고정했습니다.

---

## 🧯 재현 & 검증 (권장)
### 재현 방법(가능하면)
- Steps: 위시리스트 생성 또는 조회 전에 실행되는 사용자 검증 SQL을 계수
- 기대 결과: `users` PK 조회 1회
- 실제 결과(수정 전): 같은 `users.id`를 2회 조회

### 재발 방지(있다면)
- [x] 회귀 테스트 추가
- [ ] 모니터링/알람 보강
- [ ] 런북/문서 보강

---

## ✅ Acceptance Criteria (AC) (필수)
- [x] 사용자 검증 시 동일 PK 조회를 2회에서 1회로 줄인다.
- [x] 사용자 미존재 404와 비활성·온보딩 미완료 403 동작을 유지한다.
- [x] API·DB 스키마·설정 변경 없이 관련 테스트를 통과한다.

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew test --tests com.sagongsa.backend.wishlist.WishlistServiceUserValidationTest`
- Result: 성공, 3 tests / 0 failures
- Command: `./gradlew test --no-daemon --rerun-tasks --tests com.sagongsa.backend.wishlist.WishlistServiceTest --stacktrace`
- Result: 성공, 33 tests / 0 failures
- Command: `./gradlew test --no-daemon --rerun-tasks --tests com.sagongsa.backend.wishlist.WishlistApiIntegrationTest --stacktrace`
- Result: 성공, 26 tests / 0 failures

### CI
- 링크/결과: Draft PR 생성 후 자동 실행 결과 확인 예정

### Smoke / 수동 검증
- 시나리오: 로컬 PostgreSQL 16 Testcontainers 기반 서비스/API 통합 테스트
- 결과: 59 tests / 0 failures

### 테스트 공백(있다면 이유 필수)
- 운영 환경 부하 테스트는 수행하지 않았습니다.

---

## 🧭 영향 범위 (필수)
- [x] API 스펙 변경 없음
- [ ] API 스펙 변경 있음 (요약: )
- [x] DB 스키마 변경 없음
- [ ] DB 스키마 변경 있음 (마이그레이션/락/시간: )
- [x] 설정/환경변수 변경 없음
- [ ] 설정/환경변수 변경 있음 (항목: )
- [x] 캐시/큐/외부 연동 영향 없음
- [ ] 캐시/큐/외부 연동 영향 있음 (요약: )

---

## 💥 Breaking / Compatibility (필수)
- [x] Breaking change 없음
- [ ] Breaking change 있음 → 무엇이 깨지는지 / 마이그레이션 / 롤아웃 전략:

---

## 🚀 배포/릴리즈 (해당 시 필수)
### Feature Flag
- [x] 사용 안함
- [ ] 사용함 → Flag/기본값/롤아웃:

### 모니터링/알림
- 확인할 대시보드/지표: 위시리스트 요청 DB 쿼리 수와 응답 지연
- 에러/로그 키워드: `User was not found.`, `Wishlist can be used only by active users who completed onboarding.`

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 사용자 상태 컬럼을 Boolean 식으로 판정하지만 현재 NOT NULL 제약과 기존 허용 조건을 그대로 사용합니다.

### 롤백
- [ ] 플래그/설정으로 우회 가능
- [x] 배포 롤백(이전 태그/이미지) 가능
- [ ] 데이터 롤백/역마이그레이션 필요 (절차: )

---

## 📸 증빙 (선택)
- 전/후 비교: 위시리스트 요청당 사용자 검증 SQL 2회 → 1회
- 사전 로컬 PostgreSQL 16 제어 벤치마크(2,000회, DB 구간만): SQL 6,000 → 4,000, 712.073ms → 476.817ms(33.0% 감소)
- 주의: 운영 환경 또는 API 전체 응답시간 개선 수치가 아닙니다.

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/로직: `WishlistService#ensureWishlistUserAllowed`, `WishlistServiceUserValidationTest`
- 트레이드오프/대안: 2회의 `exists` 대신 상태 조건식을 1회 조회하고 미존재는 `EmptyResultDataAccessException`으로 구분했습니다.
- 성능/보안/호환성 영향: 사용자 검증 SQL 1회 감소, 접근 제어·응답 코드·API 호환성 유지