### PR TITLE
[chore] NF-115 프로덕션 reviewer-token 기본 비활성화

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -366,11 +366,11 @@ jobs:
             fail_preflight "APP_AUTH_TRUSTED_USER_ID_HEADER_ENABLED must not be true"
           fi
 
-          if [ "${APP_REVIEWER_TOKEN_ENABLED:-true}" != "false" ]; then
+          if [ "${APP_REVIEWER_TOKEN_ENABLED:-false}" != "false" ]; then
             require_reviewer_seed
           fi
 
-          if [ "${APP_REVIEWER_TOKEN_ENABLED:-true}" != "false" ] && [ "${APP_REVIEWER_TOKEN_REQUIRE_SECRET:-false}" = "true" ]; then
+          if [ "${APP_REVIEWER_TOKEN_ENABLED:-false}" != "false" ] && [ "${APP_REVIEWER_TOKEN_REQUIRE_SECRET:-false}" = "true" ]; then
             require_env APP_REVIEWER_TOKEN_SECRET
             require_secret_length APP_REVIEWER_TOKEN_SECRET
           fi

--- a/docs/understanding.html
+++ b/docs/understanding.html
@@ -1,0 +1,1368 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>위굴 Backend 이해 관제실</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f5f7fb;
+      --panel: #ffffff;
+      --panel-soft: #f8fafc;
+      --text: #172033;
+      --muted: #64748b;
+      --line: #dbe3ef;
+      --brand: #4f46e5;
+      --brand-soft: #eef2ff;
+      --good: #087f5b;
+      --good-soft: #e6fcf5;
+      --warn: #b45309;
+      --warn-soft: #fff7ed;
+      --danger: #b42318;
+      --danger-soft: #fff1f2;
+      --unknown: #6b7280;
+      --shadow: 0 10px 30px rgba(15, 23, 42, .07);
+    }
+    [data-theme="dark"] {
+      color-scheme: dark;
+      --bg: #0b1020;
+      --panel: #11182a;
+      --panel-soft: #172036;
+      --text: #e7ecf5;
+      --muted: #9cabbe;
+      --line: #293550;
+      --brand: #8b87ff;
+      --brand-soft: #25254b;
+      --good: #55d6a5;
+      --good-soft: #16372e;
+      --warn: #f8bd68;
+      --warn-soft: #3d2c19;
+      --danger: #ff8d8d;
+      --danger-soft: #402329;
+      --unknown: #a8b0bf;
+      --shadow: 0 10px 30px rgba(0, 0, 0, .25);
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      overflow-x: hidden;
+      background: var(--bg);
+      color: var(--text);
+      font-family: Pretendard, "Noto Sans KR", "Malgun Gothic", system-ui, sans-serif;
+      font-size: 16px;
+      line-height: 1.68;
+    }
+    button, input, select { font: inherit; }
+    button { color: inherit; }
+    code {
+      padding: .12rem .34rem;
+      border-radius: .35rem;
+      background: var(--panel-soft);
+      border: 1px solid var(--line);
+      font-family: "Cascadia Code", Consolas, monospace;
+      font-size: .88em;
+      overflow-wrap: anywhere;
+    }
+    .topbar {
+      position: sticky;
+      z-index: 30;
+      top: 0;
+      display: grid;
+      grid-template-columns: minmax(300px, 1fr) minmax(260px, 430px) auto auto;
+      gap: 12px;
+      align-items: center;
+      padding: 13px 26px;
+      border-bottom: 1px solid var(--line);
+      background: color-mix(in srgb, var(--panel) 94%, transparent);
+      backdrop-filter: blur(12px);
+    }
+    .brand { display: flex; gap: 10px; align-items: center; min-width: 0; }
+    .brand-mark {
+      display: grid; place-items: center; width: 36px; height: 36px;
+      border-radius: 11px; background: var(--brand); color: white; font-weight: 900;
+    }
+    .brand strong { display: block; font-size: 1rem; }
+    .brand small { display: block; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .search { position: relative; }
+    .search input {
+      width: 100%; padding: 9px 12px 9px 36px; border: 1px solid var(--line);
+      border-radius: 10px; background: var(--panel-soft); color: var(--text);
+    }
+    .search::before { content: "⌕"; position: absolute; left: 12px; top: 7px; color: var(--muted); font-size: 1.2rem; }
+    select, .icon-button {
+      border: 1px solid var(--line); border-radius: 10px; padding: 9px 11px;
+      background: var(--panel-soft); color: var(--text); cursor: pointer;
+    }
+    .shell {
+      display: grid;
+      grid-template-columns: 196px minmax(0, 1fr);
+      max-width: 1540px;
+      margin: 0 auto;
+    }
+    .sidebar {
+      position: sticky; top: 61px; height: calc(100vh - 61px); overflow: auto;
+      padding: 22px 14px; border-right: 1px solid var(--line); background: var(--panel);
+    }
+    .sidebar a {
+      display: block; padding: 8px 12px; margin: 2px 0; border-radius: 8px;
+      color: var(--muted); text-decoration: none; font-size: .92rem;
+    }
+    .sidebar a:hover, .sidebar a.active { color: var(--brand); background: var(--brand-soft); font-weight: 700; }
+    .baseline {
+      margin-top: 18px; padding: 12px; border: 1px solid var(--line);
+      background: var(--panel-soft); border-radius: 10px; font-size: .78rem; color: var(--muted);
+    }
+    main { min-width: 0; padding: 34px 42px 70px; }
+    section {
+      scroll-margin-top: 86px; max-width: 1120px; margin: 0 auto 28px; padding: 30px 32px;
+      background: var(--panel); border: 1px solid var(--line); border-radius: 18px; box-shadow: 0 8px 26px rgba(15, 23, 42, .045);
+    }
+    section h2 { margin: 0 0 6px; font-size: 1.48rem; letter-spacing: -.025em; }
+    section > .lead { max-width: 820px; margin: 0 0 22px; color: var(--muted); }
+    h3 { margin: 20px 0 10px; font-size: 1.04rem; }
+    p { margin: .45rem 0; }
+    h1, h2, h3, h4, p, li, dd, summary { word-break: keep-all; overflow-wrap: break-word; }
+    ul, ol { margin: .55rem 0; padding-left: 1.25rem; }
+    li + li { margin-top: .32rem; }
+    .hero {
+      padding: 38px 40px;
+      background:
+        radial-gradient(circle at 100% 0, color-mix(in srgb, var(--brand) 18%, transparent), transparent 36%),
+        var(--panel);
+    }
+    .eyebrow { color: var(--brand); font-weight: 800; font-size: .82rem; }
+    .hero h1 { max-width: 920px; margin: 7px 0 16px; font-size: clamp(2rem, 3.2vw, 3rem); line-height: 1.2; letter-spacing: -.045em; }
+    .hero .summary { max-width: 900px; color: var(--muted); font-size: 1.06rem; line-height: 1.82; }
+    .grid { display: grid; gap: 12px; }
+    .grid-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .grid-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+    .hero .grid-4 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .card {
+      padding: 18px; border: 1px solid var(--line); border-radius: 13px; background: var(--panel-soft);
+    }
+    .card h3, .card h4 { margin: 0 0 6px; }
+    .card p:last-child { margin-bottom: 0; }
+    .memory {
+      margin-top: 22px; padding: 18px 22px; border-left: 4px solid var(--brand);
+      border-radius: 0 12px 12px 0; background: var(--brand-soft);
+    }
+    .memory h3 { margin-top: 0; color: var(--brand); }
+    .badge {
+      display: inline-flex; align-items: center; gap: 4px; padding: 2px 7px; border-radius: 999px;
+      font-size: .72rem; font-weight: 800; border: 1px solid currentColor; white-space: nowrap;
+    }
+    .confirmed { color: var(--good); background: var(--good-soft); }
+    .inferred { color: var(--warn); background: var(--warn-soft); }
+    .unknown { color: var(--unknown); background: var(--panel-soft); }
+    .high { color: var(--danger); background: var(--danger-soft); }
+    .medium { color: var(--warn); background: var(--warn-soft); }
+    .low { color: var(--good); background: var(--good-soft); }
+    .filters { display: flex; flex-wrap: wrap; gap: 7px; margin: 12px 0; }
+    .filter, .control {
+      padding: 7px 10px; border: 1px solid var(--line); border-radius: 9px;
+      background: var(--panel-soft); cursor: pointer;
+    }
+    .filter.active, .control.primary { border-color: var(--brand); color: var(--brand); background: var(--brand-soft); font-weight: 700; }
+    .arch-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 13px; }
+    .node {
+      position: relative; min-height: 155px; padding: 17px; border: 1px solid var(--line);
+      border-radius: 12px; background: var(--panel-soft); cursor: pointer; transition: .15s ease;
+    }
+    .node:hover, .node.selected { transform: translateY(-2px); border-color: var(--brand); box-shadow: 0 8px 18px rgba(79, 70, 229, .10); }
+    .node h3 { margin: 4px 0 5px; }
+    .node p { color: var(--muted); font-size: .88rem; }
+    .node .kind { color: var(--brand); font-weight: 800; font-size: .72rem; }
+    .edge-legend { display: flex; flex-wrap: wrap; gap: 14px; color: var(--muted); font-size: .82rem; margin-top: 14px; }
+    .edge-legend span::before { content: ""; display: inline-block; width: 22px; height: 3px; margin-right: 6px; vertical-align: middle; background: var(--brand); }
+    .edge-legend .async::before { background: repeating-linear-gradient(90deg, var(--warn) 0 5px, transparent 5px 8px); }
+    .edge-legend .store::before { background: var(--good); }
+    .edge-legend .external::before { background: var(--danger); }
+    .flow-layout { display: grid; grid-template-columns: 250px minmax(0, 1fr); gap: 16px; }
+    .flow-list button {
+      width: 100%; text-align: left; margin-bottom: 7px; padding: 10px;
+      border: 1px solid var(--line); border-radius: 9px; background: var(--panel-soft); cursor: pointer;
+    }
+    .flow-list button.active { color: var(--brand); border-color: var(--brand); background: var(--brand-soft); font-weight: 700; }
+    .stepper { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 12px; }
+    .flow-track { display: flex; align-items: stretch; gap: 8px; overflow-x: auto; padding: 8px 2px 14px; }
+    .flow-step {
+      flex: 0 0 145px; padding: 11px; border: 1px solid var(--line); border-radius: 10px;
+      background: var(--panel-soft); color: var(--muted); font-size: .82rem;
+    }
+    .flow-step::after { content: "→"; float: right; color: var(--muted); }
+    .flow-step:last-child::after { content: ""; }
+    .flow-step.done { border-color: var(--good); color: var(--good); }
+    .flow-step.active { border-color: var(--brand); color: var(--brand); background: var(--brand-soft); box-shadow: 0 0 0 2px color-mix(in srgb, var(--brand) 18%, transparent); }
+    .step-detail { min-height: 260px; padding: 16px; border: 1px solid var(--line); border-radius: 12px; background: var(--panel-soft); }
+    .step-detail dl, .context dl { display: grid; grid-template-columns: 118px minmax(0, 1fr); gap: 7px 10px; margin: 0; }
+    dt { color: var(--muted); font-weight: 700; }
+    dd { margin: 0; overflow-wrap: anywhere; }
+    .journey { display: flex; gap: 8px; overflow-x: auto; padding: 12px 2px; }
+    .journey .phase {
+      flex: 1 0 150px; padding: 13px; border: 1px solid var(--line); border-radius: 11px; background: var(--panel-soft);
+    }
+    .journey .phase strong { display: block; color: var(--brand); margin-bottom: 6px; }
+    .table-wrap { overflow-x: auto; }
+    table { width: 100%; border-collapse: collapse; font-size: .88rem; }
+    th, td { padding: 10px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+    th { color: var(--muted); background: var(--panel-soft); }
+    .hotspot { display: grid; grid-template-columns: 110px minmax(180px, .8fr) 1.5fr; gap: 10px; padding: 11px 0; border-bottom: 1px solid var(--line); }
+    .hotspot:last-child { border-bottom: 0; }
+    .risk-card { border-left: 4px solid var(--warn); }
+    .risk-card[data-severity="높음"] { border-left-color: var(--danger); }
+    .risk-card[data-severity="낮음"] { border-left-color: var(--good); }
+    details {
+      margin: 8px 0; border: 1px solid var(--line); border-radius: 10px; background: var(--panel-soft);
+    }
+    summary { padding: 11px 13px; cursor: pointer; font-weight: 750; }
+    details > div { padding: 0 13px 13px; }
+    .quiz-question { padding: 15px; margin-bottom: 12px; border: 1px solid var(--line); border-radius: 12px; background: var(--panel-soft); }
+    .quiz-question h3 { margin-top: 0; }
+    .choice { display: block; width: 100%; text-align: left; padding: 8px 10px; margin: 6px 0; border: 1px solid var(--line); border-radius: 8px; background: var(--panel); cursor: pointer; }
+    .choice.correct { border-color: var(--good); color: var(--good); background: var(--good-soft); }
+    .choice.wrong { border-color: var(--danger); color: var(--danger); background: var(--danger-soft); }
+    .feedback { display: none; margin-top: 8px; padding: 9px; border-radius: 8px; background: var(--panel); }
+    .quiz-score { position: sticky; bottom: 10px; padding: 12px 15px; border: 1px solid var(--brand); border-radius: 11px; background: var(--brand-soft); box-shadow: var(--shadow); }
+    .context {
+      position: fixed; z-index: 50; top: 76px; right: 22px; width: min(400px, calc(100vw - 32px));
+      max-height: calc(100vh - 98px); overflow: auto;
+      padding: 22px; border: 1px solid var(--line); border-radius: 16px; background: var(--panel);
+      box-shadow: 0 24px 70px rgba(15, 23, 42, .22);
+      transform: translateX(calc(100% + 40px)); opacity: 0; pointer-events: none;
+      transition: transform .2s ease, opacity .2s ease;
+    }
+    .context.open { transform: translateX(0); opacity: 1; pointer-events: auto; }
+    .context h2 { margin: 0 0 4px; font-size: 1.08rem; }
+    .context .hint { color: var(--muted); font-size: .84rem; }
+    .context-card { margin-top: 13px; padding: 13px; border: 1px solid var(--line); border-radius: 11px; background: var(--panel-soft); }
+    .context-card h3 { margin-top: 0; }
+    .what-if { margin-top: 12px; width: 100%; padding: 9px; border: 1px solid var(--brand); color: var(--brand); background: var(--brand-soft); border-radius: 9px; cursor: pointer; font-weight: 800; }
+    .context-close {
+      float: right; width: 32px; height: 32px; padding: 0; border: 1px solid var(--line);
+      border-radius: 9px; background: var(--panel-soft); cursor: pointer;
+    }
+    .search-hit { outline: 3px solid color-mix(in srgb, var(--brand) 35%, transparent); }
+    .hidden { display: none !important; }
+    [data-depth="core"] .deep, [data-depth="core"] .medium-depth { display: none !important; }
+    [data-depth="five"] .deep { display: none !important; }
+    .notice { padding: 12px 14px; border: 1px solid var(--warn); border-radius: 10px; color: var(--warn); background: var(--warn-soft); }
+    .muted { color: var(--muted); }
+    @media (max-width: 1180px) {
+      main { padding: 28px 26px 60px; }
+      .arch-grid, .grid-3, .grid-4 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
+    @media (max-width: 760px) {
+      .topbar { grid-template-columns: minmax(0, 1fr) 48px; padding: 12px 14px; }
+      .topbar .brand { grid-column: 1 / -1; }
+      .topbar .search { grid-column: 1 / -1; }
+      .topbar select { min-width: 0; width: 100%; }
+      .topbar .icon-button { width: 48px; }
+      .shell { display: block; }
+      .sidebar { position: static; height: auto; overflow-x: auto; white-space: nowrap; border-right: 0; border-bottom: 1px solid var(--line); }
+      .sidebar a { display: inline-block; }
+      .baseline { display: none; }
+      main { padding: 12px; }
+      section { padding: 22px 18px; }
+      .hero { padding: 28px 20px; }
+      .hero h1 { font-size: 1.86rem; }
+      .hero .grid-4 { grid-template-columns: 1fr; }
+      .grid-2, .grid-3, .grid-4, .arch-grid, .flow-layout { grid-template-columns: 1fr; }
+      .hotspot { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body data-depth="five">
+  <header class="topbar">
+    <div class="brand">
+      <div class="brand-mark">위</div>
+      <div>
+        <strong>위굴 Backend 이해 관제실</strong>
+        <small>origin/develop@019d77c · 구매 전후 의사결정 지원</small>
+      </div>
+    </div>
+    <label class="search">
+      <input id="searchInput" type="search" placeholder="컴포넌트, 경로, 위험, 흐름 검색">
+    </label>
+    <select id="depthSelect" aria-label="이해 깊이">
+      <option value="core">30초 핵심</option>
+      <option value="five" selected>5분 이해</option>
+      <option value="deep">깊게 보기</option>
+    </select>
+    <button id="themeButton" class="icon-button" type="button" aria-label="테마 바꾸기">◐</button>
+  </header>
+
+  <div class="shell">
+    <nav class="sidebar" aria-label="문서 내비게이션">
+      <a href="#overview" class="active">개요</a>
+      <a href="#architecture">구조</a>
+      <a href="#flows">실행 흐름</a>
+      <a href="#data">데이터</a>
+      <a href="#state">상태</a>
+      <a href="#hotspots">꼭 봐야 할 코드</a>
+      <a href="#decisions">설계 선택</a>
+      <a href="#risks">위험</a>
+      <a href="#debug">디버깅</a>
+      <a href="#extension">확장</a>
+      <a href="#changes">최근 변화</a>
+      <a href="#quiz">퀴즈</a>
+      <div class="baseline">
+        <strong>분석 기준</strong><br>
+        <code>origin/develop</code><br>
+        Git <code>019d77c</code><br>
+        2026-08-07<br><br>
+        <span class="badge confirmed">확인됨</span>
+        작업 트리 소스·설정·테스트·Git 이력으로 확인했습니다.
+      </div>
+    </nav>
+
+    <main>
+      <section id="overview" class="hero searchable">
+        <div class="eyebrow">최신 origin/develop · 확인됨</div>
+        <h1>갖고 싶은 물건을 수집하고, 고민하고, 결정하고, 돌아보게 만드는 백엔드</h1>
+        <p class="summary">
+          위굴 Backend는 쇼핑 링크나 직접 입력으로 <code>SavedItem</code>을 만들고, 예산과 자기 점검을 반영한 구매 결정을 기록하며,
+          소셜 투표·리마인드·회고까지 이어 주는 Spring Boot API입니다. PostgreSQL이 사용자별 상태의 최종 저장소이고,
+          Google/Kakao OAuth·외부 쇼핑몰·FCM은 시스템 밖 경계입니다.
+        </p>
+        <div class="grid grid-4" style="margin-top:24px">
+          <div class="card">
+            <h3>핵심 축</h3>
+            <p><code>SavedItem</code>이 수집·결정·소셜·알림을 잇습니다.</p>
+          </div>
+          <div class="card">
+            <h3>상태의 기준</h3>
+            <p>PostgreSQL과 Flyway 스키마가 영속 상태 계약을 소유합니다.</p>
+          </div>
+          <div class="card">
+            <h3>요청 방어</h3>
+            <p><code>ApiRateLimitFilter</code>가 인증·API·고비용 요청을 IP 단위로 제한합니다.</p>
+          </div>
+          <div class="card">
+            <h3>외부 경계</h3>
+            <p>OAuth 제공자, 쇼핑몰 페이지, Playwright, Firebase FCM에 의존합니다.</p>
+          </div>
+        </div>
+        <div class="memory">
+          <h3>이것만은 기억하세요</h3>
+          <ol>
+            <li><code>POST /api/v1/items/import-link</code>도 기본 설정에서는 DB 작업 큐를 거친 뒤 결과를 기다립니다.</li>
+            <li>구매 결정은 <code>purchase_decisions</code> 하나만 바꾸지 않습니다. 위시 상태·예산·자기 점검·마스코트·리마인더를 한 트랜잭션 안에서 함께 바꿉니다.</li>
+            <li>알림은 먼저 <code>notifications</code>에 중복 방지 키와 함께 저장되고, 커밋 뒤 FCM 전송을 시도합니다.</li>
+            <li>외부 요청은 인증보다 먼저 <code>ApiRateLimitFilter</code>를 지나며, 인증·일반 API·쇼핑 import·health 정책이 중첩 적용될 수 있습니다.</li>
+            <li>운영 구성은 백엔드 loopback bind와 Caddy·fail2ban·애플리케이션 rate limit의 계층 방어를 전제로 합니다.</li>
+            <li>현재 문서는 2026-08-07에 fetch한 최신 <code>origin/develop@019d77c</code>를 설명합니다.</li>
+          </ol>
+        </div>
+      </section>
+
+      <section id="architecture" class="searchable">
+        <h2>아키텍처 지도</h2>
+        <p class="lead">노드를 누르면 실제 책임·의존성·상태·근거가 오른쪽 맥락 패널에 표시됩니다.</p>
+        <div class="filters" id="architectureFilters">
+          <button class="filter active" data-filter="전체">전체</button>
+          <button class="filter" data-filter="경계">경계</button>
+          <button class="filter" data-filter="도메인">도메인</button>
+          <button class="filter" data-filter="백그라운드 작업">백그라운드 작업</button>
+          <button class="filter" data-filter="데이터">데이터</button>
+          <button class="filter" data-filter="외부 시스템">외부 시스템</button>
+        </div>
+        <div id="architectureGrid" class="arch-grid" aria-live="polite"></div>
+        <div class="edge-legend">
+          <span>동기 호출</span>
+          <span class="async">비동기 작업</span>
+          <span class="store">저장</span>
+          <span class="external">외부 시스템</span>
+        </div>
+        <div class="medium-depth notice" style="margin-top:16px">
+          이 저장소는 엄격한 단일 아키텍처 패턴으로만 구성되지 않습니다. JPA Repository와 <code>JdbcTemplate</code> SQL이 함께 사용되며,
+          서비스별로 영속성 접근 방식이 다릅니다.
+        </div>
+      </section>
+
+      <section id="flows" class="searchable">
+        <h2>실행 흐름</h2>
+        <p class="lead">실제 코드 경로를 한 단계씩 이동하며 입력, 부수 효과, 다음 단계를 확인하세요.</p>
+        <div class="flow-layout">
+          <div id="flowList" class="flow-list"></div>
+          <div>
+            <div class="stepper">
+              <button id="flowFirst" class="control" type="button">처음</button>
+              <button id="flowPrev" class="control" type="button">이전</button>
+              <button id="flowNext" class="control primary" type="button">다음</button>
+              <button id="flowAuto" class="control" type="button">자동 재생</button>
+              <button id="flowReset" class="control" type="button">초기화</button>
+            </div>
+            <div id="flowTrack" class="flow-track"></div>
+            <div id="stepDetail" class="step-detail"></div>
+          </div>
+        </div>
+      </section>
+
+      <section id="data" class="searchable medium-depth">
+        <h2>데이터의 여정</h2>
+        <p class="lead"><code>SavedItem</code>이 어떻게 외부 링크에서 구매 결정과 회고까지 이어지는지 보여 줍니다.</p>
+        <div class="journey">
+          <div class="phase">
+            <strong>1. 수집</strong>
+            <code>ShoppingLinkImportRequest</code><br>
+            <span class="muted">SHARE 또는 DIRECT_INPUT</span>
+          </div>
+          <div class="phase">
+            <strong>2. 검증·변환</strong>
+            URL 공개 호스트 검사, 정규화, HTML 메타데이터 추출
+          </div>
+          <div class="phase">
+            <strong>3. 미리보기</strong>
+            <code>ShoppingLinkImportResponse</code>와 <code>WishlistSaveDraft</code>
+          </div>
+          <div class="phase">
+            <strong>4. 저장</strong>
+            <code>saved_items</code>와 선택적 <code>item_source_metadata</code>
+          </div>
+          <div class="phase">
+            <strong>5. 결정</strong>
+            <code>purchase_decisions</code>, 자기 점검, 예산, 상태 변경
+          </div>
+          <div class="phase">
+            <strong>6. 후속 행동</strong>
+            <code>reminder_schedules</code>, <code>notifications</code>, 회고·소셜 피드
+          </div>
+        </div>
+        <div class="grid grid-2 deep">
+          <div class="card">
+            <h3>대표 입력 모양</h3>
+            <p><code>ShoppingLinkImportRequest(inputSource, url, title, brandName, price, imageUrl)</code></p>
+            <p><code>DecisionCompleteRequest(itemId, result, finalPrice, rationaleText, selfCheckAnswers)</code></p>
+          </div>
+          <div class="card">
+            <h3>중요한 의미 변화</h3>
+            <p><code>SavedItem.status</code>는 <code>SAVED</code>에서 구매 결정에 따라 다른 상태로 바뀝니다.</p>
+            <p><code>PurchaseDecision.result</code> 변경 시 예산 차액과 변경 이력도 함께 조정됩니다.</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="state" class="searchable medium-depth">
+        <h2>상태는 누가 가지고 있나</h2>
+        <p class="lead">“이 값의 최종 책임자는 누구인가?”를 기준으로 정리했습니다.</p>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr><th>상태</th><th>최종 소유자</th><th>주요 작성자</th><th>주요 독자</th><th>생명주기·동기화</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>API rate limit window</td>
+                <td><code>FixedWindowRateLimiter</code> 프로세스 메모리</td>
+                <td><code>ApiRateLimitFilter</code></td>
+                <td>외부 요청, Micrometer, 보안 로그</td>
+                <td>policy:clientIp별 fixed window, 재시작 시 초기화, 256요청마다 만료 key 정리</td>
+              </tr>
+              <tr>
+                <td>사용자 접근 상태</td>
+                <td><code>users.status</code>, <code>users.onboarding_status</code></td>
+                <td><code>OnboardingService</code>, <code>MypageService</code></td>
+                <td><code>UserAccessService</code>, 각 도메인 서비스</td>
+                <td>API·토큰 발급 전에 반복 검증</td>
+              </tr>
+              <tr>
+                <td>인증 토큰 상태</td>
+                <td>access JWT는 클라이언트, refresh 유효성은 <code>refresh_tokens</code></td>
+                <td><code>JwtTokenService</code></td>
+                <td>Spring Security, <code>CurrentUserIdArgumentResolver</code></td>
+                <td>refresh 사용 시 기존 행을 revoke하고 새 쌍 발급</td>
+              </tr>
+              <tr>
+                <td>위시 항목</td>
+                <td><code>saved_items</code></td>
+                <td><code>WishlistService</code>, <code>DecisionService</code></td>
+                <td>홈·마이페이지·소셜·알림·회고</td>
+                <td><code>normalized_url</code>과 <code>idempotency_key</code>로 중복 제한</td>
+              </tr>
+              <tr>
+                <td>쇼핑 수집 작업</td>
+                <td><code>shopping_import_jobs</code></td>
+                <td><code>ShoppingImportJobService</code>, <code>ShoppingImportJobWorker</code></td>
+                <td>동기 브리지·작업 조회 API·메트릭</td>
+                <td><code>PENDING → RUNNING → SUCCEEDED/FAILED</code>, stale 복구·보관기간 정리</td>
+              </tr>
+              <tr>
+                <td>구매 결정과 월 예산</td>
+                <td><code>purchase_decisions</code>, <code>budget_cycles</code></td>
+                <td><code>DecisionService</code>, <code>BudgetCycleRolloverService</code></td>
+                <td>홈·마이페이지 통계·알림</td>
+                <td>사용자 timezone 기준 월, 행 잠금과 트랜잭션으로 갱신</td>
+              </tr>
+              <tr>
+                <td>알림과 푸시 토큰</td>
+                <td><code>notifications</code>, <code>device_push_tokens</code></td>
+                <td>알림 worker·<code>NotificationPublisher</code>·<code>PushTokenService</code></td>
+                <td>알림 API·홈 요약·FCM 전송</td>
+                <td>dedupe unique index, 잘못된 FCM 토큰은 비활성화</td>
+              </tr>
+              <tr>
+                <td>브라우저 프로세스</td>
+                <td><code>BrowserPageFetcher</code> 인스턴스</td>
+                <td>지연 초기화된 Playwright/Chromium</td>
+                <td>쇼핑 링크 worker</td>
+                <td><code>browserLock</code>으로 직렬화, 종료 시 정리</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="hotspots" class="searchable deep">
+        <h2>꼭 봐야 할 코드</h2>
+        <p class="lead">줄 수가 아니라 시스템의 인과관계를 바꾸는 지점을 골랐습니다.</p>
+        <div class="hotspot">
+          <span class="badge confirmed">보안</span>
+          <div><code>ApiRateLimitFilter.doFilterInternal</code></div>
+          <div>클라이언트 IP별로 health·API·authentication·expensive request 정책을 적용하고 429와 제한 헤더를 반환합니다.</div>
+        </div>
+        <div class="hotspot">
+          <span class="badge confirmed">보안</span>
+          <div><code>SecurityConfig.securityFilterChain</code></div>
+          <div>rate limit filter 순서, 공개 경로, JWT resource server, OAuth2 login, non-prod trusted header의 경계를 결정합니다.</div>
+        </div>
+        <div class="hotspot">
+          <span class="badge confirmed">보안</span>
+          <div><code>AppAuthProperties.ReviewerToken.enabled</code></div>
+          <div><code>POST /api/auth/reviewer-token</code>은 기본 비활성화된 opt-in 경로입니다. 명시적으로 켜지 않으면 Controller가 404를 반환합니다.</div>
+        </div>
+        <div class="hotspot">
+          <span class="badge confirmed">경계</span>
+          <div><code>CurrentUserIdArgumentResolver.resolveArgument</code></div>
+          <div>JWT principal과 non-prod <code>X-User-Id</code>를 사용자 ID로 변환하고 접근 가능 상태를 검증합니다.</div>
+        </div>
+        <div class="hotspot">
+          <span class="badge confirmed">핵심 로직</span>
+          <div><code>DecisionService.complete</code></div>
+          <div>위시 잠금부터 결정·예산·자기 점검·마스코트·리마인더까지 한 흐름을 소유합니다.</div>
+        </div>
+        <div class="hotspot">
+          <span class="badge confirmed">상태</span>
+          <div><code>ShoppingImportJobWorker.claimNextJob</code></div>
+          <div><code>FOR UPDATE SKIP LOCKED</code>로 여러 worker가 같은 작업을 중복 처리하지 않도록 합니다.</div>
+        </div>
+        <div class="hotspot">
+          <span class="badge confirmed">부수 효과</span>
+          <div><code>NotificationPublisher.sendAfterCommit</code></div>
+          <div>DB 커밋 전에 푸시가 먼저 나가는 일을 막고, 커밋 후 FCM 경계로 넘어갑니다.</div>
+        </div>
+        <div class="hotspot">
+          <span class="badge confirmed">보안</span>
+          <div><code>ShoppingUrlSafety.validatePublicHost</code></div>
+          <div>loopback·site-local·link-local·IPv6 ULA 등을 막아 SSRF 범위를 줄입니다.</div>
+        </div>
+        <div class="hotspot">
+          <span class="badge confirmed">성능</span>
+          <div><code>ShoppingImportJobScheduler.processNextJob</code></div>
+          <div>claim 가능한 작업이 있을 때만 concurrency 수만큼 worker를 실행합니다. 빈 큐 polling 비용의 핵심 지점입니다.</div>
+        </div>
+        <div class="hotspot">
+          <span class="badge confirmed">오류 처리</span>
+          <div><code>PublicServerSecurityGuard.run</code></div>
+          <div>운영 위험 설정을 런타임 오류로 남겨 두지 않고 애플리케이션 시작 실패로 바꿉니다.</div>
+        </div>
+      </section>
+
+      <section id="decisions" class="searchable medium-depth">
+        <h2>설계 선택</h2>
+        <p class="lead">코드와 스키마에서 확인되는 선택과 그 대가입니다.</p>
+        <div class="grid grid-2">
+          <div class="card">
+            <span class="badge confirmed">확인됨</span>
+            <h3>인메모리 fixed-window 요청 제한</h3>
+            <p><strong>선택:</strong> 인증 필터보다 앞에서 IP·정책별 window count를 관리합니다.</p>
+            <p><strong>이유:</strong> 외부 저장소 없이 API 폭주와 고비용 import를 빠르게 완화합니다.</p>
+            <p><strong>트레이드오프:</strong> 프로세스 간 상태를 공유하지 않고 재시작 시 초기화되며 capacity 초과 시 fail-open합니다.</p>
+            <p><strong>바꿀 경우:</strong> Caddy 신뢰 경계, 429 계약, load test, Micrometer 지표를 함께 봐야 합니다.</p>
+          </div>
+          <div class="card">
+            <span class="badge confirmed">확인됨</span>
+            <h3>동기 API 위에 DB 작업 큐 재사용</h3>
+            <p><strong>선택:</strong> <code>ShoppingImportSyncService</code>가 job을 submit하고 polling합니다.</p>
+            <p><strong>이유:</strong> 동일 URL 수집 합치기, 캐시, worker 복구 로직을 한 경로로 모읍니다.</p>
+            <p><strong>트레이드오프:</strong> 동기 요청 스레드가 최대 wait timeout 동안 polling합니다.</p>
+            <p><strong>바꿀 경우:</strong> import API 계약, worker, queue capacity, 클라이언트 재시도 정책을 함께 봐야 합니다.</p>
+          </div>
+          <div class="card">
+            <span class="badge confirmed">확인됨</span>
+            <h3>결정 시 여러 상태를 한 트랜잭션에서 갱신</h3>
+            <p><strong>선택:</strong> <code>DecisionService</code>가 item·budget·self-check·mascot·reminder를 조정합니다.</p>
+            <p><strong>이유:</strong> 사용자에게 보이는 결정 결과와 파생 상태의 원자성을 지킵니다.</p>
+            <p><strong>트레이드오프:</strong> 서비스가 크고 결합도가 높아 변경 영향 범위가 넓습니다.</p>
+            <p><strong>바꿀 경우:</strong> API integration test와 DB 제약·변경 이력을 같이 검증해야 합니다.</p>
+          </div>
+          <div class="card">
+            <span class="badge confirmed">확인됨</span>
+            <h3>알림 저장 후 커밋 뒤 푸시</h3>
+            <p><strong>선택:</strong> <code>TransactionSynchronization.afterCommit</code>에서 FCM을 호출합니다.</p>
+            <p><strong>이유:</strong> DB에 없는 알림이 기기에 먼저 도착하는 불일치를 줄입니다.</p>
+            <p><strong>트레이드오프:</strong> FCM 실패가 DB 알림을 롤백하지 않으며 별도 재시도 큐는 확인되지 않습니다.</p>
+            <p><strong>확신 수준:</strong> 저장·전송 순서는 확인됨, 실패 재처리 운영 정책은 알 수 없음.</p>
+          </div>
+          <div class="card">
+            <span class="badge confirmed">확인됨</span>
+            <h3>JPA와 직접 SQL 혼용</h3>
+            <p><strong>선택:</strong> 엔티티/Repository와 <code>JdbcTemplate</code>이 함께 존재합니다.</p>
+            <p><strong>이유:</strong> 복잡한 집계·잠금·조건부 upsert는 SQL로 명시합니다.</p>
+            <p><strong>트레이드오프:</strong> 엔티티 모델만 읽으면 실제 쓰기 경로와 제약을 놓칠 수 있습니다.</p>
+            <p><strong>바꿀 경우:</strong> migration, raw SQL, JPA mapping, schema smoke test를 모두 확인해야 합니다.</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="risks" class="searchable">
+        <h2>위험 지도</h2>
+        <p class="lead">증상과 첫 조사 지점을 함께 봐야 실제 디버깅에 쓸 수 있습니다.</p>
+        <div class="filters" id="riskFilters">
+          <button class="filter active" data-risk="전체">전체</button>
+          <button class="filter" data-risk="높음">높음</button>
+          <button class="filter" data-risk="중간">중간</button>
+          <button class="filter" data-risk="낮음">낮음</button>
+        </div>
+        <div id="riskGrid" class="grid grid-2">
+          <div class="card risk-card" data-severity="높음">
+            <span class="badge high">높음 · 보안</span>
+            <h3>non-prod trusted header가 사용자 경계를 우회한다</h3>
+            <p><strong>왜 위험한가:</strong> prod profile이 빠진 공개 서버에서는 <code>X-User-Id</code>만으로 <code>/api/v1/**</code> 접근이 가능해집니다.</p>
+            <p><strong>증상:</strong> 인증 없는 요청이 사용자 데이터에 접근합니다.</p>
+            <p><strong>먼저 확인:</strong> 활성 profile, <code>SecurityConfig</code>, <code>PublicServerSecurityGuard</code>, 배포 환경변수.</p>
+          </div>
+          <div class="card risk-card" data-severity="중간">
+            <span class="badge medium">중간 · 설정</span>
+            <h3>reviewer-token은 명시적으로 다시 켤 수 있다</h3>
+            <p><strong>왜 위험한가:</strong> 기본값은 꺼졌지만 <code>APP_REVIEWER_TOKEN_ENABLED=true</code>를 주입하면 고정 심사 계정 토큰 발급 경로가 다시 열립니다.</p>
+            <p><strong>증상:</strong> <code>POST /api/auth/reviewer-token</code>이 404가 아니라 토큰 응답 또는 secret 검증 응답을 반환합니다.</p>
+            <p><strong>먼저 확인:</strong> <code>AppAuthProperties</code>, <code>application-prod.yml</code>, 실제 프로세스 환경변수, <code>AppReviewerAuthIntegrationTest</code>.</p>
+          </div>
+          <div class="card risk-card" data-severity="중간">
+            <span class="badge medium">중간 · 용량 제한</span>
+            <h3>rate limit 추적 키가 가득 차면 새 IP는 fail-open된다</h3>
+            <p><strong>왜 위험한가:</strong> <code>maxTrackedKeys</code>에 도달하고 만료 키를 지워도 공간이 없으면 새 key를 제한하지 않고 통과시킵니다.</p>
+            <p><strong>증상:</strong> overflow 경고가 보이면서 일부 새 IP 요청은 제한되지 않습니다.</p>
+            <p><strong>먼저 확인:</strong> <code>ApiRateLimitFilter.logOverflowOnce</code>, <code>APP_API_RATE_LIMIT_MAX_TRACKED_KEYS</code>, 프로세스 메모리.</p>
+          </div>
+          <div class="card risk-card" data-severity="높음">
+            <span class="badge high">높음 · 외부 의존성</span>
+            <h3>브라우저 수집은 느리고 직렬화될 수 있다</h3>
+            <p><strong>왜 위험한가:</strong> <code>BrowserPageFetcher.fetch</code> 전체가 <code>browserLock</code> 안에 있어 worker concurrency와 실제 브라우저 병렬성이 다릅니다.</p>
+            <p><strong>증상:</strong> queue wait 증가, 동기 import 504, CPU·메모리 급증.</p>
+            <p><strong>먼저 확인:</strong> import Prometheus 지표, 작업 상태, Playwright 로그, fetch timeout.</p>
+          </div>
+          <div class="card risk-card" data-severity="중간">
+            <span class="badge medium">중간 · 오류 복구</span>
+            <h3>FCM 실패는 영속 알림과 분리되어 있다</h3>
+            <p><strong>왜 위험한가:</strong> 커밋 뒤 전송 실패는 <code>notifications</code>를 되돌리지 않고 일반 실패는 로그만 남깁니다.</p>
+            <p><strong>증상:</strong> 앱 안 알림은 있지만 기기 푸시는 오지 않습니다.</p>
+            <p><strong>먼저 확인:</strong> FCM enable 설정, credentials, sender 로그, token 활성 상태.</p>
+          </div>
+          <div class="card risk-card" data-severity="중간">
+            <span class="badge medium">중간 · 데이터 무결성</span>
+            <h3>결정 변경의 영향 범위가 넓다</h3>
+            <p><strong>왜 위험한가:</strong> 결과 변경은 budget delta, item status, reminder, self-check, change log를 함께 바꿉니다.</p>
+            <p><strong>증상:</strong> 통계·홈 예산·회고 대상·리마인더가 서로 맞지 않습니다.</p>
+            <p><strong>먼저 확인:</strong> <code>DecisionService.updateResult</code>, transaction rollback, 관련 integration test.</p>
+          </div>
+          <div class="card risk-card" data-severity="중간">
+            <span class="badge medium">중간 · 숨은 결합</span>
+            <h3>raw SQL과 JPA 모델이 같은 테이블을 공유한다</h3>
+            <p><strong>왜 위험한가:</strong> 엔티티 필드 변경만으로는 SQL 문자열과 migration이 자동으로 따라오지 않습니다.</p>
+            <p><strong>증상:</strong> 시작 시 schema validate 실패 또는 특정 API에서 컬럼 오류.</p>
+            <p><strong>먼저 확인:</strong> 전체 <code>rg</code> 검색, Flyway migration, <code>DomainSchemaSmokeTest</code>.</p>
+          </div>
+          <div class="card risk-card" data-severity="중간">
+            <span class="badge medium">중간 · 분산 상태</span>
+            <h3>rate limit 상태는 프로세스 메모리에만 있다</h3>
+            <p><strong>왜 위험한가:</strong> <code>FixedWindowRateLimiter</code>의 각 애플리케이션 인스턴스가 별도 <code>ConcurrentHashMap</code>을 소유합니다.</p>
+            <p><strong>증상:</strong> 재시작 시 제한이 초기화되고 다중 인스턴스에서는 총 허용량이 늘어납니다.</p>
+            <p><strong>먼저 확인:</strong> 실행 인스턴스 수, 재시작 시각, Caddy·fail2ban 상위 제한.</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="debug" class="searchable medium-depth">
+        <h2>고장 났을 때</h2>
+        <p class="lead">증상부터 시작해 가장 짧은 근거 경로로 들어갑니다.</p>
+        <details>
+          <summary>API가 401 또는 403으로 실패한다</summary>
+          <div>
+            <ol>
+              <li><code>/health</code>로 애플리케이션 자체 상태를 분리합니다.</li>
+              <li>prod/non-prod profile과 <code>SecurityConfig</code>의 경로 규칙을 확인합니다.</li>
+              <li>JWT의 <code>issuer</code>, <code>token_type=access</code>, 만료를 확인합니다.</li>
+              <li><code>CurrentUserIdArgumentResolver</code>와 <code>UserAccessService</code>에서 사용자 상태·onboarding 차단 여부를 확인합니다.</li>
+            </ol>
+          </div>
+        </details>
+        <details>
+          <summary>쇼핑 링크 가져오기가 느리거나 504가 난다</summary>
+          <div>
+            <ol>
+              <li><code>shopping_import_jobs</code>에서 job의 <code>status</code>, <code>attempt_count</code>, <code>started_at</code>을 확인합니다.</li>
+              <li><code>ShoppingImportJobScheduler.hasClaimableJob</code>와 worker enabled/concurrency를 확인합니다.</li>
+              <li>대상 사이트별 Jsoup 응답, fallback 조건, Playwright timeout과 challenge page를 확인합니다.</li>
+              <li>동일 <code>crawl_key</code> leader/follower와 cache TTL이 기대대로 작동하는지 확인합니다.</li>
+            </ol>
+          </div>
+        </details>
+        <details>
+          <summary>결정 후 예산이나 위시 상태가 맞지 않는다</summary>
+          <div>
+            <ol>
+              <li><code>purchase_decisions</code>와 <code>saved_items.status</code>를 같은 <code>item_id</code>로 비교합니다.</li>
+              <li>해당 사용자의 timezone과 <code>budget_cycles.year_month</code>를 확인합니다.</li>
+              <li><code>purchase_decision_change_logs</code>에서 결과 변경 여부를 확인합니다.</li>
+              <li><code>DecisionApiIntegrationTest</code>와 <code>DecisionServiceUnitTest</code>로 회귀를 좁힙니다.</li>
+            </ol>
+          </div>
+        </details>
+        <details>
+          <summary>앱 알림은 보이는데 기기 푸시는 오지 않는다</summary>
+          <div>
+            <ol>
+              <li><code>notifications</code> 행이 있으면 생성 경로는 통과한 것입니다.</li>
+              <li><code>APP_PUSH_FCM_ENABLED</code>와 credentials location을 확인합니다.</li>
+              <li><code>user_profiles.notification_enabled</code>, <code>user_notification_settings.push_enabled</code>를 확인합니다.</li>
+              <li><code>device_push_tokens.is_active</code>와 FCM sender 로그를 확인합니다.</li>
+            </ol>
+          </div>
+        </details>
+        <details>
+          <summary>애플리케이션이 prod에서 시작되지 않는다</summary>
+          <div>
+            <ol>
+              <li><code>PublicServerSecurityGuard</code>의 예외 메시지를 먼저 확인합니다.</li>
+              <li><code>APP_JWT_SECRET</code> 길이와 기본값 사용 여부를 확인합니다.</li>
+              <li>localhost redirect prefix와 trusted header 설정을 확인합니다.</li>
+              <li>sync bridge/worker 조합과 browser fetch 제한값을 확인합니다.</li>
+            </ol>
+          </div>
+        </details>
+      </section>
+
+      <section id="extension" class="searchable deep">
+        <h2>기능을 더하려면</h2>
+        <p class="lead">실제 구조에 맞춘 변경 순서와 함께 확인할 경계를 제시합니다.</p>
+        <div class="grid grid-2">
+          <div class="card">
+            <h3>새 API를 추가하려면</h3>
+            <ol>
+              <li>Controller 경로와 <code>@CurrentUserId</code> 필요 여부 결정</li>
+              <li>사용자 상태·소유권 검증 위치 결정</li>
+              <li>Service 트랜잭션 경계와 SQL/JPA 접근 방식 결정</li>
+              <li>SecurityConfig 공개/인증 규칙 확인</li>
+              <li>Controller·service·integration test 추가</li>
+            </ol>
+          </div>
+          <div class="card">
+            <h3>새 데이터 필드를 추가하려면</h3>
+            <ol>
+              <li>Flyway migration을 먼저 설계</li>
+              <li>JPA entity와 raw SQL 전체 검색</li>
+              <li>request/response 계약과 null 의미 결정</li>
+              <li>기존 행 호환·index·constraint 검토</li>
+              <li><code>DomainSchemaSmokeTest</code>와 관련 API test 실행</li>
+            </ol>
+          </div>
+          <div class="card">
+            <h3>새 알림 유형을 추가하려면</h3>
+            <ol>
+              <li>발생 조건과 <code>dedupeKey</code> 의미 결정</li>
+              <li><code>NotificationChannels</code>와 DB check constraint 확인</li>
+              <li><code>NotificationPublisher</code>를 통해 저장</li>
+              <li><code>targetPath</code>와 FE 라우팅 계약 합의</li>
+              <li>worker idempotency와 FCM on/off 모두 테스트</li>
+            </ol>
+          </div>
+          <div class="card">
+            <h3>새 쇼핑몰을 지원하려면</h3>
+            <ol>
+              <li>공개 URL·redirect·DNS 안전성 확인</li>
+              <li>Jsoup으로 충분한지 Playwright fallback이 필요한지 판별</li>
+              <li>정확한 상품 title·price·image 추출 근거 추가</li>
+              <li>challenge/error shell과 최대 응답 크기 처리</li>
+              <li>site별 test fixture와 live accuracy test 범위 갱신</li>
+            </ol>
+          </div>
+        </div>
+      </section>
+
+      <section id="changes" class="searchable medium-depth">
+        <h2>이해 모델 변경 기록</h2>
+        <p class="lead">Git 이력을 그대로 옮기지 않고, 머릿속 구조를 바꾼 최근 변화만 남깁니다.</p>
+        <div class="table-wrap">
+          <table>
+            <thead><tr><th>근거</th><th>개념 변화</th><th>영향 컴포넌트</th><th>검증 근거</th></tr></thead>
+            <tbody>
+              <tr>
+                <td><code>#254 · 2026-08-13</code></td>
+                <td>reviewer-token 발급은 기본 비활성화된 opt-in 경로가 되었습니다. 심사 기능이 다시 필요할 때만 환경변수로 명시적으로 활성화합니다.</td>
+                <td><code>AppAuthProperties</code>, <code>application.yml</code>, <code>application-prod.yml</code>, <code>deploy-qa.yml</code></td>
+                <td><code>AppReviewerAuthIntegrationTest</code>, <code>PublicServerSecurityGuardTest</code></td>
+              </tr>
+              <tr>
+                <td><code>019d77c</code></td>
+                <td>모든 외부 API 요청 앞에 IP 기반 fixed-window rate limit이 추가되었습니다. 정책은 health·일반 API·인증·쇼핑 import로 구분됩니다.</td>
+                <td><code>ApiRateLimitFilter</code>, <code>ClientIpResolver</code>, <code>SecurityConfig</code></td>
+                <td><code>ApiRateLimitFilterTest</code>, <code>ApiRateLimitIntegrationTest</code></td>
+              </tr>
+              <tr>
+                <td><code>f35f03d</code></td>
+                <td>QA 백엔드는 loopback bind와 Caddy 진입 경로를 기본으로 하고 fail2ban 규칙으로 scanner·SSH 공격을 계층 차단합니다.</td>
+                <td><code>application-prod.yml</code>, <code>deploy-qa.yml</code>, <code>infra/fail2ban</code></td>
+                <td>설정·배포 코드 확인, 현재 QA 런타임 적용 여부는 알 수 없음</td>
+              </tr>
+              <tr>
+                <td><code>3dfd9d3</code></td>
+                <td>위시리스트 사용자 검증이 중복 조회가 아닌 단일 상태 판정 쿼리로 바뀌었습니다.</td>
+                <td><code>WishlistService</code></td>
+                <td><code>WishlistServiceUserValidationTest</code></td>
+              </tr>
+              <tr>
+                <td><code>60501d3</code></td>
+                <td>마이페이지 목록의 투표 조회를 batch 경로로 모으고 인덱스를 추가했습니다.</td>
+                <td><code>MypageService</code>, <code>PostVoteRepository</code></td>
+                <td><code>MypageQueryCountIntegrationTest</code>, V24 migration</td>
+              </tr>
+              <tr>
+                <td><code>4455651</code></td>
+                <td>빈 쇼핑 import queue에서는 worker async fan-out을 만들기 전에 claim 가능 여부를 확인합니다.</td>
+                <td><code>ShoppingImportJobScheduler</code>, <code>ShoppingImportJobWorker</code></td>
+                <td><code>ShoppingImportJobSchedulerTest</code></td>
+              </tr>
+              <tr>
+                <td><code>e3b5151</code></td>
+                <td>QA 배포가 이전 산출물을 보존하는 운영 흐름을 갖게 되었습니다.</td>
+                <td><code>.github/workflows/deploy-qa.yml</code></td>
+                <td>Git 변경 확인, 런타임 결과는 알 수 없음</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="memory">
+          <h3>머릿속에서 바꿔야 할 것</h3>
+          <ol>
+            <li><code>POST /api/auth/reviewer-token</code>은 더 이상 기본 공개 로그인 수단이 아니며, 명시적으로 활성화해야만 동작합니다.</li>
+            <li>외부 요청은 Controller보다 먼저 <code>ApiRateLimitFilter</code>의 IP·정책 판정을 받습니다.</li>
+            <li>애플리케이션 rate limit은 인메모리 보조 방어이며 Caddy·fail2ban을 대체하지 않습니다.</li>
+            <li>쇼핑 링크 수집은 “요청 안에서 바로 크롤링”이 아니라 DB queue가 중심인 흐름입니다.</li>
+            <li>빈 queue에서도 매 tick마다 worker future를 만들지는 않습니다.</li>
+            <li>마이페이지 성능은 JPA 호출 수뿐 아니라 batch 조회와 DB index까지 함께 봐야 합니다.</li>
+          </ol>
+        </div>
+      </section>
+
+      <section id="quiz" class="searchable">
+        <h2>이해도 점검</h2>
+        <p class="lead">파일 이름 암기가 아니라 상태 소유권과 실패 경로를 이해했는지 확인합니다.</p>
+        <div id="quizContainer"></div>
+        <div class="quiz-score">이해도 점수: <strong id="quizScore">0 / 8</strong> · <span id="quizTopic">아직 답하지 않은 문제가 있습니다.</span></div>
+      </section>
+    </main>
+
+    <aside id="contextPanel" class="context" aria-live="polite">
+      <button id="contextClose" class="context-close" type="button" aria-label="맥락 패널 닫기">×</button>
+      <h2>맥락 패널</h2>
+      <p class="hint">아키텍처 노드나 실행 단계를 선택하세요.</p>
+      <div id="contextContent" class="context-card">
+        <h3>탐색 시작</h3>
+        <p>왼쪽의 <strong>구조</strong>에서 컴포넌트를 선택하면 역할, 상태, 의존성, 위험과 근거를 볼 수 있습니다.</p>
+      </div>
+    </aside>
+  </div>
+
+  <script>
+    const components = [
+      {
+        id: "security", name: "인증·API 경계", kind: "경계",
+        summary: "rate limit 뒤에서 OAuth2, JWT, CORS, 공개 경로와 사용자 식별을 결정합니다.",
+        role: "제한을 통과한 요청이 어느 인증 방식으로 들어올 수 있는지 결정하고 UUID 사용자 컨텍스트로 바꿉니다.",
+        files: ["src/main/java/com/sagongsa/backend/config/SecurityConfig.java", "src/main/java/com/sagongsa/backend/config/AppAuthProperties.java", "src/main/java/com/sagongsa/backend/auth/CurrentUserIdArgumentResolver.java", "src/main/java/com/sagongsa/backend/auth/JwtTokenService.java", "src/main/java/com/sagongsa/backend/security/ratelimit/ApiRateLimitFilter.java"],
+        input: "HTTP 요청, OAuth2 session, Bearer JWT, non-prod X-User-Id, opt-in reviewer-token 설정",
+        output: "인증된 principal, UUID userId, access/refresh token",
+        dependencies: "Google/Kakao OAuth, Spring Security, users, refresh_tokens",
+        dependents: "모든 /api/v1 도메인 Controller",
+        state: "refresh_tokens의 revoke/만료 상태. access JWT 자체는 서버에 저장하지 않음",
+        effects: "refresh token 저장·폐기, OAuth redirect, 명시적으로 활성화된 경우 reviewer token pair 발급",
+        risk: "prod profile 누락 시 trusted header가 활성화될 수 있고 reviewer-token을 환경변수로 다시 켤 수 있음",
+        evidence: "SecurityConfig.securityFilterChain, AppAuthProperties.ReviewerToken.enabled, AuthApiController.assertReviewerTokenAllowed, JwtTokenService.refresh, CurrentUserIdArgumentResolver.resolveArgument",
+        impact: "직접 영향: 전체 API 접근 정책과 filter 순서. 간접 영향: 사용자 격리, QA 접근, FE 로그인. 확인할 테스트: ApiRateLimitIntegrationTest, AuthApiControllerTest, AppReviewerAuthIntegrationTest, CurrentUserIdArgumentResolverTest."
+      },
+      {
+        id: "rate-limit", name: "IP 기반 요청 제한", kind: "경계",
+        summary: "외부 요청을 인증보다 먼저 분류하고 fixed window 제한을 적용합니다.",
+        role: "health, 일반 API, 인증, 쇼핑 import 요청의 IP별 호출량을 제한합니다.",
+        files: ["src/main/java/com/sagongsa/backend/security/ratelimit/ApiRateLimitFilter.java", "src/main/java/com/sagongsa/backend/security/ratelimit/ClientIpResolver.java", "src/main/java/com/sagongsa/backend/security/ratelimit/FixedWindowRateLimiter.java", "src/main/java/com/sagongsa/backend/config/ApiRateLimitProperties.java"],
+        input: "HTTP method, URI, remoteAddress, loopback proxy의 X-Forwarded-For",
+        output: "통과 또는 429 application/problem+json과 Retry-After/X-RateLimit-* 헤더",
+        dependencies: "인메모리 ConcurrentHashMap, Micrometer MeterRegistry, Caddy loopback proxy",
+        dependents: "OAuth2 login, /api/**, import API, health endpoint",
+        state: "프로세스 메모리의 policy:clientIp별 Window와 최대 추적 key 수",
+        effects: "요청 조기 종료, warning/rejection 로그, app.security.rate_limit.rejected counter",
+        risk: "프로세스 재시작·다중 인스턴스에서 상태를 공유하지 않으며 key capacity 초과 시 새 key는 fail-open",
+        evidence: "ApiRateLimitFilter.doFilterInternal/policiesFor, ClientIpResolver.resolve, FixedWindowRateLimiter.acquire",
+        impact: "직접 영향: 모든 외부 API 진입과 429 계약. 간접 영향: OAuth callback, load test, proxy 신뢰 경계. 확인할 테스트: ApiRateLimitFilterTest, ApiRateLimitIntegrationTest, ClientIpResolverTest, FixedWindowRateLimiterTest."
+      },
+      {
+        id: "wishlist", name: "위시리스트·결정", kind: "도메인",
+        summary: "SavedItem을 저장하고 구매 결정과 예산·후속 상태를 함께 갱신합니다.",
+        role: "사용자의 위시 항목 생명주기와 GO/STOP 결정을 처리합니다.",
+        files: ["src/main/java/com/sagongsa/backend/wishlist/WishlistService.java", "src/main/java/com/sagongsa/backend/decision/DecisionService.java", "src/main/java/com/sagongsa/backend/domain/budget/BudgetCycleRolloverService.java"],
+        input: "WishlistItemCreateRequest, DecisionCompleteRequest, DecisionResultUpdateRequest",
+        output: "WishlistItemResponse, DecisionResultResponse",
+        dependencies: "users, saved_items, purchase_decisions, budget_cycles, self_check_*, mascot_*, reminder_schedules",
+        dependents: "홈, 마이페이지, 소셜, 회고, 알림",
+        state: "SavedItem.status, PurchaseDecision.result, 월 예산, 자기 점검 요약",
+        effects: "다수 테이블 갱신, 리마인더 예약, 마스코트 반응 생성",
+        risk: "결정 변경 시 여러 파생 상태가 함께 바뀌는 높은 결합",
+        evidence: "WishlistService.create/update/drop, DecisionService.complete/updateResult",
+        impact: "직접 영향: 위시·결정 API와 DB. 간접 영향: 홈 버블, 통계, 알림, 소셜 피드. 확인할 테스트: WishlistApiIntegrationTest, DecisionApiIntegrationTest, HomeSummaryIntegrationTest."
+      },
+      {
+        id: "import", name: "쇼핑 링크 수집", kind: "도메인",
+        summary: "URL을 정규화하고 외부 페이지에서 상품 초안을 추출합니다.",
+        role: "SHARE 링크 또는 DIRECT_INPUT을 WishlistSaveDraft로 변환합니다.",
+        files: ["src/main/java/com/sagongsa/backend/itemimport/item/ShoppingLinkImportService.java", "src/main/java/com/sagongsa/backend/itemimport/item/FallbackPageFetcher.java", "src/main/java/com/sagongsa/backend/itemimport/item/BrowserPageFetcher.java"],
+        input: "ShoppingLinkImportRequest",
+        output: "ShoppingLinkImportResponse, WishlistSaveDraft",
+        dependencies: "Jsoup, Playwright Chromium, 외부 쇼핑몰, ShoppingUrlSafety",
+        dependents: "동기 import API, ShoppingImportJobWorker",
+        state: "영속 상태 직접 소유 안 함. BrowserPageFetcher가 브라우저 인스턴스를 보유",
+        effects: "DNS 조회, 외부 HTTP/브라우저 요청, HTML 파싱",
+        risk: "사이트별 HTML 변화, challenge page, 직렬 browserLock, SSRF",
+        evidence: "ShoppingLinkImportService.importSharedLink, FallbackPageFetcher.fetch, BrowserPageFetcher.fetch",
+        impact: "직접 영향: import 성공률과 정확도. 간접 영향: queue 체류 시간, CPU·메모리. 확인할 테스트: ShoppingLinkImportServiceTest, BrowserPageFetcherTest, ShoppingUrlSafetyTest."
+      },
+      {
+        id: "jobs", name: "쇼핑 import 작업 큐", kind: "백그라운드 작업",
+        summary: "DB queue에서 작업을 claim·실행·복구·정리하고 동일 crawl을 공유합니다.",
+        role: "느린 외부 수집의 동시성, capacity, 재사용, 실패 상태를 관리합니다.",
+        files: ["src/main/java/com/sagongsa/backend/itemimport/job/ShoppingImportJobService.java", "src/main/java/com/sagongsa/backend/itemimport/job/ShoppingImportJobWorker.java", "src/main/java/com/sagongsa/backend/itemimport/job/ShoppingImportJobScheduler.java"],
+        input: "job submit, scheduled tick",
+        output: "PENDING/RUNNING/SUCCEEDED/FAILED, result_json 또는 error",
+        dependencies: "shopping_import_jobs, ShoppingLinkImportService, TaskScheduler, Executor",
+        dependents: "import-link 동기 브리지, import-jobs API, Prometheus metrics",
+        state: "shopping_import_jobs가 최종 소유. leader/follower와 crawl_key로 공유",
+        effects: "행 잠금, 외부 crawl, stale recovery, retention cleanup",
+        risk: "queue backlog, worker 중단, follower 상태 동기화, 동기 polling timeout",
+        evidence: "ShoppingImportJobService.submit, ShoppingImportJobWorker.claimNextJob, ShoppingImportJobScheduler.processNextJob",
+        impact: "직접 영향: 모든 링크 수집 API. 간접 영향: DB 부하, 외부 사이트 요청량, 응답 지연. 확인할 테스트: ShoppingImportJobApiIntegrationTest, ShoppingImportJobSchedulerTest."
+      },
+      {
+        id: "notification", name: "알림·리마인더·푸시", kind: "백그라운드 작업",
+        summary: "도메인 조건을 찾아 알림을 저장하고 커밋 뒤 FCM으로 보냅니다.",
+        role: "예약 리마인더와 주기적 조건 알림을 idempotent하게 생성합니다.",
+        files: ["src/main/java/com/sagongsa/backend/notification/NotificationTriggerWorker.java", "src/main/java/com/sagongsa/backend/notification/ReminderNotificationWorker.java", "src/main/java/com/sagongsa/backend/notification/NotificationPublisher.java", "src/main/java/com/sagongsa/backend/notification/PushNotificationService.java"],
+        input: "scheduled tick, NotificationPublishRequest, reminder_schedules",
+        output: "notifications 행, 선택적 FCM message",
+        dependencies: "notifications, reminder_schedules, device_push_tokens, Firebase FCM",
+        dependents: "알림 API, 홈 요약, 모바일 클라이언트",
+        state: "알림 읽음 상태·dedupe, reminder status, push token 활성 상태",
+        effects: "DB insert/update, FCM 외부 전송, 잘못된 토큰 비활성화",
+        risk: "FCM 일반 실패의 자동 재시도 경로가 코드에서 확인되지 않음",
+        evidence: "NotificationPublisher.publish/sendAfterCommit, PushNotificationService.send",
+        impact: "직접 영향: 인앱 알림과 푸시. 간접 영향: 사용자 재방문, FE targetPath 계약. 확인할 테스트: NotificationTriggerWorkerIntegrationTest, PushNotificationServiceTest."
+      },
+      {
+        id: "social", name: "소셜 피드", kind: "도메인",
+        summary: "위시·결정에 연결된 게시물, 투표, 댓글, 신고와 차단을 다룹니다.",
+        role: "사용자가 위시 고민을 공유하고 다른 사용자의 반응을 받는 흐름을 제공합니다.",
+        files: ["src/main/java/com/sagongsa/backend/social/SocialPostService.java", "src/main/resources/static/app.html", "src/main/java/com/sagongsa/backend/social/VoteService.java", "src/main/java/com/sagongsa/backend/social/CommentService.java", "src/main/java/com/sagongsa/backend/social/ReportService.java"],
+        input: "게시물·투표·댓글·신고 API 요청",
+        output: "feed_posts, post_votes, post_comments, post_reports",
+        dependencies: "users, saved_items, purchase_decisions, FileUploadService",
+        dependents: "소셜 API, 마이페이지, 24시간/7일 알림 trigger",
+        state: "게시물 moderation/deleted, 활성 투표, soft-deleted 댓글, 차단 관계",
+        effects: "파일 저장, DB 변경, 신고 누적에 따른 moderation, app.html DOM 렌더링",
+        risk: "soft delete·moderation·block 조건과 사용자 입력의 출력 인코딩을 조회·렌더링마다 일관되게 적용해야 함",
+        evidence: "SocialFeedController, SocialPostService, app.html#renderFeedCard, VoteService, BlockService",
+        impact: "직접 영향: 피드 노출과 상호작용. 간접 영향: 소셜 알림, 마이페이지 목록, 신고 제재, 정적 웹 화면 보안. 확인할 테스트: SocialFeedApiIntegrationTest, VoteIntegrationTest, UserReportApiIntegrationTest."
+      },
+      {
+        id: "database", name: "PostgreSQL·Flyway", kind: "데이터",
+        summary: "사용자별 영속 상태, 제약, 잠금과 조회 성능의 최종 기준입니다.",
+        role: "도메인 상태와 비동기 작업 상태를 영속화하고 일관성을 제약으로 보장합니다.",
+        files: ["src/main/resources/db/migration/V1__domain_schema_baseline.sql", "src/main/resources/db/migration/V22__add_shopping_import_jobs.sql", "src/main/resources/db/migration/V23__add_shopping_import_shared_crawl.sql", "src/main/resources/db/migration/V24__add_post_votes_user_active_created_index.sql"],
+        input: "JPA와 JdbcTemplate query/update",
+        output: "영속 행, unique/check/FK 위반, 잠금 결과",
+        dependencies: "PostgreSQL",
+        dependents: "사실상 모든 도메인 서비스와 worker",
+        state: "users, saved_items, purchase_decisions, budget_cycles, notifications, shopping_import_jobs 등",
+        effects: "트랜잭션, row/advisory lock, Flyway migration",
+        risk: "raw SQL과 entity mapping의 drift, migration 순서, index 누락",
+        evidence: "application.yml ddl-auto=validate, V1~V24 migrations, DomainSchemaSmokeTest",
+        impact: "직접 영향: 전체 영속 계약. 간접 영향: API 성능과 worker 동시성. 확인할 테스트: DomainSchemaSmokeTest, PostgreSqlContainerTest, 전체 integration test."
+      },
+      {
+        id: "external", name: "외부 제공자", kind: "외부 시스템",
+        summary: "Google/Kakao, 쇼핑몰, Firebase가 신뢰 경계 밖에서 동작합니다.",
+        role: "사용자 신원, 상품 원문, 기기 푸시 전달을 제공합니다.",
+        files: ["src/main/resources/application.yml", "src/main/java/com/sagongsa/backend/config/FirebasePushConfig.java"],
+        input: "OAuth authorization, HTTP/browser fetch, FCM send",
+        output: "OAuth profile, HTML/redirect, FCM 결과",
+        dependencies: "네트워크·provider 설정·credentials",
+        dependents: "인증, 쇼핑 import, push notification",
+        state: "서버가 최종 소유하지 않는 provider 계정·페이지·기기 전달 상태",
+        effects: "외부 호출과 실패·rate limit·HTML 변화",
+        risk: "내부 테스트가 외부 제공자의 현재 동작을 완전히 보장하지 못함",
+        evidence: "application.yml provider URI, BrowserPageFetcher, FirebaseFcmMessageSender",
+        impact: "직접 영향: 로그인·수집·푸시. 간접 영향: 사용자 온보딩과 알림 신뢰성. 확인할 테스트: provider별 설정 test와 live smoke는 별도 필요."
+      }
+    ];
+
+    const flows = [
+      {
+        id: "ingress", name: "외부 요청 → rate limit → 인증",
+        steps: [
+          ["요청 도착", "Caddy → loopback backend", "외부 HTTP 요청", "운영 백엔드는 기본적으로 127.0.0.1에 bind되고 Caddy가 요청을 전달합니다.", "remoteAddress와 X-Forwarded-For가 있는 servlet request", "Caddy·fail2ban 경계", "ApiRateLimitFilter"],
+          ["클라이언트 IP 결정", "ClientIpResolver.resolve", "remoteAddress, X-Forwarded-For", "직접 접속이면 remoteAddress를 사용하고 loopback proxy일 때만 첫 forwarded IP를 신뢰합니다.", "ClientIp(address, internal)", "DNS 조회 없이 IP literal만 정규화", "정책 선택"],
+          ["정책 중첩", "ApiRateLimitFilter.policiesFor", "method, requestURI", "health·일반 API·인증·고비용 import 중 해당하는 정책을 모두 고릅니다.", "Policy 목록", "없음", "fixed window 획득"],
+          ["호출량 판정", "FixedWindowRateLimiter.acquire", "policy:clientIp key", "현재 window count를 늘리고 한도·80% 경고·key capacity를 판정합니다.", "통과 또는 거부 결정", "프로세스 메모리 갱신, metric/log", "SecurityFilterChain 또는 429"],
+          ["인증·Controller", "SecurityConfig.securityFilterChain", "제한을 통과한 요청", "OAuth2/JWT/공개 경로 규칙을 적용한 뒤 Controller로 전달합니다.", "API 응답", "인증과 도메인 부수 효과", "클라이언트"]
+        ]
+      },
+      {
+        id: "auth", name: "OAuth 로그인 → 앱 JWT",
+        steps: [
+          ["OAuth 시작", "SecurityConfig.authorizationRequestResolver", "provider와 redirect_uri", "허용 redirect URI를 session에 보관하고 provider별 prompt를 추가합니다.", "OAuth authorization request", "HTTP redirect", "OAuth 제공자"],
+          ["Provider 인증", "Google/Kakao", "사용자 동의·로그인", "외부 제공자가 authorization code를 callback으로 돌려줍니다.", "authorization code", "외부 네트워크", "CustomOAuth2UserService"],
+          ["계정 연결", "CustomOAuth2UserService → SocialAccountLinkService", "OAuth2User attributes", "provider profile을 내부 user/social account와 연결합니다.", "SocialOAuth2User", "users·social_accounts 쓰기 가능", "SuccessHandler"],
+          ["토큰 발급", "OAuth2AppAuthenticationSuccessHandler → JwtTokenService.issueTokenPair", "SocialUserProfile, authorities", "access/refresh JWT를 만들고 refresh hash를 저장합니다.", "TokenPair", "refresh_tokens insert", "앱 callback"],
+          ["앱 복귀", "AppRedirectUriSupport.buildSuccessRedirectUri", "허용된 앱 redirect URI와 TokenPair", "앱이 소비할 callback URI로 redirect합니다.", "accessToken, refreshToken", "민감 정보가 redirect URI에 포함됨", "클라이언트 저장·API 호출"]
+        ]
+      },
+      {
+        id: "import", name: "동기 쇼핑 링크 가져오기",
+        steps: [
+          ["요청 수신", "ItemImportController.importLink", "userId, ShoppingLinkImportRequest", "사용자 컨텍스트와 요청을 동기 브리지로 전달합니다.", "service call", "request log context", "ShoppingImportSyncService"],
+          ["작업 등록", "ShoppingImportJobService.submit", "userId, request", "중복 요청·동일 crawl leader·cache를 확인하고 job을 생성 또는 재사용합니다.", "jobId, PENDING 또는 재사용 상태", "shopping_import_jobs insert/lock", "Scheduler"],
+          ["작업 claim", "ShoppingImportJobWorker.claimNextJob", "PENDING leader job", "FOR UPDATE SKIP LOCKED로 한 worker가 RUNNING 상태를 소유합니다.", "ClaimedJob", "leader와 follower 상태 갱신", "ShoppingLinkImportService"],
+          ["페이지 수집", "FallbackPageFetcher → BrowserPageFetcher", "정규화된 공개 URL", "HTTP 우선 수집 후 상태·error shell에 따라 브라우저 fallback을 사용합니다.", "FetchedPage", "외부 HTTP·Chromium", "메타데이터 추출"],
+          ["초안 생성", "ShoppingLinkImportService.importSharedLink", "FetchedPage HTML", "title·price·image·category를 검증·정규화해 save draft를 만듭니다.", "ShoppingLinkImportResponse", "영속 저장 없음", "worker 결과 저장"],
+          ["작업 완료", "ShoppingImportJobWorker.markSucceeded", "result_json", "leader와 follower를 SUCCEEDED로 바꿉니다.", "terminal job state", "shopping_import_jobs update", "동기 polling"],
+          ["응답 반환", "ShoppingImportSyncService.importLink", "SUCCEEDED job", "polling 중 결과를 발견해 기존 동기 API 응답으로 반환합니다.", "200 ShoppingLinkImportResponse", "대기 중 request thread 사용", "클라이언트"]
+        ]
+      },
+      {
+        id: "decision", name: "위시 저장 → 구매 결정",
+        steps: [
+          ["위시 저장", "WishlistService.create", "WishlistItemCreateRequest, Idempotency-Key", "사용자 상태·필드·중복 URL을 검증하고 saved_items를 만듭니다.", "WishlistItemResponse", "saved_items, item_source_metadata insert", "결정 API"],
+          ["결정 검증", "DecisionService.complete", "DecisionCompleteRequest", "사용자와 위시 행을 잠그고 기존 결정·SAVED 상태를 확인합니다.", "정규화된 결정", "saved_items row lock", "예산 계산"],
+          ["월 예산 확보", "BudgetCycleRolloverService.ensureBudgetCycle", "userId, yearMonth", "현재 월이 없으면 가장 최근 과거 예산을 복사하고 spent를 0으로 시작합니다.", "budget cycle", "budget_cycles insert 가능", "결정 저장"],
+          ["결정 저장", "DecisionService.insertDecision + insertSelfCheck", "GO/STOP, finalPrice, 답변", "결정과 자기 점검 요약·상세를 저장합니다.", "purchase decision", "purchase_decisions, self_check_* insert", "파생 상태"],
+          ["파생 상태 갱신", "DecisionService", "결정 결과", "SavedItem 상태, GO 예산 지출, mascot reaction, regret reminder를 조정합니다.", "DecisionResultResponse 구성 요소", "여러 테이블 update/insert", "응답"],
+          ["결과 반환", "DecisionController.complete", "완료된 트랜잭션", "예산 소진·마스코트·리마인더를 포함한 결과를 반환합니다.", "DecisionResultResponse", "트랜잭션 commit", "홈·마이페이지·후속 알림"]
+        ]
+      },
+      {
+        id: "push", name: "예약 조건 → 인앱 알림 → FCM",
+        steps: [
+          ["주기 실행", "NotificationTriggerScheduler 또는 ReminderNotificationScheduler", "scheduled tick", "기한이 된 조건이나 reminder를 worker에 위임합니다.", "worker call", "scheduler thread", "대상 조회"],
+          ["대상 선택", "NotificationTriggerWorker / ReminderNotificationWorker", "현재 시각·DB 상태", "활성 사용자, 설정, 기존 알림, 기한을 기준으로 대상을 찾습니다.", "NotificationPublishRequest", "DB read, reminder row lock 가능", "NotificationPublisher"],
+          ["중복 방지 저장", "NotificationPublisher.publish", "userId, type, dedupeKey", "unique 조건과 ON CONFLICT DO NOTHING으로 인앱 알림을 한 번만 저장합니다.", "created 또는 duplicate", "notifications insert", "commit"],
+          ["커밋 뒤 전송", "NotificationPublisher.sendAfterCommit", "NotificationPushMessage", "DB 트랜잭션이 성공한 뒤 push service를 호출합니다.", "push send call", "DB와 외부 전송 경계 분리", "PushNotificationService"],
+          ["설정·토큰 확인", "PushNotificationService.send", "userId, message", "사용자 push 설정과 활성 device token을 조회합니다.", "FcmSendRequest 목록", "DB read", "FirebaseFcmMessageSender"],
+          ["FCM 결과 처리", "FirebaseFcmMessageSender.send", "token, title, body, data", "Firebase로 보내고 invalid token이면 비활성화합니다.", "success/invalid/failed", "외부 FCM, device_push_tokens update 가능", "모바일 기기"]
+        ]
+      },
+      {
+        id: "social", name: "소셜 게시물 → 투표 요약 알림",
+        steps: [
+          ["게시물 생성", "SocialFeedController → SocialPostService", "CreatePostRequest, userId", "소유권과 대상 item/decision을 검증하고 feed post를 저장합니다.", "PostResponse", "feed_posts insert", "피드 조회"],
+          ["투표", "VoteService", "postId, voteType, voter", "기존 활성 투표를 취소하거나 새 투표를 저장합니다.", "VoteResponse", "post_votes insert/update", "24시간 경과"],
+          ["요약 대상 조회", "NotificationTriggerWorker.publishVoteSummaries", "now", "24시간 내 활성 투표 수와 아직 알리지 않은 post를 찾습니다.", "VotePostTarget", "집계 query", "NotificationPublisher"],
+          ["알림 생성", "NotificationPublisher.publish", "SOCIAL_VOTE_SUMMARY, post dedupeKey", "인앱 알림을 중복 없이 저장하고 커밋 뒤 푸시합니다.", "notification", "notifications insert, 선택적 FCM", "게시물 작성자"]
+        ]
+      }
+    ];
+
+    const quiz = [
+      {
+        q: "외부 /api 요청이 JWT 인증보다 먼저 통과해야 하는 애플리케이션 경계는?",
+        choices: ["ApiRateLimitFilter", "DecisionService", "Flyway migration"],
+        answer: 0,
+        why: "SecurityConfig는 ApiRateLimitFilter를 OAuth2AuthorizationRequestRedirectFilter보다 앞에 배치합니다.",
+        topic: "보안 경계"
+      },
+      {
+        q: "동기 쇼핑 링크 API가 기본 설정에서 실제 크롤링을 시작하기 전에 거치는 핵심 상태 저장소는?",
+        choices: ["HTTP session", "shopping_import_jobs", "saved_items"],
+        answer: 1,
+        why: "ShoppingImportSyncService는 job을 submit하고 shopping_import_jobs 상태를 polling합니다.",
+        topic: "실행 흐름"
+      },
+      {
+        q: "구매 결정을 완료할 때 DecisionService가 함께 바꾸지 않는 것은?",
+        choices: ["월 예산", "SavedItem 상태", "OAuth provider 계정"],
+        answer: 2,
+        why: "결정 흐름은 item·budget·self-check·mascot·reminder를 바꾸지만 외부 OAuth 계정은 건드리지 않습니다.",
+        topic: "상태 소유권"
+      },
+      {
+        q: "알림 DB 저장이 실패했는데 FCM이 먼저 전송되는 일을 막는 경계는?",
+        choices: ["afterCommit callback", "fixedDelay scheduler", "CORS filter"],
+        answer: 0,
+        why: "NotificationPublisher는 TransactionSynchronization.afterCommit에서 push service를 호출합니다.",
+        topic: "실패 동작"
+      },
+      {
+        q: "prod가 아닌 profile에서 사용자 인증 경계를 특별히 조심해야 하는 이유는?",
+        choices: ["Flyway가 꺼지기 때문", "trusted X-User-Id 경로가 활성화되기 때문", "FCM이 항상 켜지기 때문"],
+        answer: 1,
+        why: "SecurityConfig와 CurrentUserIdArgumentResolver는 non-prod에서 trusted header를 허용합니다.",
+        topic: "보안 경계"
+      },
+      {
+        q: "여러 shopping import worker가 같은 PENDING leader job을 동시에 가져가지 않게 하는 핵심 SQL 동작은?",
+        choices: ["ON DELETE CASCADE", "FOR UPDATE SKIP LOCKED", "GROUP BY"],
+        answer: 1,
+        why: "claimNextJob은 후보 행을 FOR UPDATE SKIP LOCKED로 고른 뒤 RUNNING으로 바꿉니다.",
+        topic: "동시성"
+      },
+      {
+        q: "앱 안에는 알림이 있지만 기기 푸시가 없다면 가장 먼저 분리해서 봐야 할 경계는?",
+        choices: ["notifications 저장과 FCM 전송", "saved_items와 budget_cycles", "OAuth와 Flyway"],
+        answer: 0,
+        why: "인앱 알림은 DB에 먼저 저장되고 FCM은 커밋 뒤 별도 외부 호출이므로 두 경계의 성공 여부가 다를 수 있습니다.",
+        topic: "디버깅"
+      },
+      {
+        q: "새 DB 컬럼을 추가할 때 JPA entity만 수정하면 위험한 가장 직접적인 이유는?",
+        choices: ["이 프로젝트는 raw SQL과 Flyway migration도 같은 테이블 계약을 사용하기 때문", "모든 API가 GraphQL이기 때문", "PostgreSQL을 사용하지 않기 때문"],
+        answer: 0,
+        why: "JdbcTemplate SQL, JPA mapping, Flyway migration이 함께 존재하므로 전체 검색과 스키마 검증이 필요합니다.",
+        topic: "확장 경로"
+      }
+    ];
+
+    const architectureGrid = document.getElementById("architectureGrid");
+    const contextContent = document.getElementById("contextContent");
+    const contextPanel = document.getElementById("contextPanel");
+    let selectedComponent = null;
+
+    function renderArchitecture(filter = "전체") {
+      architectureGrid.innerHTML = "";
+      components.filter(component => filter === "전체" || component.kind === filter).forEach(component => {
+        const node = document.createElement("article");
+        node.className = "node searchable";
+        node.dataset.id = component.id;
+        node.innerHTML = `<div class="kind">${component.kind}</div><h3>${component.name}</h3><p>${component.summary}</p><span class="badge confirmed">확인됨</span>`;
+        node.addEventListener("click", () => selectComponent(component.id));
+        architectureGrid.appendChild(node);
+      });
+    }
+
+    function selectComponent(id) {
+      selectedComponent = components.find(component => component.id === id);
+      contextPanel.classList.add("open");
+      document.querySelectorAll(".node").forEach(node => node.classList.toggle("selected", node.dataset.id === id));
+      const fileList = selectedComponent.files.map(file => `<li><code>${file}</code></li>`).join("");
+      contextContent.innerHTML = `
+        <span class="badge confirmed">확인됨</span>
+        <h3>${selectedComponent.name}</h3>
+        <dl>
+          <dt>역할</dt><dd>${selectedComponent.role}</dd>
+          <dt>입력</dt><dd>${selectedComponent.input}</dd>
+          <dt>출력</dt><dd>${selectedComponent.output}</dd>
+          <dt>의존 대상</dt><dd>${selectedComponent.dependencies}</dd>
+          <dt>의존하는 쪽</dt><dd>${selectedComponent.dependents}</dd>
+          <dt>소유 상태</dt><dd>${selectedComponent.state}</dd>
+          <dt>부수 효과</dt><dd>${selectedComponent.effects}</dd>
+          <dt>위험</dt><dd>${selectedComponent.risk}</dd>
+          <dt>근거</dt><dd>${selectedComponent.evidence}</dd>
+        </dl>
+        <h3>관련 파일</h3>
+        <ul>${fileList}</ul>
+        <button class="what-if" type="button" id="whatIfButton">이걸 바꾸면?</button>
+        <div id="whatIfResult"></div>
+      `;
+      document.getElementById("whatIfButton").addEventListener("click", () => {
+        document.getElementById("whatIfResult").innerHTML = `
+          <div class="context-card">
+            <h3>변경 영향</h3>
+            <p>${selectedComponent.impact}</p>
+            <p><span class="badge confirmed">확신 수준 · 확인됨</span></p>
+          </div>
+        `;
+      });
+    }
+
+    document.getElementById("contextClose").addEventListener("click", () => {
+      contextPanel.classList.remove("open");
+    });
+
+    document.getElementById("architectureFilters").addEventListener("click", event => {
+      const button = event.target.closest("[data-filter]");
+      if (!button) return;
+      document.querySelectorAll("#architectureFilters .filter").forEach(item => item.classList.remove("active"));
+      button.classList.add("active");
+      renderArchitecture(button.dataset.filter);
+    });
+
+    let currentFlow = 0;
+    let currentStep = 0;
+    let autoTimer = null;
+    const flowList = document.getElementById("flowList");
+    const flowTrack = document.getElementById("flowTrack");
+    const stepDetail = document.getElementById("stepDetail");
+
+    function renderFlowList() {
+      flowList.innerHTML = flows.map((flow, index) =>
+        `<button type="button" data-flow="${index}" class="${index === currentFlow ? "active" : ""}">${flow.name}</button>`
+      ).join("");
+      flowList.querySelectorAll("button").forEach(button => button.addEventListener("click", () => {
+        currentFlow = Number(button.dataset.flow);
+        currentStep = 0;
+        stopAuto();
+        renderFlow();
+      }));
+    }
+
+    function renderFlow() {
+      renderFlowList();
+      const flow = flows[currentFlow];
+      flowTrack.innerHTML = flow.steps.map((step, index) =>
+        `<div class="flow-step ${index < currentStep ? "done" : ""} ${index === currentStep ? "active" : ""}"><strong>${step[0]}</strong><br>${step[1]}</div>`
+      ).join("");
+      const step = flow.steps[currentStep];
+      stepDetail.innerHTML = `
+        <span class="badge confirmed">확인됨</span>
+        <h3>${currentStep + 1}. ${step[0]}</h3>
+        <dl>
+          <dt>현재 위치</dt><dd>${step[1]}</dd>
+          <dt>실행 코드</dt><dd><code>${step[1]}</code></dd>
+          <dt>들어오는 데이터</dt><dd>${step[2]}</dd>
+          <dt>하는 일</dt><dd>${step[3]}</dd>
+          <dt>나가는 데이터</dt><dd>${step[4]}</dd>
+          <dt>부수 효과</dt><dd>${step[5]}</dd>
+          <dt>다음 단계</dt><dd>${step[6]}</dd>
+        </dl>
+      `;
+      const active = flowTrack.querySelector(".active");
+      if (active) active.scrollIntoView({behavior: "smooth", block: "nearest", inline: "center"});
+    }
+
+    function stopAuto() {
+      if (autoTimer) window.clearInterval(autoTimer);
+      autoTimer = null;
+      document.getElementById("flowAuto").textContent = "자동 재생";
+    }
+
+    document.getElementById("flowFirst").addEventListener("click", () => { currentStep = 0; renderFlow(); });
+    document.getElementById("flowPrev").addEventListener("click", () => { currentStep = Math.max(0, currentStep - 1); renderFlow(); });
+    document.getElementById("flowNext").addEventListener("click", () => {
+      currentStep = Math.min(flows[currentFlow].steps.length - 1, currentStep + 1);
+      renderFlow();
+    });
+    document.getElementById("flowReset").addEventListener("click", () => { stopAuto(); currentFlow = 0; currentStep = 0; renderFlow(); });
+    document.getElementById("flowAuto").addEventListener("click", () => {
+      if (autoTimer) { stopAuto(); return; }
+      document.getElementById("flowAuto").textContent = "정지";
+      autoTimer = window.setInterval(() => {
+        if (currentStep >= flows[currentFlow].steps.length - 1) {
+          stopAuto();
+        } else {
+          currentStep += 1;
+          renderFlow();
+        }
+      }, 1800);
+    });
+
+    document.getElementById("riskFilters").addEventListener("click", event => {
+      const button = event.target.closest("[data-risk]");
+      if (!button) return;
+      document.querySelectorAll("#riskFilters .filter").forEach(item => item.classList.remove("active"));
+      button.classList.add("active");
+      document.querySelectorAll(".risk-card").forEach(card => {
+        card.classList.toggle("hidden", button.dataset.risk !== "전체" && card.dataset.severity !== button.dataset.risk);
+      });
+    });
+
+    const answered = new Map();
+    function renderQuiz() {
+      const container = document.getElementById("quizContainer");
+      container.innerHTML = quiz.map((item, questionIndex) => `
+        <article class="quiz-question">
+          <h3>${questionIndex + 1}. ${item.q}</h3>
+          ${item.choices.map((choice, choiceIndex) =>
+            `<button type="button" class="choice" data-question="${questionIndex}" data-choice="${choiceIndex}">${choice}</button>`
+          ).join("")}
+          <div class="feedback" id="feedback-${questionIndex}"></div>
+        </article>
+      `).join("");
+      container.querySelectorAll(".choice").forEach(button => button.addEventListener("click", answerQuiz));
+    }
+
+    function answerQuiz(event) {
+      const questionIndex = Number(event.currentTarget.dataset.question);
+      const choiceIndex = Number(event.currentTarget.dataset.choice);
+      const item = quiz[questionIndex];
+      answered.set(questionIndex, choiceIndex === item.answer);
+      const question = event.currentTarget.closest(".quiz-question");
+      question.querySelectorAll(".choice").forEach(button => {
+        button.disabled = true;
+        const value = Number(button.dataset.choice);
+        if (value === item.answer) button.classList.add("correct");
+        else if (value === choiceIndex) button.classList.add("wrong");
+      });
+      const feedback = document.getElementById(`feedback-${questionIndex}`);
+      feedback.style.display = "block";
+      feedback.innerHTML = `<strong>${choiceIndex === item.answer ? "정답" : "다시 확인해보세요"}</strong><br>${item.why}`;
+      updateScore();
+    }
+
+    function updateScore() {
+      const score = [...answered.values()].filter(Boolean).length;
+      document.getElementById("quizScore").textContent = `${score} / ${quiz.length}`;
+      const missingTopics = quiz.filter((item, index) => !answered.get(index)).map(item => item.topic);
+      document.getElementById("quizTopic").textContent = missingTopics.length
+        ? `다시 볼 주제: ${[...new Set(missingTopics)].join(", ")}`
+        : "핵심 인과관계를 모두 이해했습니다.";
+    }
+
+    document.getElementById("depthSelect").addEventListener("change", event => {
+      document.body.dataset.depth = event.target.value;
+    });
+
+    document.getElementById("themeButton").addEventListener("click", () => {
+      const next = document.documentElement.dataset.theme === "dark" ? "light" : "dark";
+      document.documentElement.dataset.theme = next;
+      localStorage.setItem("understanding-theme", next);
+    });
+
+    const savedTheme = localStorage.getItem("understanding-theme");
+    if (savedTheme) document.documentElement.dataset.theme = savedTheme;
+
+    document.getElementById("searchInput").addEventListener("input", event => {
+      const query = event.target.value.trim().toLowerCase();
+      document.querySelectorAll(".search-hit").forEach(element => element.classList.remove("search-hit"));
+      if (!query) return;
+      const candidate = [...document.querySelectorAll(".searchable, .node, .card, details, .hotspot")]
+        .find(element => element.textContent.toLowerCase().includes(query));
+      if (candidate) {
+        candidate.classList.add("search-hit");
+        candidate.scrollIntoView({behavior: "smooth", block: "center"});
+      }
+    });
+
+    const sections = [...document.querySelectorAll("main section")];
+    const navLinks = [...document.querySelectorAll(".sidebar a")];
+    const observer = new IntersectionObserver(entries => {
+      const visible = entries.filter(entry => entry.isIntersecting).sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+      if (!visible) return;
+      navLinks.forEach(link => link.classList.toggle("active", link.getAttribute("href") === `#${visible.target.id}`));
+    }, {rootMargin: "-20% 0px -65% 0px", threshold: [0, .2, .6]});
+    sections.forEach(section => observer.observe(section));
+
+    renderArchitecture();
+    renderFlow();
+    renderQuiz();
+  </script>
+</body>
+</html>

--- a/src/main/java/com/sagongsa/backend/config/AppAuthProperties.java
+++ b/src/main/java/com/sagongsa/backend/config/AppAuthProperties.java
@@ -63,7 +63,7 @@ public class AppAuthProperties {
 
 	public static class ReviewerToken {
 
-		private boolean enabled = true;
+		private boolean enabled;
 		private boolean requireSecret;
 		private String secret = "";
 		private int rateLimitMaxAttempts = 10;

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -14,7 +14,7 @@ app:
     trusted-user-id-header:
       enabled: false
     reviewer-token:
-      enabled: ${APP_REVIEWER_TOKEN_ENABLED:true}
+      enabled: ${APP_REVIEWER_TOKEN_ENABLED:false}
       require-secret: ${APP_REVIEWER_TOKEN_REQUIRE_SECRET:false}
       secret: ${APP_REVIEWER_TOKEN_SECRET:}
   shopping:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,7 +76,7 @@ app:
     refresh-token-ttl: ${APP_REFRESH_TOKEN_TTL:P30D}
     allowed-redirect-uri-prefixes: ${APP_ALLOWED_REDIRECT_URI_PREFIXES:sagongsa404://auth/callback,http://localhost/auth/callback,http://127.0.0.1/auth/callback,https://localhost/auth/callback,https://127.0.0.1/auth/callback}
     reviewer-token:
-      enabled: ${APP_REVIEWER_TOKEN_ENABLED:true}
+      enabled: ${APP_REVIEWER_TOKEN_ENABLED:false}
       require-secret: ${APP_REVIEWER_TOKEN_REQUIRE_SECRET:false}
       secret: ${APP_REVIEWER_TOKEN_SECRET:}
       rate-limit-max-attempts: ${APP_REVIEWER_TOKEN_RATE_LIMIT_MAX_ATTEMPTS:10}

--- a/src/test/java/com/sagongsa/backend/auth/AppReviewerAuthIntegrationTest.java
+++ b/src/test/java/com/sagongsa/backend/auth/AppReviewerAuthIntegrationTest.java
@@ -28,6 +28,7 @@ import org.springframework.test.web.servlet.MvcResult;
 	"app.auth.trusted-user-id-header.enabled=false",
 	"app.auth.jwt-secret=test-jwt-secret-for-private-test-security-checks",
 	"app.auth.allowed-redirect-uri-prefixes=sagongsa404://auth/callback",
+	"app.auth.reviewer-token.enabled=true",
 	"app.auth.reviewer-token.secret=test-reviewer-token-secret-for-private-test",
 	"app.shopping.import.browser-fetch.enabled=true"
 })
@@ -100,7 +101,16 @@ class AppReviewerAuthIntegrationTest extends PostgreSqlContainerTest {
 
 	@AfterEach
 	void restoreReviewerTokenConfiguration() {
+		appAuthProperties.getReviewerToken().setEnabled(true);
 		appAuthProperties.getReviewerToken().setRequireSecret(false);
+	}
+
+	@Test
+	void returnsNotFoundWhenReviewerTokenIsDisabled() throws Exception {
+		appAuthProperties.getReviewerToken().setEnabled(false);
+
+		mockMvc.perform(post("/api/auth/reviewer-token"))
+			.andExpect(status().isNotFound());
 	}
 
 	@Test

--- a/src/test/java/com/sagongsa/backend/config/PublicServerSecurityGuardTest.java
+++ b/src/test/java/com/sagongsa/backend/config/PublicServerSecurityGuardTest.java
@@ -1,5 +1,6 @@
 package com.sagongsa.backend.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -9,6 +10,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
 
 class PublicServerSecurityGuardTest {
+
+	@Test
+	void reviewerTokenIsDisabledByDefault() {
+		AppAuthProperties authProperties = new AppAuthProperties();
+
+		assertThat(authProperties.getReviewerToken().isEnabled()).isFalse();
+	}
 
 	@Test
 	void acceptsPrivateTestSafeProdSettings() {
@@ -110,6 +118,7 @@ class PublicServerSecurityGuardTest {
 		AppAuthProperties authProperties = new AppAuthProperties();
 		authProperties.setJwtSecret("private-test-jwt-secret-with-strong-length");
 		authProperties.setAllowedRedirectUriPrefixes(List.of("sagongsa404://auth/callback"));
+		authProperties.getReviewerToken().setEnabled(true);
 		authProperties.getReviewerToken().setRequireSecret(true);
 		authProperties.getReviewerToken().setSecret("private-test-reviewer-token-secret-long");
 		return authProperties;


### PR DESCRIPTION
## 변경 내용
- reviewer-token 설정의 애플리케이션 기본값과 prod 기본값을 false로 변경했습니다.
- QA 배포 preflight도 환경변수 미설정 시 비활성 상태로 해석하도록 통일했습니다.
- 기존 심사 로그인 통합 테스트는 enabled=true를 명시해 opt-in 동작을 보존했습니다.
- 비활성 상태에서 POST /api/auth/reviewer-token이 404를 반환하는 테스트를 추가했습니다.
- 보안 상태 소유권 변경을 docs/understanding.html에 반영했습니다.

## 변경 이유
Google Play 심사가 종료된 뒤에도 고정 심사 계정 토큰 발급 경로가 기본 활성화되어 있으면 환경변수 누락 시 불필요한 인증 경로가 열립니다. 필요한 환경에서만 명시적으로 활성화하는 안전한 기본값으로 전환합니다.

## 영향
- APP_REVIEWER_TOKEN_ENABLED를 설정하지 않은 환경에서는 reviewer-token API가 404를 반환합니다.
- 다시 필요한 경우 APP_REVIEWER_TOKEN_ENABLED=true를 명시하면 기존 동작을 사용할 수 있습니다.
- 2번 소셜 이미지 URL 보안 변경은 이 PR에 포함하지 않았습니다.

## 검증
- ./gradlew test --tests com.sagongsa.backend.config.PublicServerSecurityGuardTest --tests com.sagongsa.backend.auth.AppReviewerAuthIntegrationTest
- docs/understanding.html JavaScript 문법 및 Korean metadata 확인
- git diff --check

Closes #254