### PR TITLE
[chore] NF-114 API 폭주 및 인증 요청 제한 추가

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -308,7 +308,9 @@ jobs:
               @sensitive path_regexp sensitive (?i)^/(?:\\.(?:env(?:[./_-].*)?|git(?:/.*)?|aws(?:/.*)?|ssh(?:/.*)?)|manager(?:/.*)?|cgi-bin(?:/.*)?|actuator(?:/.*)?|wp-admin(?:/.*)?|wp-login\\.php|xmlrpc\\.php|phpmyadmin(?:/.*)?|vendor/phpunit(?:/.*)?)$
               respond @sensitive 404
 
-              reverse_proxy 127.0.0.1:$port
+              reverse_proxy 127.0.0.1:$port {
+                  header_up X-Forwarded-For {remote_host}
+              }
           }
           EOF
 

--- a/src/main/java/com/sagongsa/backend/auth/AuthApiController.java
+++ b/src/main/java/com/sagongsa/backend/auth/AuthApiController.java
@@ -2,6 +2,7 @@ package com.sagongsa.backend.auth;
 
 import com.sagongsa.backend.config.AppAuthProperties;
 import com.sagongsa.backend.domain.auth.UserAccountRepository;
+import com.sagongsa.backend.security.ratelimit.ClientIpResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,17 +43,20 @@ public class AuthApiController {
 	private final UserAccessService userAccessService;
 	private final AppAuthProperties appAuthProperties;
 	private final ReviewerTokenRateLimiter reviewerTokenRateLimiter;
+	private final ClientIpResolver clientIpResolver;
 
 	public AuthApiController(JwtTokenService jwtTokenService,
 		UserAccountRepository userAccountRepository,
 		UserAccessService userAccessService,
 		AppAuthProperties appAuthProperties,
-		ReviewerTokenRateLimiter reviewerTokenRateLimiter) {
+		ReviewerTokenRateLimiter reviewerTokenRateLimiter,
+		ClientIpResolver clientIpResolver) {
 		this.jwtTokenService = jwtTokenService;
 		this.userAccountRepository = userAccountRepository;
 		this.userAccessService = userAccessService;
 		this.appAuthProperties = appAuthProperties;
 		this.reviewerTokenRateLimiter = reviewerTokenRateLimiter;
+		this.clientIpResolver = clientIpResolver;
 	}
 
 	@GetMapping("/me")
@@ -136,7 +140,7 @@ public class AuthApiController {
 			),
 			List.of(new SimpleGrantedAuthority("ROLE_USER"))
 		);
-		log.info("App reviewer token issued from remoteAddress={}", request.getRemoteAddr());
+		log.info("App reviewer token issued from clientIp={}", clientIpResolver.resolve(request).address());
 		return toTokenResponse(tokenPair);
 	}
 
@@ -146,10 +150,11 @@ public class AuthApiController {
 			throw new ResponseStatusException(HttpStatus.NOT_FOUND);
 		}
 
-		reviewerTokenRateLimiter.assertAllowed(request.getRemoteAddr());
+		String clientIp = clientIpResolver.resolve(request).address();
+		reviewerTokenRateLimiter.assertAllowed(clientIp);
 		if (properties.isRequireSecret()
 			&& (!StringUtils.hasText(properties.getSecret()) || !constantTimeEquals(properties.getSecret(), reviewerToken))) {
-			log.warn("App reviewer token rejected from remoteAddress={}", request.getRemoteAddr());
+			log.warn("App reviewer token rejected from clientIp={}", clientIp);
 			throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Invalid reviewer token secret");
 		}
 	}

--- a/src/main/java/com/sagongsa/backend/config/ApiRateLimitProperties.java
+++ b/src/main/java/com/sagongsa/backend/config/ApiRateLimitProperties.java
@@ -1,0 +1,77 @@
+package com.sagongsa.backend.config;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.security.rate-limit")
+public class ApiRateLimitProperties {
+
+	private boolean enabled = true;
+	private int maxTrackedKeys = 10_000;
+	private final Policy api = new Policy(600, Duration.ofMinutes(1));
+	private final Policy authentication = new Policy(30, Duration.ofMinutes(1));
+	private final Policy expensiveRequest = new Policy(30, Duration.ofMinutes(1));
+	private final Policy health = new Policy(120, Duration.ofMinutes(1));
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public int getMaxTrackedKeys() {
+		return maxTrackedKeys;
+	}
+
+	public void setMaxTrackedKeys(int maxTrackedKeys) {
+		this.maxTrackedKeys = maxTrackedKeys;
+	}
+
+	public Policy getApi() {
+		return api;
+	}
+
+	public Policy getAuthentication() {
+		return authentication;
+	}
+
+	public Policy getExpensiveRequest() {
+		return expensiveRequest;
+	}
+
+	public Policy getHealth() {
+		return health;
+	}
+
+	public static class Policy {
+
+		private int maxRequests;
+		private Duration window;
+
+		public Policy() {
+		}
+
+		Policy(int maxRequests, Duration window) {
+			this.maxRequests = maxRequests;
+			this.window = window;
+		}
+
+		public int getMaxRequests() {
+			return maxRequests;
+		}
+
+		public void setMaxRequests(int maxRequests) {
+			this.maxRequests = maxRequests;
+		}
+
+		public Duration getWindow() {
+			return window;
+		}
+
+		public void setWindow(Duration window) {
+			this.window = window;
+		}
+	}
+}

--- a/src/main/java/com/sagongsa/backend/config/SecurityConfig.java
+++ b/src/main/java/com/sagongsa/backend/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.sagongsa.backend.auth.AppRedirectUriSupport;
 import com.sagongsa.backend.auth.CustomOAuth2UserService;
 import com.sagongsa.backend.auth.OAuth2AppAuthenticationFailureHandler;
 import com.sagongsa.backend.auth.OAuth2AppAuthenticationSuccessHandler;
+import com.sagongsa.backend.security.ratelimit.ApiRateLimitFilter;
 import com.nimbusds.jose.jwk.source.ImmutableSecret;
 import jakarta.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
@@ -17,6 +18,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -33,6 +35,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
@@ -56,7 +59,11 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
-@EnableConfigurationProperties({AppAuthProperties.class, AppCorsProperties.class})
+@EnableConfigurationProperties({
+	AppAuthProperties.class,
+	AppCorsProperties.class,
+	ApiRateLimitProperties.class
+})
 public class SecurityConfig {
 
 	private static final String AUTHORIZATION_BASE_URI = "/oauth2/authorization";
@@ -72,6 +79,7 @@ public class SecurityConfig {
 		@Value("${app.auth.trusted-user-id-header.enabled:false}") boolean trustedUserIdHeaderEnabled,
 		CorsConfigurationSource corsConfigurationSource,
 		@Qualifier("apiAccessTokenJwtDecoder") JwtDecoder apiAccessTokenJwtDecoder,
+		ApiRateLimitFilter apiRateLimitFilter,
 		Environment environment
 	) throws Exception {
 		boolean nonProd = !environment.acceptsProfiles(Profiles.of("prod"));
@@ -124,9 +132,17 @@ public class SecurityConfig {
 			.oauth2Client(Customizer.withDefaults())
 			.oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt
 				.decoder(apiAccessTokenJwtDecoder)
-				.jwtAuthenticationConverter(jwtAuthenticationConverter)));
+				.jwtAuthenticationConverter(jwtAuthenticationConverter)))
+			.addFilterBefore(apiRateLimitFilter, OAuth2AuthorizationRequestRedirectFilter.class);
 
 		return http.build();
+	}
+
+	@Bean
+	FilterRegistrationBean<ApiRateLimitFilter> apiRateLimitFilterRegistration(ApiRateLimitFilter filter) {
+		FilterRegistrationBean<ApiRateLimitFilter> registration = new FilterRegistrationBean<>(filter);
+		registration.setEnabled(false);
+		return registration;
 	}
 
 	@Bean

--- a/src/main/java/com/sagongsa/backend/security/ratelimit/ApiRateLimitFilter.java
+++ b/src/main/java/com/sagongsa/backend/security/ratelimit/ApiRateLimitFilter.java
@@ -1,0 +1,214 @@
+package com.sagongsa.backend.security.ratelimit;
+
+import com.sagongsa.backend.config.ApiRateLimitProperties;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class ApiRateLimitFilter extends OncePerRequestFilter {
+
+	private static final Logger log = LoggerFactory.getLogger(ApiRateLimitFilter.class);
+	private static final Duration OVERFLOW_WARNING_INTERVAL = Duration.ofMinutes(1);
+	private static final String IMPORT_LINK_PATH = "/api/v1/items/import-link";
+	private static final String IMPORT_JOBS_PATH = "/api/v1/items/import-jobs";
+
+	private final ApiRateLimitProperties properties;
+	private final ClientIpResolver clientIpResolver;
+	private final FixedWindowRateLimiter rateLimiter;
+	private final MeterRegistry meterRegistry;
+	private final Clock clock;
+	private final Map<String, Counter> rejectedCounters = new ConcurrentHashMap<>();
+	private final AtomicLong nextOverflowWarningAtMillis = new AtomicLong();
+
+	@Autowired
+	public ApiRateLimitFilter(
+		ApiRateLimitProperties properties,
+		ClientIpResolver clientIpResolver,
+		MeterRegistry meterRegistry
+	) {
+		this(properties, clientIpResolver, meterRegistry, Clock.systemUTC());
+	}
+
+	ApiRateLimitFilter(
+		ApiRateLimitProperties properties,
+		ClientIpResolver clientIpResolver,
+		MeterRegistry meterRegistry,
+		Clock clock
+	) {
+		this.properties = properties;
+		this.clientIpResolver = clientIpResolver;
+		this.meterRegistry = meterRegistry;
+		this.clock = clock;
+		this.rateLimiter = new FixedWindowRateLimiter(clock);
+	}
+
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain
+	) throws ServletException, IOException {
+		if (!properties.isEnabled()) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+		if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		ClientIpResolver.ClientIp clientIp = clientIpResolver.resolve(request);
+		if (clientIp.internal()) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		for (Policy policy : policiesFor(request)) {
+			FixedWindowRateLimiter.Decision decision = rateLimiter.acquire(
+				policy.name().toLowerCase(Locale.ROOT) + ":" + clientIp.address(),
+				policy.properties().getMaxRequests(),
+				policy.properties().getWindow(),
+				properties.getMaxTrackedKeys()
+			);
+
+			if (decision.untracked()) {
+				logOverflowOnce();
+				continue;
+			}
+			if (decision.warningReached()) {
+				log.warn(
+					"api rate limit nearing threshold policy={} clientIp={} method={} path={} count={} limit={} windowSeconds={}",
+					policy.name(),
+					clientIp.address(),
+					request.getMethod(),
+					request.getRequestURI(),
+					decision.count(),
+					policy.properties().getMaxRequests(),
+					windowSeconds(policy.properties().getWindow())
+				);
+			}
+			if (!decision.allowed()) {
+				rejectedCounter(policy).increment();
+				if (decision.firstRejection()) {
+					log.warn(
+						"api rate limit exceeded policy={} clientIp={} method={} path={} count={} limit={} resetAt={}",
+						policy.name(),
+						clientIp.address(),
+						request.getMethod(),
+						request.getRequestURI(),
+						decision.count(),
+						policy.properties().getMaxRequests(),
+						decision.resetsAt()
+					);
+				}
+				writeRateLimitedResponse(response, policy, decision);
+				return;
+			}
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	private List<Policy> policiesFor(HttpServletRequest request) {
+		String path = request.getRequestURI();
+		List<Policy> policies = new ArrayList<>(3);
+
+		if ("/health".equals(path) || "/api/health".equals(path)) {
+			policies.add(new Policy("HEALTH", properties.getHealth()));
+		}
+		if (path.startsWith("/api/")) {
+			policies.add(new Policy("API", properties.getApi()));
+		}
+		if (isAuthenticationPath(path)) {
+			policies.add(new Policy("AUTHENTICATION", properties.getAuthentication()));
+		}
+		if ("POST".equalsIgnoreCase(request.getMethod())
+			&& (IMPORT_LINK_PATH.equals(path) || IMPORT_JOBS_PATH.equals(path))) {
+			policies.add(new Policy("EXPENSIVE_REQUEST", properties.getExpensiveRequest()));
+		}
+
+		return policies;
+	}
+
+	private boolean isAuthenticationPath(String path) {
+		return path.startsWith("/oauth2/")
+			|| path.startsWith("/login/oauth2/")
+			|| path.startsWith("/api/auth/");
+	}
+
+	private Counter rejectedCounter(Policy policy) {
+		return rejectedCounters.computeIfAbsent(policy.name(), ignored -> Counter.builder(
+				"app.security.rate_limit.rejected"
+			)
+			.description("Requests rejected by the application rate limiter")
+			.tag("policy", policy.name().toLowerCase(Locale.ROOT))
+			.register(meterRegistry));
+	}
+
+	private void writeRateLimitedResponse(
+		HttpServletResponse response,
+		Policy policy,
+		FixedWindowRateLimiter.Decision decision
+	) throws IOException {
+		long retryAfterSeconds = Math.max(
+			1,
+			(long)Math.ceil(
+				Duration.between(Instant.now(clock), decision.resetsAt()).toMillis() / 1000.0d
+			)
+		);
+		response.setStatus(429);
+		response.setHeader(HttpHeaders.RETRY_AFTER, Long.toString(retryAfterSeconds));
+		response.setHeader("X-RateLimit-Limit", Integer.toString(policy.properties().getMaxRequests()));
+		response.setHeader("X-RateLimit-Remaining", Integer.toString(decision.remaining()));
+		response.setHeader("X-RateLimit-Reset", Long.toString(decision.resetsAt().getEpochSecond()));
+		response.setContentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
+		response.getWriter().printf(
+			"{\"status\":429,\"error\":\"Too Many Requests\",\"policy\":\"%s\",\"retryAfterSeconds\":%d}",
+			policy.name().toLowerCase(Locale.ROOT),
+			retryAfterSeconds
+		);
+	}
+
+	private void logOverflowOnce() {
+		long now = clock.millis();
+		long next = nextOverflowWarningAtMillis.get();
+		if (now < next) {
+			return;
+		}
+		long updated = now + OVERFLOW_WARNING_INTERVAL.toMillis();
+		if (nextOverflowWarningAtMillis.compareAndSet(next, updated)) {
+			log.warn(
+				"api rate limiter key capacity reached maxTrackedKeys={} new keys are temporarily fail-open",
+				properties.getMaxTrackedKeys()
+			);
+		}
+	}
+
+	private long windowSeconds(Duration window) {
+		return window == null ? 0 : Math.max(1, window.toSeconds());
+	}
+
+	private record Policy(String name, ApiRateLimitProperties.Policy properties) {
+	}
+}

--- a/src/main/java/com/sagongsa/backend/security/ratelimit/ClientIpResolver.java
+++ b/src/main/java/com/sagongsa/backend/security/ratelimit/ClientIpResolver.java
@@ -1,0 +1,71 @@
+package com.sagongsa.backend.security.ratelimit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class ClientIpResolver {
+
+	private static final String FORWARDED_FOR_HEADER = "X-Forwarded-For";
+	private static final int MAX_IP_LITERAL_LENGTH = 45;
+
+	public ClientIp resolve(HttpServletRequest request) {
+		String remoteAddress = normalizeLiteral(request.getRemoteAddr());
+		boolean loopback = isLoopback(remoteAddress);
+
+		if (loopback) {
+			String forwardedAddress = firstForwardedAddress(request.getHeader(FORWARDED_FOR_HEADER));
+			if (forwardedAddress != null && !isLoopback(forwardedAddress)) {
+				return new ClientIp(forwardedAddress, false);
+			}
+			return new ClientIp(remoteAddress, true);
+		}
+
+		return new ClientIp(remoteAddress, false);
+	}
+
+	private String firstForwardedAddress(String header) {
+		if (!StringUtils.hasText(header)) {
+			return null;
+		}
+		String normalized = normalizeLiteral(header.split(",", 2)[0].trim());
+		return "unknown".equals(normalized) ? null : normalized;
+	}
+
+	private String normalizeLiteral(String rawAddress) {
+		if (!StringUtils.hasText(rawAddress)) {
+			return "unknown";
+		}
+
+		String candidate = rawAddress.trim();
+		if (candidate.startsWith("[") && candidate.endsWith("]")) {
+			candidate = candidate.substring(1, candidate.length() - 1);
+		}
+		if (candidate.length() > MAX_IP_LITERAL_LENGTH || !candidate.matches("[0-9A-Fa-f:.]+")) {
+			return "unknown";
+		}
+
+		try {
+			return InetAddress.getByName(candidate).getHostAddress();
+		} catch (UnknownHostException exception) {
+			return "unknown";
+		}
+	}
+
+	private boolean isLoopback(String address) {
+		if ("unknown".equals(address)) {
+			return false;
+		}
+		try {
+			return InetAddress.getByName(address).isLoopbackAddress();
+		} catch (UnknownHostException exception) {
+			return false;
+		}
+	}
+
+	public record ClientIp(String address, boolean internal) {
+	}
+}

--- a/src/main/java/com/sagongsa/backend/security/ratelimit/FixedWindowRateLimiter.java
+++ b/src/main/java/com/sagongsa/backend/security/ratelimit/FixedWindowRateLimiter.java
@@ -1,0 +1,83 @@
+package com.sagongsa.backend.security.ratelimit;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+final class FixedWindowRateLimiter {
+
+	private static final long CLEANUP_INTERVAL = 256;
+
+	private final Clock clock;
+	private final ConcurrentHashMap<String, Window> windows = new ConcurrentHashMap<>();
+	private final AtomicLong requests = new AtomicLong();
+
+	FixedWindowRateLimiter(Clock clock) {
+		this.clock = clock;
+	}
+
+	Decision acquire(String key, int maxRequests, Duration windowSize, int maxTrackedKeys) {
+		if (maxRequests <= 0 || windowSize == null || windowSize.isZero() || windowSize.isNegative()) {
+			return Decision.notLimited();
+		}
+
+		Instant now = Instant.now(clock);
+		if (requests.incrementAndGet() % CLEANUP_INTERVAL == 0) {
+			removeExpired(now);
+		}
+
+		Window existing = windows.get(key);
+		if (existing == null && maxTrackedKeys > 0 && windows.size() >= maxTrackedKeys) {
+			removeExpired(now);
+			if (windows.size() >= maxTrackedKeys) {
+				return Decision.untrackedDecision();
+			}
+		}
+
+		Window updated = windows.compute(key, (ignored, current) -> {
+			if (current == null || !now.isBefore(current.expiresAt())) {
+				return new Window(now.plus(windowSize), 1);
+			}
+			return new Window(current.expiresAt(), current.count() + 1);
+		});
+
+		int warningAt = Math.max(1, (int)Math.ceil(maxRequests * 0.8d));
+		boolean allowed = updated.count() <= maxRequests;
+		return new Decision(
+			allowed,
+			updated.count(),
+			Math.max(0, maxRequests - updated.count()),
+			updated.expiresAt(),
+			updated.count() == warningAt,
+			updated.count() == maxRequests + 1,
+			false
+		);
+	}
+
+	private void removeExpired(Instant now) {
+		windows.entrySet().removeIf(entry -> !now.isBefore(entry.getValue().expiresAt()));
+	}
+
+	record Decision(
+		boolean allowed,
+		int count,
+		int remaining,
+		Instant resetsAt,
+		boolean warningReached,
+		boolean firstRejection,
+		boolean untracked
+	) {
+		static Decision notLimited() {
+			return new Decision(true, 0, Integer.MAX_VALUE, Instant.EPOCH, false, false, false);
+		}
+
+		static Decision untrackedDecision() {
+			return new Decision(true, 0, Integer.MAX_VALUE, Instant.EPOCH, false, false, true);
+		}
+	}
+
+	private record Window(Instant expiresAt, int count) {
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,6 +51,22 @@ logging:
     console: "%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5level [%thread] [requestId=%X{requestId}] [userId=%X{userId}] %logger{36} - %msg%n"
 
 app:
+  security:
+    rate-limit:
+      enabled: ${APP_API_RATE_LIMIT_ENABLED:true}
+      max-tracked-keys: ${APP_API_RATE_LIMIT_MAX_TRACKED_KEYS:10000}
+      api:
+        max-requests: ${APP_API_RATE_LIMIT_MAX_REQUESTS:600}
+        window: ${APP_API_RATE_LIMIT_WINDOW:PT1M}
+      authentication:
+        max-requests: ${APP_AUTH_RATE_LIMIT_MAX_REQUESTS:30}
+        window: ${APP_AUTH_RATE_LIMIT_WINDOW:PT1M}
+      expensive-request:
+        max-requests: ${APP_EXPENSIVE_RATE_LIMIT_MAX_REQUESTS:30}
+        window: ${APP_EXPENSIVE_RATE_LIMIT_WINDOW:PT1M}
+      health:
+        max-requests: ${APP_HEALTH_RATE_LIMIT_MAX_REQUESTS:120}
+        window: ${APP_HEALTH_RATE_LIMIT_WINDOW:PT1M}
   admin:
     notification-token: ${APP_ADMIN_NOTIFICATION_TOKEN:}
   auth:

--- a/src/test/java/com/sagongsa/backend/security/ratelimit/ApiRateLimitFilterTest.java
+++ b/src/test/java/com/sagongsa/backend/security/ratelimit/ApiRateLimitFilterTest.java
@@ -1,0 +1,106 @@
+package com.sagongsa.backend.security.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sagongsa.backend.config.ApiRateLimitProperties;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class ApiRateLimitFilterTest {
+
+	private ApiRateLimitProperties properties;
+	private SimpleMeterRegistry meterRegistry;
+	private ApiRateLimitFilter filter;
+
+	@BeforeEach
+	void setUp() {
+		properties = new ApiRateLimitProperties();
+		properties.getApi().setMaxRequests(3);
+		properties.getAuthentication().setMaxRequests(2);
+		properties.getExpensiveRequest().setMaxRequests(1);
+		properties.getHealth().setMaxRequests(2);
+		meterRegistry = new SimpleMeterRegistry();
+		filter = new ApiRateLimitFilter(
+			properties,
+			new ClientIpResolver(),
+			meterRegistry,
+			Clock.fixed(Instant.parse("2026-08-06T00:00:00Z"), ZoneOffset.UTC)
+		);
+	}
+
+	@Test
+	void rejectsAuthenticationBurstWithRetryHeaders() throws Exception {
+		assertThat(execute("GET", "/oauth2/authorization/google", "203.0.113.10").getStatus()).isEqualTo(200);
+		assertThat(execute("GET", "/oauth2/authorization/google", "203.0.113.10").getStatus()).isEqualTo(200);
+
+		MockHttpServletResponse rejected =
+			execute("GET", "/oauth2/authorization/google", "203.0.113.10");
+
+		assertThat(rejected.getStatus()).isEqualTo(429);
+		assertThat(rejected.getHeader("Retry-After")).isEqualTo("60");
+		assertThat(rejected.getHeader("X-RateLimit-Limit")).isEqualTo("2");
+		assertThat(rejected.getContentAsString()).contains("\"policy\":\"authentication\"");
+		assertThat(meterRegistry.get("app.security.rate_limit.rejected")
+			.tag("policy", "authentication")
+			.counter()
+			.count()).isEqualTo(1);
+	}
+
+	@Test
+	void appliesStricterLimitToExpensiveImportRequests() throws Exception {
+		assertThat(execute("POST", "/api/v1/items/import-link", "203.0.113.11").getStatus()).isEqualTo(200);
+
+		MockHttpServletResponse rejected =
+			execute("POST", "/api/v1/items/import-link", "203.0.113.11");
+
+		assertThat(rejected.getStatus()).isEqualTo(429);
+		assertThat(rejected.getContentAsString()).contains("\"policy\":\"expensive_request\"");
+	}
+
+	@Test
+	void keepsDifferentClientAddressesIndependent() throws Exception {
+		execute("GET", "/api/v1/users/me", "203.0.113.12");
+		execute("GET", "/api/v1/users/me", "203.0.113.12");
+		execute("GET", "/api/v1/users/me", "203.0.113.12");
+
+		assertThat(execute("GET", "/api/v1/users/me", "198.51.100.12").getStatus()).isEqualTo(200);
+	}
+
+	@Test
+	void bypassesInternalLoopbackTrafficWithoutForwardedAddress() throws Exception {
+		for (int i = 0; i < 10; i++) {
+			MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/users/me");
+			request.setRemoteAddr("127.0.0.1");
+			MockHttpServletResponse response = new MockHttpServletResponse();
+
+			filter.doFilter(request, response, new MockFilterChain());
+
+			assertThat(response.getStatus()).isEqualTo(200);
+		}
+	}
+
+	@Test
+	void bypassesCorsPreflightRequests() throws Exception {
+		for (int i = 0; i < 10; i++) {
+			assertThat(execute("OPTIONS", "/api/auth/me", "203.0.113.13").getStatus()).isEqualTo(200);
+		}
+	}
+
+	private MockHttpServletResponse execute(String method, String path, String clientIp) throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest(method, path);
+		request.setRemoteAddr("127.0.0.1");
+		request.addHeader("X-Forwarded-For", clientIp);
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter.doFilter(request, response, new MockFilterChain());
+
+		return response;
+	}
+}

--- a/src/test/java/com/sagongsa/backend/security/ratelimit/ApiRateLimitIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/security/ratelimit/ApiRateLimitIntegrationTest.java
@@ -1,0 +1,54 @@
+package com.sagongsa.backend.security.ratelimit;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sagongsa.backend.support.PostgreSqlContainerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ApiRateLimitIntegrationTest extends PostgreSqlContainerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void limitsUnauthenticatedAuthenticationRequestsBeforeController() throws Exception {
+		for (int i = 0; i < 30; i++) {
+			mockMvc.perform(get("/api/auth/me")
+					.remoteAddress("127.0.0.1")
+					.header("X-Forwarded-For", "203.0.113.30"))
+				.andExpect(status().isUnauthorized());
+		}
+
+		mockMvc.perform(get("/api/auth/me")
+				.remoteAddress("127.0.0.1")
+				.header("X-Forwarded-For", "203.0.113.30"))
+			.andExpect(status().isTooManyRequests())
+			.andExpect(header().string("X-RateLimit-Limit", "30"))
+			.andExpect(header().exists("Retry-After"));
+	}
+
+	@Test
+	void limitsExpensiveRequestBeforeAuthenticationWork() throws Exception {
+		for (int i = 0; i < 30; i++) {
+			mockMvc.perform(post("/api/v1/items/import-jobs")
+					.remoteAddress("127.0.0.1")
+					.header("X-Forwarded-For", "203.0.113.31"))
+				.andExpect(status().isBadRequest());
+		}
+
+		mockMvc.perform(post("/api/v1/items/import-jobs")
+				.remoteAddress("127.0.0.1")
+				.header("X-Forwarded-For", "203.0.113.31"))
+			.andExpect(status().isTooManyRequests())
+			.andExpect(header().string("X-RateLimit-Limit", "30"));
+	}
+}

--- a/src/test/java/com/sagongsa/backend/security/ratelimit/ClientIpResolverTest.java
+++ b/src/test/java/com/sagongsa/backend/security/ratelimit/ClientIpResolverTest.java
@@ -1,0 +1,56 @@
+package com.sagongsa.backend.security.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class ClientIpResolverTest {
+
+	private final ClientIpResolver resolver = new ClientIpResolver();
+
+	@Test
+	void trustsForwardedAddressOnlyFromLoopbackProxy() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setRemoteAddr("127.0.0.1");
+		request.addHeader("X-Forwarded-For", "203.0.113.10");
+
+		ClientIpResolver.ClientIp clientIp = resolver.resolve(request);
+
+		assertThat(clientIp.address()).isEqualTo("203.0.113.10");
+		assertThat(clientIp.internal()).isFalse();
+	}
+
+	@Test
+	void ignoresSpoofedForwardedAddressOnDirectConnection() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setRemoteAddr("198.51.100.20");
+		request.addHeader("X-Forwarded-For", "203.0.113.99");
+
+		ClientIpResolver.ClientIp clientIp = resolver.resolve(request);
+
+		assertThat(clientIp.address()).isEqualTo("198.51.100.20");
+		assertThat(clientIp.internal()).isFalse();
+	}
+
+	@Test
+	void marksLoopbackWithoutForwardedAddressAsInternal() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setRemoteAddr("::1");
+
+		ClientIpResolver.ClientIp clientIp = resolver.resolve(request);
+
+		assertThat(clientIp.internal()).isTrue();
+	}
+
+	@Test
+	void rejectsNonLiteralForwardedAddress() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setRemoteAddr("127.0.0.1");
+		request.addHeader("X-Forwarded-For", "attacker.example");
+
+		ClientIpResolver.ClientIp clientIp = resolver.resolve(request);
+
+		assertThat(clientIp.internal()).isTrue();
+	}
+}

--- a/src/test/java/com/sagongsa/backend/security/ratelimit/FixedWindowRateLimiterTest.java
+++ b/src/test/java/com/sagongsa/backend/security/ratelimit/FixedWindowRateLimiterTest.java
@@ -1,0 +1,88 @@
+package com.sagongsa.backend.security.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+class FixedWindowRateLimiterTest {
+
+	private final MutableClock clock = new MutableClock(Instant.parse("2026-08-06T00:00:00Z"));
+	private final FixedWindowRateLimiter rateLimiter = new FixedWindowRateLimiter(clock);
+
+	@Test
+	void allowsLimitAndRejectsNextRequest() {
+		assertThat(acquire("api:203.0.113.10", 2).allowed()).isTrue();
+		assertThat(acquire("api:203.0.113.10", 2).allowed()).isTrue();
+
+		FixedWindowRateLimiter.Decision rejected = acquire("api:203.0.113.10", 2);
+
+		assertThat(rejected.allowed()).isFalse();
+		assertThat(rejected.firstRejection()).isTrue();
+		assertThat(rejected.remaining()).isZero();
+	}
+
+	@Test
+	void keepsClientWindowsIndependent() {
+		acquire("api:203.0.113.10", 1);
+
+		assertThat(acquire("api:198.51.100.20", 1).allowed()).isTrue();
+	}
+
+	@Test
+	void resetsAfterWindowExpires() {
+		acquire("api:203.0.113.10", 1);
+		assertThat(acquire("api:203.0.113.10", 1).allowed()).isFalse();
+
+		clock.advance(Duration.ofMinutes(1));
+
+		assertThat(acquire("api:203.0.113.10", 1).allowed()).isTrue();
+	}
+
+	@Test
+	void failsOpenWhenKeyCapacityIsFull() {
+		rateLimiter.acquire("api:203.0.113.10", 1, Duration.ofMinutes(1), 1);
+
+		FixedWindowRateLimiter.Decision decision =
+			rateLimiter.acquire("api:198.51.100.20", 1, Duration.ofMinutes(1), 1);
+
+		assertThat(decision.allowed()).isTrue();
+		assertThat(decision.untracked()).isTrue();
+	}
+
+	private FixedWindowRateLimiter.Decision acquire(String key, int maxRequests) {
+		return rateLimiter.acquire(key, maxRequests, Duration.ofMinutes(1), 100);
+	}
+
+	private static class MutableClock extends Clock {
+
+		private Instant instant;
+
+		private MutableClock(Instant instant) {
+			this.instant = instant;
+		}
+
+		void advance(Duration duration) {
+			instant = instant.plus(duration);
+		}
+
+		@Override
+		public ZoneId getZone() {
+			return ZoneOffset.UTC;
+		}
+
+		@Override
+		public Clock withZone(ZoneId zone) {
+			return this;
+		}
+
+		@Override
+		public Instant instant() {
+			return instant;
+		}
+	}
+}


### PR DESCRIPTION
# 🧰 Chore PR

## 🔗 작업 키 / 이슈 링크 (필수)
- Tracking Key: **NF-114**
- Jira: https://parkjaehong.atlassian.net/browse/NF-114 (있다면)

> PR 제목: `NF-114 API 폭주 및 인증 요청 제한 추가`  
> 브랜치: `chore/NF-114-api-rate-limit`

---

### 🔒 Close Issue (필수)
- GitHub: Closes #252

---

## 🧩 한눈에 요약 (필수)
### 무엇을 변경했나? (인프라/빌드/CI/의존성 등)
- [x] 인프라
- [x] 설정파일
- [ ] 빌드 파일
- [x] CI
- [ ] 의존성
- [ ] 런타임/비즈니스 로직 리팩터링 없음 (있으면 Refactor PR 템플릿 사용)

### 왜 필요한가? (안정성/속도/보안/개발경험)
- NF-113의 민감 경로·반복 스캐너 차단에 더해 정상 API 경로를 이용한 요청 폭주와 로그인 공격을 애플리케이션 진입부에서 제한합니다.
- 최근 2주 관측 최대치보다 충분히 높은 기본 한도를 적용하고 내부 호출과 CORS 사전 요청을 제외해 정상 사용자 오탐 가능성을 낮춥니다.

### 범위(스코프)
- Included: 실제 외부 IP 판별, 일반 API·인증·쇼핑 링크 분석·health별 fixed-window 제한, 429 재시도 응답, 임계 로그·차단 메트릭, 환경변수 설정, Caddy 실제 IP 전달
- Not included: 영구 IP 차단, Redis 기반 분산 제한, QA 배포 및 런타임 한도 조정

---

## 🧪 테스트 / 검증 (필수)
### 로컬
- Command: `./gradlew test --console=plain`
- Result: 656개 테스트 통과, 기존 skip 9
- Command: `./gradlew test --tests 'com.sagongsa.backend.security.ratelimit.*' --console=plain`
- Result: 쇼핑 링크 분석 정상 30회 허용 및 31번째 429 포함 제한 전용 테스트 통과
- Command: `git diff --check`
- Result: 성공

### CI
- 링크/결과: 자동 실행 예정

### Smoke / 수동 검증 (해당 시)
- 시나리오: loopback Caddy에서 외부 IP를 전달받아 정책별 한도까지 통과하고 다음 요청을 차단
- 결과: MockMvc 통합 테스트 통과

### 테스트 공백(있다면 이유 필수)
- QA 런타임의 실제 `429`와 경고 로그·메트릭은 머지 후 자동 배포 안정화 단계에서 확인합니다.

---

## 🧭 영향 범위 (필수)
- [ ] 설정/환경변수 변경 없음
- [x] 설정/환경변수 변경 있음 (항목: `APP_*_RATE_LIMIT_*`, 기본 활성화)
- [ ] CI/빌드 파이프라인 영향 없음
- [x] CI/빌드 파이프라인 영향 있음 (요약: QA Caddy가 실제 클라이언트 IP를 명시적으로 전달)
- [x] 의존성(dependency) 변경 없음
- [ ] 의존성(dependency) 변경 있음 (패키지/버전/주요 변경점: )

---

## ⚠️ 리스크 & 롤백 (필수)
### 리스크
- 동일 NAT를 공유하는 사용자는 같은 IP 한도를 공유합니다.
- 단일 인스턴스 메모리 기반 제한이므로 서버가 여러 대로 확장되면 인스턴스별로 한도가 적용됩니다.
- 추적 키 용량이 가득 차면 제한 기능이 서비스 장애를 만들지 않도록 신규 키는 일시적으로 fail-open합니다.

### 롤백
- [x] 단순 revert로 가능
- [ ] 버전 pin/되돌리기 필요 (대상: , 방법: )
- [x] 배포 롤백(이전 태그/이미지) 가능
- 긴급 시 `APP_API_RATE_LIMIT_ENABLED=false`로 즉시 비활성화할 수 있습니다.

---

## 💬 리뷰 가이드 (필수)
- 꼭 봐야 하는 파일/설정: `ApiRateLimitFilter`, `ClientIpResolver`, `SecurityConfig`, `.github/workflows/deploy-qa.yml`
- 트레이드오프/대안: 엣지 전용 또는 Redis 제한 대신 현재 단일 QA 인스턴스에서 즉시 적용 가능한 애플리케이션 메모리 제한을 선택했습니다.
- 성능/보안/호환성 영향: 일반 API 600회/분, 인증 30회/분, 쇼핑 링크 분석 30회/분, health 120회/분. 내부 loopback과 CORS OPTIONS는 집계 제외하며 API 계약 변경은 없습니다.
